### PR TITLE
Fix to deserialize the parents properly

### DIFF
--- a/SpiffWorkflow/storage/DictionarySerializer.py
+++ b/SpiffWorkflow/storage/DictionarySerializer.py
@@ -458,6 +458,10 @@ class DictionarySerializer(Serializer):
         # task_tree
         workflow.task_tree = self._deserialize_task(workflow, s_state['task_tree'])
 
+        # Re-connect parents
+        for task in workflow.get_tasks():
+            task.parent = workflow.get_task(task.parent)
+
         return workflow
 
     def _serialize_task(self, task, skip_children=False):
@@ -505,7 +509,9 @@ class DictionarySerializer(Serializer):
         task.id = s_state['id']
 
         # parent
-        task.parent = workflow.get_task(s_state['parent'])
+        # as the task_tree might not be complete yet
+        # keep the ids so they can be processed at the end
+        task.parent = s_state['parent']
 
         # children
         task.children = [self._deserialize_task(workflow, c) for c in s_state['children']]

--- a/tests/SpiffWorkflow/PersistSmallWorkflowTest.py
+++ b/tests/SpiffWorkflow/PersistSmallWorkflowTest.py
@@ -86,6 +86,23 @@ class PersistSmallWorkflowTest(unittest.TestCase):
         self.assertEqual(1, len([t for t in new_workflow.get_tasks() if t.task_spec.name == 'Start']))
         self.assertEqual(1, len([t for t in new_workflow.get_tasks() if t.task_spec.name == 'Root']))
 
+    def testDeserialization(self):
+        """
+        Tests the that deserialized workflow can be completed.
+        """
+        old_workflow = self.workflow
+
+        old_workflow.complete_next()
+        self.assertEquals('task_a2', old_workflow.last_task.get_name())
+        serializer = DictionarySerializer()
+        serialized_workflow = old_workflow.serialize(serializer)
+
+        serializer = DictionarySerializer()
+        new_workflow = Workflow.deserialize(serializer, serialized_workflow)
+        self.assertEquals('task_a2', old_workflow.last_task.get_name())
+        new_workflow.complete_all()
+        self.assertEquals('task_a2', old_workflow.last_task.get_name())
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(PersistSmallWorkflowTest)


### PR DESCRIPTION
Hi!

I've been playing around with SpiffWorkflow for a while and found a deserialization problem in the Dictionary serializer. I've created a test so you can see the kind of scenario I'm fixing, but essentially, the task_tree tasks parents doen't get deserialized as the function to retrieve tasks based on UUID (get_tasks()) relies on the actual 'task_tree' attribute being constructed. 

I've postponed the parents deserialization to the end of deserialize_workflow where all the tasks in the task_tree had been created.
