### PR TITLE
Fix ExecuteTask ping test. In some platforms the call won't return the expected task transitions.

### DIFF
--- a/tests/SpiffWorkflow/ExecuteProcessMock.py
+++ b/tests/SpiffWorkflow/ExecuteProcessMock.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python
+import time
+
+def main():
+    time.sleep(0.5)
+    print "127.0.0.1"
+
+if __name__ == "__main__":
+    main()

--- a/tests/SpiffWorkflow/specs/ExecuteTest.py
+++ b/tests/SpiffWorkflow/specs/ExecuteTest.py
@@ -21,7 +21,7 @@ class ExecuteTest(TaskSpecTest):
                        args=self.cmd_args)
 
     def setUp(self):
-        self.cmd_args = "ping", "-c", "1", "-t", "1", "127.0.0.1"
+        self.cmd_args = ["python", "ExecuteProcessMock.py"]
         TaskSpecTest.setUp(self)
 
     def testConstructor(self):


### PR DESCRIPTION
I'm getting this when executing the unit test suite:

```
==============================================================
FAIL: testPattern (specs.ExecuteTest.ExecuteTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jplana/Code/SelfServiceHotfixService/SpiffWorkflow/tests/SpiffWorkflow/specs/ExecuteTest.py", line 43, in testPattern
    Task.COMPLETED])
AssertionError: Lists differ: [4, 16, 32] != [4, 8, 16, 32]

First differing element 1:
16
8

Second list contains 1 additional elements.
First extra element 3:
32

- [4, 16, 32]
+ [4, 8, 16, 32]
?     +++


----------------------------------------------------------------------
```

The problem seems show up only under the osx platform, but not in linux. I'd say that `my_task.subprocess.poll()` (in Execute.py) behaves quite diferently between mac and linux. I found that if we call instead the python interpreter with an arbitrary script (I added one to the test suite), that call actually takes enough time to make the task go through the missing WAITING state. 

I know that this is a very basic patch, but it's a solution for the actually failing test suite.
