### PR TITLE
Fix celery tests

### DIFF
--- a/SpiffWorkflow/storage/DictionarySerializer.py
+++ b/SpiffWorkflow/storage/DictionarySerializer.py
@@ -11,7 +11,7 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-import marshal
+import pickle
 from base64 import b64encode, b64decode
 from SpiffWorkflow import Workflow
 from SpiffWorkflow.util.impl import get_class
@@ -23,18 +23,18 @@ from SpiffWorkflow.storage.Serializer import Serializer
 
 class DictionarySerializer(Serializer):
     def _serialize_dict(self, thedict):
-        return dict((k, b64encode(marshal.dumps(v)))
+        return dict((k, b64encode(pickle.dumps(v)))
                     for k, v in thedict.iteritems())
 
     def _deserialize_dict(self, s_state):
-        return dict((k, marshal.loads(b64decode(v)))
+        return dict((k, pickle.loads(b64decode(v)))
                     for k, v in s_state.iteritems())
 
     def _serialize_list(self, thelist):
-        return [b64encode(marshal.dumps(v)) for v in thelist]
+        return [b64encode(pickle.dumps(v)) for v in thelist]
 
     def _deserialize_list(self, s_state):
-        return [b64decode(marshal.loads(v)) for v in s_state]
+        return [pickle.loads(b64decode(v)) for v in s_state]
 
     def _serialize_attrib(self, attrib):
         return attrib.name
@@ -239,7 +239,7 @@ class DictionarySerializer(Serializer):
     def _serialize_join(self, spec):
         s_state = self._serialize_task_spec(spec)
         s_state['split_task'] = spec.split_task
-        s_state['threshold'] = b64encode(marshal.dumps(spec.threshold))
+        s_state['threshold'] = b64encode(pickle.dumps(spec.threshold))
         s_state['cancel_remaining'] = spec.cancel_remaining
         return s_state
 
@@ -247,7 +247,7 @@ class DictionarySerializer(Serializer):
         spec = Join(wf_spec,
                     s_state['name'],
                     split_task = s_state['split_task'],
-                    threshold = marshal.loads(b64decode(s_state['threshold'])),
+                    threshold = pickle.loads(b64decode(s_state['threshold'])),
                     cancel = s_state['cancel_remaining'])
         self._deserialize_task_spec(wf_spec, s_state, spec = spec)
         return spec

--- a/SpiffWorkflow/storage/DictionarySerializer.py
+++ b/SpiffWorkflow/storage/DictionarySerializer.py
@@ -30,11 +30,11 @@ class DictionarySerializer(Serializer):
         return dict((k, marshal.loads(b64decode(v)))
                     for k, v in s_state.iteritems())
 
-    def _serialize_list(self, thedict):
-        return [(k, b64encode(marshal.dumps(v))) for k, v in thedict]
+    def _serialize_list(self, thelist):
+        return [b64encode(marshal.dumps(v)) for v in thelist]
 
     def _deserialize_list(self, s_state):
-        return [(k, b64decode(marshal.loads(v))) for k, v in s_state]
+        return [b64decode(marshal.loads(v)) for v in s_state]
 
     def _serialize_attrib(self, attrib):
         return attrib.name

--- a/tests/SpiffWorkflow/specs/CeleryTest.py
+++ b/tests/SpiffWorkflow/specs/CeleryTest.py
@@ -1,13 +1,13 @@
 import os
 import sys
 import unittest
+import pickle
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-
 from TaskSpecTest import TaskSpecTest
 from SpiffWorkflow.specs import Celery, WorkflowSpec
 from SpiffWorkflow.operators import Attrib
 from SpiffWorkflow.storage import DictionarySerializer
-
+from base64 import b64encode
 
 class CeleryTest(TaskSpecTest):
     CORRELATE = Celery
@@ -54,14 +54,18 @@ class CeleryTest(TaskSpecTest):
         kw_defined2 = Celery.deserialize(serializer, new_wf_spec, data)
         self.assertIsInstance(kw_defined2.kwargs['some_ref'], Attrib)
 
+
+        args = [b64encode(pickle.dumps(v)) for v in [Attrib('the_attribute'), u'ip', u'dc455016e2e04a469c01a866f11c0854']]
+
+        data = { u'R': b64encode(pickle.dumps(u'1'))}
         # Comes from live data. Bug not identified, but there we are...
         data = {u'inputs': [u'Wait:1'], u'lookahead': 2, u'description': u'',
-          u'outputs': [], u'args': [[u'Attrib', u'ip'], [u'spiff:value',
-          u'dc455016e2e04a469c01a866f11c0854']], u'manual': False,
-          u'data': {u'R': u'1'}, u'locks': [], u'pre_assign': [],
+                u'outputs': [], u'args': args,
+          u'manual': False,
+          u'data': data, u'locks': [], u'pre_assign': [],
           u'call': u'call.x',
           u'internal': False, u'post_assign': [], u'id': 8,
-          u'result_key': None, u'defines': {u'R': u'1'},
+          u'result_key': None, u'defines': data,
           u'class': u'SpiffWorkflow.specs.Celery.Celery',
           u'name': u'RS1:1'}
         Celery.deserialize(serializer, new_wf_spec, data)


### PR DESCRIPTION
Hi again!

I found these two exceptions:

```
=================================================================
ERROR: testSerializationWithoutKwargs (specs.CeleryTest.CeleryTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jplana/Code/SelfServiceHotfixService/SpiffWorkflow/tests/SpiffWorkflow/specs/CeleryTest.py", line 37, in testSerializationWithoutKwargs
    data = nokw.serialize(serializer)
  File "/Users/jplana/Code/SelfServiceHotfixService/SpiffWorkflow/tests/SpiffWorkflow/../../SpiffWorkflow/specs/Celery.py", line 252, in serialize
    return serializer._serialize_celery(self)
  File "/Users/jplana/Code/SelfServiceHotfixService/SpiffWorkflow/tests/SpiffWorkflow/../../SpiffWorkflow/storage/DictionarySerializer.py", line 175, in _serialize_celery
    args = self._serialize_list(spec.args)
  File "/Users/jplana/Code/SelfServiceHotfixService/SpiffWorkflow/tests/SpiffWorkflow/../../SpiffWorkflow/storage/DictionarySerializer.py", line 34, in _serialize_list
    return [(k, b64encode(marshal.dumps(v))) for k, v in thedict]
TypeError: 'Attrib' object is not iterable
```

and, after fixing the problem:

```
=================================================================
ERROR: testSerialize (specs.CeleryTest.CeleryTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/jplana/Code/SelfServiceHotfixService/SpiffWorkflow/tests/SpiffWorkflow/specs/TaskSpecTest.py", line 76, in testSerialize
    serialized = spec.serialize(serializer)
  File "/Users/jplana/Code/SelfServiceHotfixService/SpiffWorkflow/tests/SpiffWorkflow/../../SpiffWorkflow/specs/Celery.py", line 252, in serialize
    return serializer._serialize_celery(self)
  File "/Users/jplana/Code/SelfServiceHotfixService/SpiffWorkflow/tests/SpiffWorkflow/../../SpiffWorkflow/storage/DictionarySerializer.py", line 175, in _serialize_celery
    args = self._serialize_list(spec.args)
  File "/Users/jplana/Code/SelfServiceHotfixService/SpiffWorkflow/tests/SpiffWorkflow/../../SpiffWorkflow/storage/DictionarySerializer.py", line 34, in _serialize_list
    return [b64encode(marshal.dumps(v)) for v in thelist]
ValueError: unmarshallable object

----------------------------------------------------------------------
```

So I changed all marshalls to pickles (which I think is better anyway for serialization/storage), and changed the celery dictionary serialization. 
I've checked that the unittests passes when celery is installed. It seems that these tests are only executed when celery is installed, so they're easy to miss. These will fix these two small bugs.
