### PR TITLE
Fixed JSON serialisation of MultiInstance.times attribute (present in wo...

### DIFF
--- a/SpiffWorkflow/storage/DictionarySerializer.py
+++ b/SpiffWorkflow/storage/DictionarySerializer.py
@@ -421,8 +421,8 @@ class DictionarySerializer(Serializer):
         s_state['data'] = workflow.data
 
         # last_node
-        value = workflow.last_task
-        s_state['last_task'] = value.id if not value is None else None
+        #value = workflow.last_task
+        #s_state['last_task'] = value.id if not value is None else None
 
         # outer_workflow
         #s_state['outer_workflow'] = workflow.outer_workflow.id
@@ -446,7 +446,7 @@ class DictionarySerializer(Serializer):
         workflow.data = s_state['data']
 
         # last_task
-        workflow.last_task = s_state['last_task']
+        workflow.last_task = None #s_state['last_task']
 
         # outer_workflow
         #workflow.outer_workflow =  find_workflow_by_id(remap_workflow_id(s_state['outer_workflow']))

--- a/SpiffWorkflow/storage/JSONSerializer.py
+++ b/SpiffWorkflow/storage/JSONSerializer.py
@@ -17,6 +17,7 @@ import json
 import uuid
 from SpiffWorkflow.storage import DictionarySerializer
 from SpiffWorkflow.storage.Serializer import Serializer
+from SpiffWorkflow.operators import Attrib
 
 _dictserializer = DictionarySerializer()
 
@@ -26,6 +27,9 @@ def object_hook(dct):
 
     if '__bytes__' in dct:
         return dct['__bytes__'].encode('ascii')
+    
+    if '__attrib__' in dct:
+        return Attrib(dct['__attrib__'])
 
     return dct
 
@@ -35,6 +39,9 @@ def default(obj):
 
     if isinstance(obj, bytes):
         return {'__bytes__': obj.decode('ascii') }
+        
+    if isinstance(obj, Attrib):
+        return {'__attrib__': obj.name}
 
     raise TypeError('%r is not JSON serializable' % obj)
 


### PR DESCRIPTION
XMLSerializer allows MultiInstance.times to be an Attrib causing type errors when re-serializing to JSON:

```
from SpiffWorkflow.storage import *
x_ser = XmlSerializer()
spec = x_ser.deserialize_workflow_spec(open('tests/SpiffWorkflow/data/spiff/workflow1.xml').read())
j_ser = JSONSerializer()
j_data = j_ser.serialize_workflow_spec(spec)
jspec = j_ser.deserialize_workflow_spec(j_data)
...
  File "./SpiffWorkflow/storage/JSONSerializer.py", line 40, in default
    raise TypeError('%r is not JSON serializable' % obj)
TypeError: <SpiffWorkflow.operators.Attrib object at 0x10b024410> is not JSON serializable
```

Im not sure if this is a specification inconsistency. If it is then perhaps the appropriate fix is in XMLSerializer instead.
