### PR TITLE
Add missing _deserialize_operator method

### DIFF
--- a/SpiffWorkflow/bpmn/storage/CompactWorkflowSerializer.py
+++ b/SpiffWorkflow/bpmn/storage/CompactWorkflowSerializer.py
@@ -303,7 +303,7 @@ class CompactWorkflowSerializer(Serializer):
         :param read_only: this should be in read only mode
         :param kwargs: Any extra kwargs passed to the deserialize_workflow method will be passed through here
         """
-        return BpmnWorkflow(workflow_spec, read_only=read_only)
+        return BpmnWorkflow(workflow_spec, read_only=read_only, **kwargs)
 
     def _get_workflow_state(self, workflow):
         active_tasks = workflow.get_tasks(state=(Task.READY | Task.WAITING))

--- a/SpiffWorkflow/storage/DictionarySerializer.py
+++ b/SpiffWorkflow/storage/DictionarySerializer.py
@@ -53,6 +53,9 @@ class DictionarySerializer(Serializer):
     def _serialize_operator(self, op):
         return [self._serialize_arg(a) for a in op.args]
 
+    def _deserialize_operator(self, s_state):
+        return [self._deserialize_arg(c) for c in s_state]
+
     def _serialize_operator_equal(self, op):
         return self._serialize_operator(op)
 

--- a/SpiffWorkflow/storage/XmlSerializer.py
+++ b/SpiffWorkflow/storage/XmlSerializer.py
@@ -193,9 +193,9 @@ class XmlSerializer(Serializer):
             _exc('Invalid task name "%s"' % name)
         if name in read_specs:
             _exc('Duplicate task name "%s"' % name)
-        if cancel != '' and cancel != u'0':
+        if cancel != '' and cancel != '0':
             kwargs['cancel'] = True
-        if success != '' and success != u'0':
+        if success != '' and success != '0':
             kwargs['success'] = True
         if times != '':
             kwargs['times'] = int(times)

--- a/tests/SpiffWorkflow/specs/CeleryTest.py
+++ b/tests/SpiffWorkflow/specs/CeleryTest.py
@@ -59,19 +59,19 @@ class CeleryTest(TaskSpecTest):
         self.assertIsInstance(kw_defined2.kwargs['some_ref'], Attrib)
 
 
-        args = [b64encode(pickle.dumps(v)) for v in [Attrib('the_attribute'), u'ip', u'dc455016e2e04a469c01a866f11c0854']]
+        args = [b64encode(pickle.dumps(v)) for v in [Attrib('the_attribute'), 'ip', 'dc455016e2e04a469c01a866f11c0854']]
 
-        data = { u'R': b64encode(pickle.dumps(u'1'))}
+        data = { 'R': b64encode(pickle.dumps('1'))}
         # Comes from live data. Bug not identified, but there we are...
-        data = {u'inputs': [u'Wait:1'], u'lookahead': 2, u'description': u'',
-                u'outputs': [], u'args': args,
-          u'manual': False,
-          u'data': data, u'locks': [], u'pre_assign': [],
-          u'call': u'call.x',
-          u'internal': False, u'post_assign': [], u'id': 8,
-          u'result_key': None, u'defines': data,
-          u'class': u'SpiffWorkflow.specs.Celery.Celery',
-          u'name': u'RS1:1'}
+        data = {'inputs': ['Wait:1'], 'lookahead': 2, 'description': '',
+                'outputs': [], 'args': args,
+          'manual': False,
+          'data': data, 'locks': [], 'pre_assign': [],
+          'call': 'call.x',
+          'internal': False, 'post_assign': [], 'id': 8,
+          'result_key': None, 'defines': data,
+          'class': 'SpiffWorkflow.specs.Celery.Celery',
+          'name': 'RS1:1'}
         Celery.deserialize(serializer, new_wf_spec, data)
 
 def suite():


### PR DESCRIPTION
This is still an issue even with the latest version. Here is my approach, I have a spiffworkflow instance constructed from bpmn xml. I then want to serialize it to json like this.

instance = JSONSerializer().serialize_workflow(spiffworkflow, include_spec=True)

So the serialize works for me, but the reverse thows this stack
.spiffworkflow = JSONSerializer().deserialize_workflow(instance)
...
  File "/home/davidl/.python/src/spiffworkflow/SpiffWorkflow/storage/DictionarySerializer.py", line 470, in deserialize_workflow
    wf_spec = self.deserialize_workflow_spec(s_state['wf_spec'], **kwargs)
  File "/home/davidl/.python/src/spiffworkflow/SpiffWorkflow/storage/DictionarySerializer.py", line 435, in deserialize_workflow_spec
    task_spec = task_spec_cls.deserialize(self, spec, task_spec_state)
  File "/home/davidl/.python/src/spiffworkflow/SpiffWorkflow/specs/ExclusiveChoice.py", line 92, in deserialize
    return serializer._deserialize_exclusive_choice(wf_spec, s_state)
  File "/home/davidl/.python/src/spiffworkflow/SpiffWorkflow/storage/DictionarySerializer.py", line 230, in _deserialize_exclusive_choice
    self._deserialize_multi_choice(wf_spec, s_state, spec=spec)
  File "/home/davidl/.python/src/spiffworkflow/SpiffWorkflow/storage/DictionarySerializer.py", line 291, in _deserialize_multi_choice
    condition = self._deserialize_arg(cond)
  File "/home/davidl/.python/src/spiffworkflow/SpiffWorkflow/storage/DictionarySerializer.py", line 110, in _deserialize_arg
    return arg_cls.deserialize(self, arg)
  File "/home/davidl/.python/src/spiffworkflow/SpiffWorkflow/operators.py", line 204, in deserialize
    return serializer._deserialize_operator(s_state)
AttributeError: 'DictionarySerializer' object has no attribute '_deserialize_operator'

Adding the function seems to fix the issue for me.
