### PR TITLE
Removed dotVizualizer import causing issues with project start

### DIFF
--- a/SpiffWorkflow/storage/__init__.py
+++ b/SpiffWorkflow/storage/__init__.py
@@ -4,7 +4,6 @@ from .OpenWfeXmlSerializer import OpenWfeXmlSerializer
 from .XmlSerializer import XmlSerializer
 from .DictionarySerializer import DictionarySerializer
 from .JSONSerializer import JSONSerializer
-from .dotVisualizer import dotVisualizer
 
 import inspect
 __all__ = [name for name, obj in list(locals().items())


### PR DESCRIPTION
The dotVizualizer utility requires a specific install of the GvGen module from source(https://github.com/stricaud/gvgen) 

Since this is a utility only, not installing the GvGen module causes the entire library to fail over with missing module error and thus forcing an install of GvGen.
