### PR TITLE
Pass task data as locals to the execute function of BPMN Script Engine

### DIFF
--- a/SpiffWorkflow/bpmn/BpmnScriptEngine.py
+++ b/SpiffWorkflow/bpmn/BpmnScriptEngine.py
@@ -42,10 +42,11 @@ class BpmnScriptEngine(object):
         else:
             return self._eval(task, expression, **task.data)
 
-    def execute(self, task, script):
+    def execute(self, task, script, **kwargs):
         """
         Execute the script, within the context of the specified task
         """
+        locals().update(kwargs)
         exec(script)
 
     def _eval(self, task, expression, **kwargs):

--- a/SpiffWorkflow/bpmn/specs/ScriptTask.py
+++ b/SpiffWorkflow/bpmn/specs/ScriptTask.py
@@ -46,7 +46,7 @@ class ScriptTask(Simple, BpmnSpecMixin):
             return
         assert not task.workflow.read_only
         try:
-            task.workflow.script_engine.execute(task, self.script)
+            task.workflow.script_engine.execute(task, self.script, **task.data)
         except Exception:
             LOG.error('Error executing ScriptTask; task=%r', task, exc_info=True)
             # set state to WAITING (because it is definitely not COMPLETED)


### PR DESCRIPTION
Advantage: The "condition" gateway condition type and the "Script" task block can use the same variables (without needing to reference the task object in scripts)