### PR TITLE
Flake8 clean

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length=120
+

--- a/SpiffWorkflow/__init__.py
+++ b/SpiffWorkflow/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 from __future__ import division, absolute_import
 from .version import __version__
 from .workflow import Workflow

--- a/SpiffWorkflow/bpmn/parser/BpmnParser.py
+++ b/SpiffWorkflow/bpmn/parser/BpmnParser.py
@@ -34,8 +34,13 @@ from ..specs.StartEvent import StartEvent
 from ..specs.UserTask import UserTask
 from ..specs.EndEvent import EndEvent
 from .ProcessParser import ProcessParser
-from .util import *
-from .task_parsers import *
+from .util import full_tag, xpath_eval, first
+from .task_parsers import (StartEventParser, EndEventParser, UserTaskParser,
+                           NoneTaskParser, ManualTaskParser,
+                           ExclusiveGatewayParser, ParallelGatewayParser,
+                           InclusiveGatewayParser, CallActivityParser,
+                           ScriptTaskParser, IntermediateCatchEventParser,
+                           BoundaryEventParser)
 import xml.etree.ElementTree as ET
 
 

--- a/SpiffWorkflow/bpmn/parser/BpmnParser.py
+++ b/SpiffWorkflow/bpmn/parser/BpmnParser.py
@@ -152,11 +152,14 @@ class BpmnParser(object):
             xpath('.//bpmn:conditionExpression'))
         if conditionExpression is not None:
             conditionExpression = conditionExpression.text
-        return self.parse_condition(conditionExpression, outgoing_task, outgoing_task_node, sequence_flow_node, condition_expression_node, task_parser)
+        return self.parse_condition(conditionExpression, outgoing_task, outgoing_task_node,
+                                    sequence_flow_node, condition_expression_node, task_parser)
 
-    def parse_condition(self, condition_expression, outgoing_task, outgoing_task_node, sequence_flow_node, condition_expression_node, task_parser):
+    def parse_condition(self, condition_expression, outgoing_task, outgoing_task_node, sequence_flow_node,
+                        condition_expression_node, task_parser):
         """
-        Pre-parse the given condition expression, and return the parsed version. The returned version will be passed to the Script Engine
+        Pre-parse the given condition expression, and return the parsed version.
+        The returned version will be passed to the Script Engine
         for evaluation.
         """
         return condition_expression
@@ -174,7 +177,8 @@ class BpmnParser(object):
 
     def get_spec(self, process_id_or_name):
         """
-        Parses the required subset of the BPMN files, in order to provide an instance of BpmnProcessSpec (i.e. WorkflowSpec)
+        Parses the required subset of the BPMN files, in order to provide an
+        instance of BpmnProcessSpec (i.e. WorkflowSpec)
         for the given process ID or name. The Name is matched first.
         """
         return self.get_process_parser(process_id_or_name).get_spec()

--- a/SpiffWorkflow/bpmn/parser/ProcessParser.py
+++ b/SpiffWorkflow/bpmn/parser/ProcessParser.py
@@ -20,7 +20,7 @@ from builtins import object
 
 from .ValidationException import ValidationException
 from ..specs.BpmnProcessSpec import BpmnProcessSpec
-from .util import *
+from .util import xpath_eval
 
 
 class ProcessParser(object):

--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -23,7 +23,7 @@ import sys
 import traceback
 from .ValidationException import ValidationException
 from ..specs.BoundaryEvent import _BoundaryEventParent
-from .util import *
+from .util import xpath_eval, one
 
 LOG = logging.getLogger(__name__)
 
@@ -88,7 +88,8 @@ class TaskParser(object):
                 './/bpmn:sequenceFlow[@sourceRef="%s"]' % self.get_id())
             if len(outgoing) > 1 and not self.handles_multiple_outgoing():
                 raise ValidationException(
-                    'Multiple outgoing flows are not supported for tasks of type', node=self.node, filename=self.process_parser.filename)
+                    'Multiple outgoing flows are not supported for tasks of type', node=self.node,
+                    filename=self.process_parser.filename)
             for sequence_flow in outgoing:
                 target_ref = sequence_flow.get('targetRef')
                 target_node = one(
@@ -107,7 +108,7 @@ class TaskParser(object):
                         c, target_node, sequence_flow, sequence_flow.get('id') == default_outgoing)
 
             return parent_task if boundary_event_nodes else self.task
-        except ValidationException as vx:
+        except ValidationException:
             raise
         except Exception as ex:
             exc_info = sys.exc_info()
@@ -137,9 +138,11 @@ class TaskParser(object):
 
     def create_task(self):
         """
-        Create an instance of the task appropriately. A subclass can override this method to get extra information from the node.
+        Create an instance of the task appropriately. A subclass can override
+        this method to get extra information from the node.
         """
-        return self.spec_class(self.spec, self.get_task_spec_name(), lane=self.get_lane(), description=self.node.get('name', None))
+        return self.spec_class(self.spec, self.get_task_spec_name(), lane=self.get_lane(),
+                               description=self.node.get('name', None))
 
     def connect_outgoing(self, outgoing_task, outgoing_task_node, sequence_flow_node, is_default):
         """

--- a/SpiffWorkflow/bpmn/parser/task_parsers.py
+++ b/SpiffWorkflow/bpmn/parser/task_parsers.py
@@ -19,7 +19,7 @@ from __future__ import division
 
 from .ValidationException import ValidationException
 from .TaskParser import TaskParser
-from .util import *
+from .util import first, one
 from ..specs.event_definitions import TimerEventDefinition, MessageEventDefinition
 import xml.etree.ElementTree as ET
 
@@ -67,7 +67,8 @@ class UserTaskParser(TaskParser):
 class ManualTaskParser(UserTaskParser):
 
     """
-    Base class for parsing Manual Tasks. Currently assumes that Manual Tasks should be treated the same way as User Tasks.
+    Base class for parsing Manual Tasks. Currently assumes that Manual Tasks 
+    should be treated the same way as User Tasks.
     """
     pass
 
@@ -75,7 +76,8 @@ class ManualTaskParser(UserTaskParser):
 class NoneTaskParser(UserTaskParser):
 
     """
-    Base class for parsing unspecified Tasks. Currently assumes that such Tasks should be treated the same way as User Tasks.
+    Base class for parsing unspecified Tasks. Currently assumes that such Tasks 
+    should be treated the same way as User Tasks.
     """
     pass
 
@@ -95,7 +97,8 @@ class ExclusiveGatewayParser(TaskParser):
                 outgoing_task, outgoing_task_node, sequence_flow_node, task_parser=self)
             if cond is None:
                 raise ValidationException(
-                    'Non-default exclusive outgoing sequence flow without condition', sequence_flow_node, self.process_parser.filename)
+                    'Non-default exclusive outgoing sequence flow without condition', sequence_flow_node,
+                    self.process_parser.filename)
             self.task.connect_outgoing_if(cond, outgoing_task, sequence_flow_node.get('id'), sequence_flow_node.get(
                 'name', None), self.parser._parse_documentation(sequence_flow_node, task_parser=self))
 
@@ -129,18 +132,21 @@ class InclusiveGatewayParser(TaskParser):
 class CallActivityParser(TaskParser):
 
     """
-    Parses a CallActivity node. This also supports the not-quite-correct BPMN that Signavio produces (which does not have a calledElement attribute).
+    Parses a CallActivity node. This also supports the not-quite-correct BPMN that Signavio produces 
+    (which does not have a calledElement attribute).
     """
 
     def create_task(self):
         wf_spec = self.get_subprocess_parser().get_spec()
-        return self.spec_class(self.spec, self.get_task_spec_name(), bpmn_wf_spec=wf_spec, bpmn_wf_class=self.parser.WORKFLOW_CLASS, description=self.node.get('name', None))
+        return self.spec_class(self.spec, self.get_task_spec_name(), bpmn_wf_spec=wf_spec,
+                               bpmn_wf_class=self.parser.WORKFLOW_CLASS, description=self.node.get('name', None))
 
     def get_subprocess_parser(self):
         calledElement = self.node.get('calledElement', None)
         if not calledElement:
             raise ValidationException(
-                'No "calledElement" attribute for Call Activity.', node=self.node, filename=self.process_parser.filename)
+                'No "calledElement" attribute for Call Activity.', node=self.node,
+                filename=self.process_parser.filename)
         return self.parser.get_process_parser(calledElement)
 
 
@@ -170,7 +176,8 @@ class IntermediateCatchEventParser(TaskParser):
 
     def create_task(self):
         event_definition = self.get_event_definition()
-        return self.spec_class(self.spec, self.get_task_spec_name(), event_definition, description=self.node.get('name', None))
+        return self.spec_class(self.spec, self.get_task_spec_name(), event_definition,
+                               description=self.node.get('name', None))
 
     def get_event_definition(self):
         """
@@ -205,17 +212,20 @@ class IntermediateCatchEventParser(TaskParser):
         This currently only supports the timeDate node for specifying an expiry time for the timer.
         """
         timeDate = first(self.xpath('.//bpmn:timeDate'))
-        return TimerEventDefinition(self.node.get('name', timeDate.text), self.parser.parse_condition(timeDate.text, None, None, None, None, self))
+        return TimerEventDefinition(self.node.get('name', timeDate.text), self.parser.parse_condition(
+            timeDate.text, None, None, None, None, self))
 
 
 class BoundaryEventParser(IntermediateCatchEventParser):
 
     """
-    Parse a Catching Boundary Event. This extends the IntermediateCatchEventParser in order to parse the event definition.
+    Parse a Catching Boundary Event. This extends the IntermediateCatchEventParser
+    in order to parse the event definition.
     """
 
     def create_task(self):
         event_definition = self.get_event_definition()
         cancel_activity = self.node.get(
             'cancelActivity', default='false').lower() == 'true'
-        return self.spec_class(self.spec, self.get_task_spec_name(), cancel_activity=cancel_activity, event_definition=event_definition, description=self.node.get('name', None))
+        return self.spec_class(self.spec, self.get_task_spec_name(), cancel_activity=cancel_activity,
+                               event_definition=event_definition, description=self.node.get('name', None))

--- a/SpiffWorkflow/bpmn/parser/task_parsers.py
+++ b/SpiffWorkflow/bpmn/parser/task_parsers.py
@@ -67,7 +67,7 @@ class UserTaskParser(TaskParser):
 class ManualTaskParser(UserTaskParser):
 
     """
-    Base class for parsing Manual Tasks. Currently assumes that Manual Tasks 
+    Base class for parsing Manual Tasks. Currently assumes that Manual Tasks
     should be treated the same way as User Tasks.
     """
     pass
@@ -76,7 +76,7 @@ class ManualTaskParser(UserTaskParser):
 class NoneTaskParser(UserTaskParser):
 
     """
-    Base class for parsing unspecified Tasks. Currently assumes that such Tasks 
+    Base class for parsing unspecified Tasks. Currently assumes that such Tasks
     should be treated the same way as User Tasks.
     """
     pass
@@ -132,7 +132,7 @@ class InclusiveGatewayParser(TaskParser):
 class CallActivityParser(TaskParser):
 
     """
-    Parses a CallActivity node. This also supports the not-quite-correct BPMN that Signavio produces 
+    Parses a CallActivity node. This also supports the not-quite-correct BPMN that Signavio produces
     (which does not have a calledElement attribute).
     """
 

--- a/SpiffWorkflow/bpmn/serializer/BpmnSerializer.py
+++ b/SpiffWorkflow/bpmn/serializer/BpmnSerializer.py
@@ -38,7 +38,8 @@ class BpmnSerializer(Serializer):
 
     def serialize_workflow_spec(self, wf_spec, **kwargs):
         raise NotImplementedError(
-            "The BpmnSerializer class cannot be used to serialize. BPMN authoring should be done using a supported editor.")
+            "The BpmnSerializer class cannot be used to serialize. BPMN authoring should be done using a "
+            "supported editor.")
 
     def serialize_workflow(self, workflow, **kwargs):
         raise NotImplementedError(
@@ -89,7 +90,7 @@ class BpmnSerializer(Serializer):
                 # It is in the root of the ZIP and is a BPMN file
                 try:
                     svg = package_zip.read(info.filename[:-5] + '.svg')
-                except KeyError as e:
+                except KeyError:
                     svg = None
 
                 bpmn_fp = package_zip.open(info)

--- a/SpiffWorkflow/bpmn/specs/BoundaryEvent.py
+++ b/SpiffWorkflow/bpmn/specs/BoundaryEvent.py
@@ -33,7 +33,8 @@ class _BoundaryEventParent(BpmnSpecMixin):
         if child_task.task_spec == self.main_child_task_spec or self._should_cancel(child_task.task_spec):
             for sibling in child_task.parent.children:
                 if sibling != child_task:
-                    if sibling.task_spec == self.main_child_task_spec or (isinstance(sibling.task_spec, BoundaryEvent) and not sibling._is_finished()):
+                    if sibling.task_spec == self.main_child_task_spec or (isinstance(sibling.task_spec, BoundaryEvent)
+                                                                          and not sibling._is_finished()):
                         sibling.cancel()
             for t in child_task.workflow._get_waiting_tasks():
                 t.task_spec._update(t)

--- a/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
+++ b/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
@@ -150,7 +150,7 @@ class BpmnProcessSpec(WorkflowSpec):
         svg_content = ''
         svg_done = set()
         for spec in self.get_specs_depth_first():
-            if spec.svg and not spec.svg in svg_done:
+            if spec.svg and spec.svg not in svg_done:
                 svg_content += '<p>' + spec.svg + "</p>"
                 svg_done.add(spec.svg)
         return html_text.replace('___CONTENT___', svg_content)

--- a/SpiffWorkflow/bpmn/specs/BpmnSpecMixin.py
+++ b/SpiffWorkflow/bpmn/specs/BpmnSpecMixin.py
@@ -190,7 +190,8 @@ class BpmnSpecMixin(TaskSpec):
     def _update_hook(self, my_task):
         prev_state = my_task.state
         super(BpmnSpecMixin, self)._update_hook(my_task)
-        if prev_state != Task.WAITING and my_task.state == Task.WAITING and not my_task.workflow._is_busy_with_restore():
+        if (prev_state != Task.WAITING and my_task.state == Task.WAITING and
+                not my_task.workflow._is_busy_with_restore()):
             self.entering_waiting_state(my_task)
 
     def _on_ready_before_hook(self, my_task):

--- a/SpiffWorkflow/bpmn/specs/EndEvent.py
+++ b/SpiffWorkflow/bpmn/specs/EndEvent.py
@@ -34,8 +34,8 @@ class EndEvent(Simple, BpmnSpecMixin):
     For all other End Events, the behavior associated with the Event type is performed, e.g., the associated Message is
     sent for a Message End Event, the associated signal is sent for a Signal End Event, and so on. The Process
     instance is then completed, if and only if the following two conditions hold:
-     * All start nodes of the Process have been visited. More precisely, all Start Events have been triggered, and for all
-    starting Event-Based Gateways, one of the associated Events has been triggered.
+     * All start nodes of the Process have been visited. More precisely, all Start Events have been triggered, and
+       for all starting Event-Based Gateways, one of the associated Events has been triggered.
      * There is no token remaining within the Process instance.
     """
 

--- a/SpiffWorkflow/bpmn/specs/IntermediateCatchEvent.py
+++ b/SpiffWorkflow/bpmn/specs/IntermediateCatchEvent.py
@@ -39,7 +39,8 @@ class IntermediateCatchEvent(Simple, BpmnSpecMixin):
 
     def _update_hook(self, my_task):
         target_state = getattr(my_task, '_bpmn_load_target_state', None)
-        if target_state == Task.READY or (not my_task.workflow._is_busy_with_restore() and self.event_definition.has_fired(my_task)):
+        if target_state == Task.READY or (not my_task.workflow._is_busy_with_restore() and
+                                          self.event_definition.has_fired(my_task)):
             super(IntermediateCatchEvent, self)._update_hook(my_task)
         else:
             if not my_task.parent._is_finished():

--- a/SpiffWorkflow/bpmn/specs/ParallelGateway.py
+++ b/SpiffWorkflow/bpmn/specs/ParallelGateway.py
@@ -16,10 +16,7 @@ from __future__ import division
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
-from collections import deque
-
 import logging
-from ...task import Task
 from .UnstructuredJoin import UnstructuredJoin
 
 LOG = logging.getLogger(__name__)

--- a/SpiffWorkflow/bpmn/specs/UnstructuredJoin.py
+++ b/SpiffWorkflow/bpmn/specs/UnstructuredJoin.py
@@ -16,8 +16,6 @@ from __future__ import division
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
-from collections import deque
-
 import logging
 from ...task import Task
 from .BpmnSpecMixin import BpmnSpecMixin

--- a/SpiffWorkflow/serializer/dict.py
+++ b/SpiffWorkflow/serializer/dict.py
@@ -20,8 +20,13 @@ from base64 import b64encode, b64decode
 from .. import Workflow
 from ..util.impl import get_class
 from ..task import Task
-from ..operators import *
-from ..specs import *
+from ..operators import (Attrib, PathAttrib, Equal, NotEqual,
+                         Operator, GreaterThan, LessThan, Match)
+from ..specs import (Cancel, AcquireMutex, CancelTask, Celery, Choose,
+                     ExclusiveChoice, Execute, Gate, Join, MultiChoice,
+                     MultiInstance, ReleaseMutex, Simple, WorkflowSpec,
+                     TaskSpec, SubWorkflow, StartTask, ThreadMerge,
+                     ThreadSplit, ThreadStart, Merge, Trigger)
 from .base import Serializer
 from .exceptions import TaskNotSupportedError
 import warnings
@@ -457,7 +462,7 @@ class DictionarySerializer(Serializer):
 
         # last_node
         value = workflow.last_task
-        s_state['last_task'] = value.id if not value is None else None
+        s_state['last_task'] = value.id if value is not None else None
 
         # outer_workflow
         # s_state['outer_workflow'] = workflow.outer_workflow.id
@@ -517,7 +522,7 @@ class DictionarySerializer(Serializer):
         # s_state['workflow'] = task.workflow.id
 
         # parent
-        s_state['parent'] = task.parent.id if not task.parent is None else None
+        s_state['parent'] = task.parent.id if task.parent is not None else None
 
         # children
         if not skip_children:

--- a/SpiffWorkflow/serializer/prettyxml.py
+++ b/SpiffWorkflow/serializer/prettyxml.py
@@ -256,7 +256,7 @@ class XmlSerializer(Serializer):
                     _exc('Empty %s tag' % node.nodeName)
                 if context == '':
                     context = []
-                elif type(context) != type([]):
+                elif not isinstance(context, list):
                     context = [context]
                 context.append(node.firstChild.nodeValue)
             elif node.nodeName == 'lock':

--- a/SpiffWorkflow/serializer/xml.py
+++ b/SpiffWorkflow/serializer/xml.py
@@ -21,8 +21,13 @@ from lxml import etree
 from lxml.etree import SubElement
 from .. import Workflow, specs, operators
 from ..task import Task
-from ..operators import *
-from ..specs import *
+from ..operators import (Attrib, Assign, PathAttrib, Equal, NotEqual,
+                         GreaterThan, LessThan, Match)
+from ..specs import (Cancel, AcquireMutex, CancelTask, Celery, Choose,
+                     ExclusiveChoice, Execute, Gate, Join, MultiChoice,
+                     MultiInstance, ReleaseMutex, Simple, WorkflowSpec,
+                     SubWorkflow, StartTask, ThreadMerge,
+                     ThreadSplit, ThreadStart, Merge, Trigger)
 from .base import Serializer
 from .exceptions import TaskNotSupportedError
 
@@ -126,7 +131,7 @@ class XmlSerializer(Serializer):
         if value.tag == 'attribute':
             return Attrib.deserialize(self, value)
         elif value.tag == 'path':
-            return Path.deserialize(self, value)
+            return PathAttrib.deserialize(self, value)
         elif value.tag == 'assign':
             return Assign.deserialize(self, value)
         else:

--- a/SpiffWorkflow/specs/Celery.py
+++ b/SpiffWorkflow/specs/Celery.py
@@ -27,7 +27,6 @@ from ..util import merge_dictionary
 
 try:
     from celery.app import default_app
-    from celery.result import AsyncResult
 except ImportError:
     have_celery = False
 else:
@@ -67,9 +66,9 @@ def Serializable(o):
         return o
     else:
         try:
-            s = json.dumps(o)
+            json.dumps(o)
             return o
-        except:
+        except Exception:
             LOG.debug("Got a non-serilizeable object: %s" % o)
             return o.__repr__()
 

--- a/SpiffWorkflow/specs/Trigger.py
+++ b/SpiffWorkflow/specs/Trigger.py
@@ -51,7 +51,7 @@ class Trigger(TaskSpec):
         assert wf_spec is not None
         assert name is not None
         assert context is not None
-        assert type(context) == type([])
+        assert isinstance(context, list)
         TaskSpec.__init__(self, wf_spec, name, **kwargs)
         self.context = context
         self.times = times

--- a/SpiffWorkflow/specs/WorkflowSpec.py
+++ b/SpiffWorkflow/specs/WorkflowSpec.py
@@ -81,7 +81,7 @@ class WorkflowSpec(object):
                 if task in history:
                     msg = "Found loop with '%s': %s then '%s' again" % (
                         task.name, '->'.join([p.name for p in history]),
-                            task.name)
+                        task.name)
                     raise Exception(msg)
                 for predecessor in task.inputs:
                     recursive_find_loop(predecessor, current)
@@ -140,7 +140,8 @@ class WorkflowSpec(object):
 
         def recursive_dump(task_spec, indent):
             if task_spec in done:
-                return '[shown earlier] %s (%s:%s)' % (task_spec.name, task_spec.__class__.__name__, hex(id(task_spec))) + '\n'
+                return '[shown earlier] %s (%s:%s)' % (
+                    task_spec.name, task_spec.__class__.__name__, hex(id(task_spec))) + '\n'
 
             done.add(task_spec)
             dump = '%s (%s:%s)' % (
@@ -149,11 +150,11 @@ class WorkflowSpec(object):
                 if task_spec.inputs:
                     dump += indent + '-  IN: ' + \
                         ','.join(['%s (%s)' % (t.name, hex(id(t)))
-                                 for t in task_spec.inputs]) + '\n'
+                                  for t in task_spec.inputs]) + '\n'
                 if task_spec.outputs:
                     dump += indent + '- OUT: ' + \
                         ','.join(['%s (%s)' % (t.name, hex(id(t)))
-                                 for t in task_spec.outputs]) + '\n'
+                                  for t in task_spec.outputs]) + '\n'
             sub_specs = ([task_spec.spec.start] if hasattr(
                 task_spec, 'spec') else []) + task_spec.outputs
             for i, t in enumerate(sub_specs):

--- a/SpiffWorkflow/specs/__init__.py
+++ b/SpiffWorkflow/specs/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 from __future__ import division, absolute_import
 from .base import TaskSpec
 from .AcquireMutex import AcquireMutex

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -391,8 +391,8 @@ class TaskSpec(object):
         assert my_task is not None
 
         if my_task.workflow.debug:
-            print("Executing %s: %s (%s)" % (
-            my_task.task_spec.__class__.__name__, my_task.get_name(), my_task.get_description()))
+            print("Executing %s: %s (%s)" % (my_task.task_spec.__class__.__name__,
+                                             my_task.get_name(), my_task.get_description()))
 
         self._on_complete_hook(my_task)
 

--- a/SpiffWorkflow/workflow.py
+++ b/SpiffWorkflow/workflow.py
@@ -90,7 +90,7 @@ class Workflow(object):
         iter = Task.Iterator(self.task_tree, mask)
         try:
             next(iter)
-        except:
+        except:  # noqa (would it be possible to just catch Exception instead?)
             # No waiting tasks found.
             return True
         return False
@@ -231,7 +231,7 @@ class Workflow(object):
             try:
                 iter = Task.Iterator(self.last_task, Task.READY)
                 task = next(iter)
-            except:
+            except:  # noqa (would it be possible catch Exception instead?)
                 task = None
             self.last_task = None
             if task is not None:


### PR DESCRIPTION
I've gotten rid of all flake8 warnings (except for the bug reported in #71). I added a few noqa's where exceptions are caught, I wonder whether that's needed in #72 

The line length is set to 120, so I've fixed any longer lines. I wonder whether we should stick to pep8 and 80 characters in #70 