### PR TITLE
Fixed parsing of cancelActivity in BoundaryEventParser

### DIFF
--- a/SpiffWorkflow/bpmn/parser/task_parsers.py
+++ b/SpiffWorkflow/bpmn/parser/task_parsers.py
@@ -245,8 +245,9 @@ class BoundaryEventParser(IntermediateCatchEventParser):
 
     def create_task(self):
         event_definition = self.get_event_definition()
+        # BPMN spec states that cancelActivity is True by default
         cancel_activity = self.node.get(
-            'cancelActivity', default='false').lower() == 'true'
+            'cancelActivity', default='true').lower() == 'true'
         return self.spec_class(self.spec, self.get_task_spec_name(),
                                cancel_activity=cancel_activity,
                                event_definition=event_definition,

--- a/SpiffWorkflow/bpmn/serializer/CompactWorkflowSerializer.py
+++ b/SpiffWorkflow/bpmn/serializer/CompactWorkflowSerializer.py
@@ -31,6 +31,9 @@ from ...serializer.base import Serializer
 from ..workflow import BpmnWorkflow
 
 
+LOG = logging.getLogger(__name__)
+
+
 class UnrecoverableWorkflowChange(Exception):
     """
     This is thrown if the workflow cannot be restored because the workflow spec
@@ -158,7 +161,7 @@ class _BpmnProcessSpecState(object):
     def go(self, workflow):
         leaf_tasks = []
         self._go(workflow.task_tree.children[0], self.route, leaf_tasks)
-        logging.debug('Leaf tasks after load, before _update: %s', leaf_tasks)
+        LOG.debug('Leaf tasks after load, before _update: %s', leaf_tasks)
         for task in sorted(
                 leaf_tasks,
                 key=lambda t: 0 if getattr(

--- a/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
+++ b/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
@@ -24,6 +24,9 @@ from ...specs.WorkflowSpec import WorkflowSpec
 import xml.etree.ElementTree as ET
 
 
+LOG = logging.getLogger(__name__)
+
+
 class _EndJoin(UnstructuredJoin):
 
     def _check_threshold_unstructured(self, my_task, force=False):
@@ -48,7 +51,7 @@ class _EndJoin(UnstructuredJoin):
                 waiting_tasks.append(task)
 
         if len(waiting_tasks) == 0:
-            logging.debug(
+            LOG.debug(
                 'Endjoin Task ready: %s (ready/waiting tasks: %s)',
                 my_task,
                 list(my_task.workflow.get_tasks(Task.READY | Task.WAITING)))


### PR DESCRIPTION
Previous version of parser was not compatible with BPMN specification - cancelActivity property must be treated as True if it's missing from node. BPMN authoring tools like Camunda Modeler always omit this property on all interrupting boundary events.

