### PR TITLE
Initial support for BPMN escalation boundary event on CallActivity tasks

### DIFF
--- a/SpiffWorkflow/bpmn/specs/BoundaryEvent.py
+++ b/SpiffWorkflow/bpmn/specs/BoundaryEvent.py
@@ -77,3 +77,16 @@ class BoundaryEvent(IntermediateCatchEvent):
         super(BoundaryEvent, self).__init__(
             wf_spec, name, event_definition=event_definition, **kwargs)
         self._cancel_activity = cancel_activity
+
+    def accept_message(self, my_task, message):
+        ret = super(BoundaryEvent, self).accept_message(my_task, message)
+        # after accepting message this node will be in READY state but
+        # if for some reason the task we are attached to gets to COMPLETE
+        # state before us then our _BoundaryEventParent will cancel()
+        # this node along with all the other siblings
+        #
+        # to prevent this we complete() this task because _BoundaryEventParent
+        # only cancels unfinished children
+        if ret and my_task._has_state(Task.READY):
+            my_task.complete()
+        return ret

--- a/SpiffWorkflow/bpmn/specs/EndEvent.py
+++ b/SpiffWorkflow/bpmn/specs/EndEvent.py
@@ -42,14 +42,20 @@ class EndEvent(Simple, BpmnSpecMixin):
      * There is no token remaining within the Process instance.
     """
 
-    def __init__(self, wf_spec, name, is_terminate_event=False, **kwargs):
+    def __init__(self, wf_spec, name, is_terminate_event=False,
+                 is_escalation_event=False, escalation_code=None, **kwargs):
         """
         Constructor.
 
         :param is_terminate_event: True if this is a terminating end event
+        :param is_escalation_event: True if this is a escalation end event
+        :param escalation_code: optional string with escalation code
+        for escalation end events
         """
         super(EndEvent, self).__init__(wf_spec, name, **kwargs)
         self.is_terminate_event = is_terminate_event
+        self.is_escalation_event = is_escalation_event
+        self.escalation_code = escalation_code
 
     def _on_complete_hook(self, my_task):
         if self.is_terminate_event:
@@ -69,5 +75,13 @@ class EndEvent(Simple, BpmnSpecMixin):
                             start_sibling.cancel()
 
             my_task.workflow.refresh_waiting_tasks()
+        elif self.is_escalation_event:
+            # send escalation as message to outer workflow
+            wf = my_task.workflow
+            message = 'x_escalation:%s:%s' % (
+                wf.name, # this is a copy of CallActivity task spec name
+                self.escalation_code or '*',
+            )
+            wf.outer_workflow.accept_message(message)
 
         super(EndEvent, self)._on_complete_hook(my_task)

--- a/SpiffWorkflow/bpmn/specs/UnstructuredJoin.py
+++ b/SpiffWorkflow/bpmn/specs/UnstructuredJoin.py
@@ -147,6 +147,6 @@ class UnstructuredJoin(Join, BpmnSpecMixin):
             my_task._set_state(Task.WAITING)
             return
 
-        logging.debug('UnstructuredJoin._update_hook: %s (%s) - Children: %s',
+        LOG.debug('UnstructuredJoin._update_hook: %s (%s) - Children: %s',
                       self.name, self.description, len(my_task.children))
         super(UnstructuredJoin, self)._update_hook(my_task)

--- a/SpiffWorkflow/bpmn/specs/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/event_definitions.py
@@ -18,6 +18,7 @@ from builtins import object
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
 
+import sys
 import datetime
 import logging
 
@@ -138,7 +139,11 @@ class EscalationEventDefinition(CatchingEventDefinition, ThrowingEventDefinition
         return my_task._get_internal_data('event_fired', False)
 
     def _accept_message(self, my_task, message):
-        if isinstance(message, basestring) and message.startswith('x_escalation:'):
+        if sys.version_info[0] == 3:
+            string_types = str,
+        else:
+            string_types = basestring,
+        if isinstance(message, string_types) and message.startswith('x_escalation:'):
             parts = message.split(':')
             if len(parts) == 3:
                 _, source_task_name, recv_escalation_code = parts

--- a/SpiffWorkflow/workflow.py
+++ b/SpiffWorkflow/workflow.py
@@ -117,6 +117,12 @@ class Workflow(object):
             self.locks[name] = mutex()
         return self.locks[name]
 
+    def set_data(self, **kwargs):
+        """
+        Defines the given attribute/value pairs.
+        """
+        self.data.update(kwargs)
+
     def get_data(self, name, default=None):
         """
         Returns the value of the data field with the given name, or the given

--- a/tests/SpiffWorkflow/bpmn/CallActivityEscalationTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivityEscalationTest.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import, division
+
+from __future__ import division, absolute_import
+import unittest
+import datetime
+import time
+from SpiffWorkflow.task import Task
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+__author__ = 'kbogus@gmail.com'
+
+
+def on_reached_cb(workflow, task, completed_set):
+    # In workflows that load a subworkflow, the newly loaded children
+    # will not have on_reached_cb() assigned. By using this function, we
+    # re-assign the function in every step, thus making sure that new
+    # children also call on_reached_cb().
+    for child in task.children:
+        track_task(child.task_spec, completed_set)
+    return True
+
+
+def on_complete_cb(workflow, task, completed_set):
+    completed_set.add(task.task_spec.name)
+    return True
+
+
+def track_task(task_spec, completed_set):
+    if task_spec.reached_event.is_connected(on_reached_cb):
+        task_spec.reached_event.disconnect(on_reached_cb)
+    task_spec.reached_event.connect(on_reached_cb, completed_set)
+    if task_spec.completed_event.is_connected(on_complete_cb):
+        task_spec.completed_event.disconnect(on_complete_cb)
+    task_spec.completed_event.connect(on_complete_cb, completed_set)
+
+
+def track_workflow(wf_spec, completed_set):
+    for name in wf_spec.task_specs:
+        track_task(wf_spec.task_specs[name], completed_set)
+
+
+class CallActivityEscalationTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        self.spec = self.load_spec()
+
+    def load_spec(self):
+        return self.load_workflow_spec('Test-Workflows/*.bpmn20.xml', 'CallActivity-Escalation-Test')
+
+    def testShouldEscalate(self):
+        completed_set = set()
+        track_workflow(self.spec, completed_set)
+        self.workflow = BpmnWorkflow(self.spec)
+        for task in self.workflow.get_tasks(Task.READY):
+            task.set_data(should_escalate=True)
+        self.save_restore()
+        self.workflow.complete_all()
+        self.assertEqual(True, self.workflow.is_completed())
+
+        self.assertEqual(True, 'EndEvent_specific1_noninterrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific1_noninterrupting_escalated' in completed_set)
+
+        self.assertEqual(True, 'EndEvent_specific1_interrupting_normal' not in completed_set)
+        self.assertEqual(True, 'EndEvent_specific1_interrupting_escalated' in completed_set)
+
+        self.assertEqual(True, 'EndEvent_specific2_noninterrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_noninterrupting_escalated' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_noninterrupting_missingvariable' not in completed_set)
+
+        self.assertEqual(True, 'EndEvent_specific2_interrupting_normal' not in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_interrupting_escalated' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_interrupting_missingvariable' not in completed_set)
+
+        self.assertEqual(True, 'EndEvent_general_noninterrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_general_noninterrupting_escalated' in completed_set)
+
+        self.assertEqual(True, 'EndEvent_general_interrupting_normal' not in completed_set)
+        self.assertEqual(True, 'EndEvent_general_interrupting_escalated' in completed_set)
+
+    def testShouldNotEscalate(self):
+        completed_set = set()
+        track_workflow(self.spec, completed_set)
+        self.workflow = BpmnWorkflow(self.spec)
+        for task in self.workflow.get_tasks(Task.READY):
+            task.set_data(should_escalate=False)
+        self.save_restore()
+        self.workflow.complete_all()
+        self.assertEqual(True, self.workflow.is_completed())
+
+        self.assertEqual(True, 'EndEvent_specific1_noninterrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific1_noninterrupting_escalated' not in completed_set)
+
+        self.assertEqual(True, 'EndEvent_specific1_interrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific1_interrupting_escalated' not in completed_set)
+
+        self.assertEqual(True, 'EndEvent_specific2_noninterrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_noninterrupting_escalated' not in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_noninterrupting_missingvariable' not in completed_set)
+
+        self.assertEqual(True, 'EndEvent_specific2_interrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_interrupting_escalated' not in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_interrupting_missingvariable' not in completed_set)
+
+        self.assertEqual(True, 'EndEvent_general_noninterrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_general_noninterrupting_escalated' not in completed_set)
+
+        self.assertEqual(True, 'EndEvent_general_interrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_general_interrupting_escalated' not in completed_set)
+
+    def testMissingVariable(self):
+        completed_set = set()
+        track_workflow(self.spec, completed_set)
+        self.workflow = BpmnWorkflow(self.spec)
+        self.save_restore()
+        self.workflow.complete_all()
+        self.assertEqual(True, self.workflow.is_completed())
+
+        self.assertEqual(True, 'EndEvent_specific1_noninterrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific1_noninterrupting_escalated' not in completed_set)
+
+        self.assertEqual(True, 'EndEvent_specific1_interrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific1_interrupting_escalated' not in completed_set)
+
+        self.assertEqual(True, 'EndEvent_specific2_noninterrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_noninterrupting_escalated' not in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_noninterrupting_missingvariable' in completed_set)
+
+        self.assertEqual(True, 'EndEvent_specific2_interrupting_normal' not in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_interrupting_escalated' not in completed_set)
+        self.assertEqual(True, 'EndEvent_specific2_interrupting_missingvariable' in completed_set)
+
+        self.assertEqual(True, 'EndEvent_general_noninterrupting_normal' in completed_set)
+        self.assertEqual(True, 'EndEvent_general_noninterrupting_escalated' in completed_set)
+
+        self.assertEqual(True, 'EndEvent_general_interrupting_normal' not in completed_set)
+        self.assertEqual(True, 'EndEvent_general_interrupting_escalated' in completed_set)
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(CallActivityEscalationTest)
+
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/bpmn/CallActivityEscalationTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivityEscalationTest.py
@@ -55,7 +55,6 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
         self.workflow = BpmnWorkflow(self.spec)
         for task in self.workflow.get_tasks(Task.READY):
             task.set_data(should_escalate=True)
-        self.save_restore()
         self.workflow.complete_all()
         self.assertEqual(True, self.workflow.is_completed())
 
@@ -85,7 +84,6 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
         self.workflow = BpmnWorkflow(self.spec)
         for task in self.workflow.get_tasks(Task.READY):
             task.set_data(should_escalate=False)
-        self.save_restore()
         self.workflow.complete_all()
         self.assertEqual(True, self.workflow.is_completed())
 
@@ -113,7 +111,6 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
         completed_set = set()
         track_workflow(self.spec, completed_set)
         self.workflow = BpmnWorkflow(self.spec)
-        self.save_restore()
         self.workflow.complete_all()
         self.assertEqual(True, self.workflow.is_completed())
 

--- a/tests/SpiffWorkflow/bpmn/CallActivityEscalationTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivityEscalationTest.py
@@ -55,6 +55,7 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
         self.workflow = BpmnWorkflow(self.spec)
         for task in self.workflow.get_tasks(Task.READY):
             task.set_data(should_escalate=True)
+        self.save_restore()
         self.workflow.complete_all()
         self.assertEqual(True, self.workflow.is_completed())
 
@@ -84,6 +85,7 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
         self.workflow = BpmnWorkflow(self.spec)
         for task in self.workflow.get_tasks(Task.READY):
             task.set_data(should_escalate=False)
+        self.save_restore()
         self.workflow.complete_all()
         self.assertEqual(True, self.workflow.is_completed())
 
@@ -111,6 +113,7 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
         completed_set = set()
         track_workflow(self.spec, completed_set)
         self.workflow = BpmnWorkflow(self.spec)
+        self.save_restore()
         self.workflow.complete_all()
         self.assertEqual(True, self.workflow.is_completed())
 
@@ -135,8 +138,20 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
         self.assertEqual(True, 'EndEvent_general_interrupting_escalated' in completed_set)
 
 
+class CallActivityEscalationWithoutSaveRestoreTest(CallActivityEscalationTest):
+    def save_restore(self):
+        pass # disabling save_restore for this test case
+
+
 def suite():
-    return unittest.TestLoader().loadTestsFromTestCase(CallActivityEscalationTest)
+    loader = unittest.TestLoader()
+    return unittest.TestSuite([
+        loader.loadTestsFromTestCase(cls)
+        for cls in [
+            CallActivityEscalationTest,
+            CallActivityEscalationWithoutSaveRestoreTest,
+        ]
+    ])
 
 
 if __name__ == '__main__':

--- a/tests/SpiffWorkflow/bpmn/data/Test-Workflows/CallActivity-Escalation-Test-Sub.bpmn20.xml
+++ b/tests/SpiffWorkflow/bpmn/data/Test-Workflows/CallActivity-Escalation-Test-Sub.bpmn20.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.8.0">
+  <bpmn:process id="CallActivity-Escalation-Test-Sub" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1pdxvjo</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1fftpux" name="should escalate?" default="SequenceFlow_07vs6qb">
+      <bpmn:incoming>SequenceFlow_0expyhf</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_07vs6qb</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_15hc88y</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1pdxvjo" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_0faf08n" />
+    <bpmn:endEvent id="EndEvent_0kpn6yh">
+      <bpmn:incoming>SequenceFlow_07vs6qb</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_07vs6qb" name="no" sourceRef="ExclusiveGateway_1fftpux" targetRef="EndEvent_0kpn6yh" />
+    <bpmn:sequenceFlow id="SequenceFlow_15hc88y" name="yes" sourceRef="ExclusiveGateway_1fftpux" targetRef="EndEvent_09tnjk6">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="python"><![CDATA[task.get_data('should_escalate')]]></bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="EndEvent_09tnjk6">
+      <bpmn:incoming>SequenceFlow_15hc88y</bpmn:incoming>
+      <bpmn:escalationEventDefinition escalationRef="Escalation_1oeml95" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_0faf08n" name="variable present?" default="SequenceFlow_0rwyweg">
+      <bpmn:incoming>SequenceFlow_1pdxvjo</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0expyhf</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_0rwyweg</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_0expyhf" name="yes" sourceRef="ExclusiveGateway_0faf08n" targetRef="ExclusiveGateway_1fftpux">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" language="python"><![CDATA['should_escalate' in task.data]]></bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_0rwyweg" name="no" sourceRef="ExclusiveGateway_0faf08n" targetRef="EndEvent_1iplfgs" />
+    <bpmn:endEvent id="EndEvent_1iplfgs">
+      <bpmn:incoming>SequenceFlow_0rwyweg</bpmn:incoming>
+      <bpmn:escalationEventDefinition escalationRef="Escalation_0i2y5fh" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:escalation id="Escalation_1oeml95" name="Escalation_1d67ilm" escalationCode="test-escalation" />
+  <bpmn:escalation id="Escalation_0i2y5fh" name="Escalation_0vdmq95" escalationCode="no-variable-present" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CallActivity-Escalation-Test-Sub">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="79" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="52" y="138" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1fftpux_di" bpmnElement="ExclusiveGateway_1fftpux" isMarkerVisible="true">
+        <dc:Bounds x="308" y="95" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="293" y="149" width="82" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1pdxvjo_di" bpmnElement="SequenceFlow_1pdxvjo">
+        <di:waypoint xsi:type="dc:Point" x="115" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="173" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="99" y="99" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0kpn6yh_di" bpmnElement="EndEvent_0kpn6yh">
+        <dc:Bounds x="469" y="23" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="487" y="63" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_07vs6qb_di" bpmnElement="SequenceFlow_07vs6qb">
+        <di:waypoint xsi:type="dc:Point" x="333" y="95" />
+        <di:waypoint xsi:type="dc:Point" x="333" y="41" />
+        <di:waypoint xsi:type="dc:Point" x="469" y="41" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="342" y="62" width="12" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_15hc88y_di" bpmnElement="SequenceFlow_15hc88y">
+        <di:waypoint xsi:type="dc:Point" x="358" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="469" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="405" y="99" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1fzzy0c_di" bpmnElement="EndEvent_09tnjk6">
+        <dc:Bounds x="469" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="487" y="142" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_0faf08n_di" bpmnElement="ExclusiveGateway_0faf08n" isMarkerVisible="true">
+        <dc:Bounds x="173" y="95" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="156" y="149" width="84" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0expyhf_di" bpmnElement="SequenceFlow_0expyhf">
+        <di:waypoint xsi:type="dc:Point" x="223" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="308" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="257" y="99" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rwyweg_di" bpmnElement="SequenceFlow_0rwyweg">
+        <di:waypoint xsi:type="dc:Point" x="198" y="95" />
+        <di:waypoint xsi:type="dc:Point" x="198" y="59" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="207" y="71" width="12" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1bihs4n_di" bpmnElement="EndEvent_1iplfgs">
+        <dc:Bounds x="180" y="23" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="198" y="63" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/Test-Workflows/CallActivity-Escalation-Test.bpmn20.xml
+++ b/tests/SpiffWorkflow/bpmn/data/Test-Workflows/CallActivity-Escalation-Test.bpmn20.xml
@@ -1,0 +1,692 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.8.0">
+  <bpmn:process id="CallActivity-Escalation-Test" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_16zp7m1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_16zp7m1" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_1wcltkh" />
+    <bpmn:parallelGateway id="ExclusiveGateway_1wcltkh">
+      <bpmn:incoming>SequenceFlow_16zp7m1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1kda3po</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1s1w90v</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_14zh7re</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_0how4sz</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_09hcnsg</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1svgn4k</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="EndEvent_general_noninterrupting_normal">
+      <bpmn:incoming>SequenceFlow_0poxg37</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1ah0nyw" sourceRef="Task_1x5aq4g" targetRef="Task_09hpbad" />
+    <bpmn:boundaryEvent id="BoundaryEvent_0qerug4" cancelActivity="false" attachedToRef="Task_1x5aq4g">
+      <bpmn:outgoing>SequenceFlow_04o4ekt</bpmn:outgoing>
+      <bpmn:escalationEventDefinition />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="EndEvent_general_noninterrupting_escalated">
+      <bpmn:incoming>SequenceFlow_1v1zuh1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_04o4ekt" sourceRef="BoundaryEvent_0qerug4" targetRef="Task_0ctsy5q" />
+    <bpmn:callActivity id="Task_1x5aq4g" calledElement="CallActivity-Escalation-Test-Sub">
+      <bpmn:incoming>SequenceFlow_1kda3po</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1ah0nyw</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="SequenceFlow_1kda3po" sourceRef="ExclusiveGateway_1wcltkh" targetRef="Task_1x5aq4g" />
+    <bpmn:callActivity id="CallActivity_13dg1lb" calledElement="CallActivity-Escalation-Test-Sub">
+      <bpmn:incoming>SequenceFlow_1s1w90v</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1ra76av</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:boundaryEvent id="BoundaryEvent_081wgw6" attachedToRef="CallActivity_13dg1lb">
+      <bpmn:outgoing>SequenceFlow_00n7udr</bpmn:outgoing>
+      <bpmn:escalationEventDefinition escalationRef="Escalation_18yknx4" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="EndEvent_specific2_interrupting_escalated">
+      <bpmn:incoming>SequenceFlow_1smtf8a</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_00n7udr" sourceRef="BoundaryEvent_081wgw6" targetRef="Task_1xxsdf3" />
+    <bpmn:endEvent id="EndEvent_specific2_interrupting_missingvariable">
+      <bpmn:incoming>SequenceFlow_072gxkd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0oox1qd" sourceRef="BoundaryEvent_00sji6t" targetRef="Task_1l5un85" />
+    <bpmn:boundaryEvent id="BoundaryEvent_00sji6t" attachedToRef="CallActivity_13dg1lb">
+      <bpmn:outgoing>SequenceFlow_0oox1qd</bpmn:outgoing>
+      <bpmn:escalationEventDefinition escalationRef="Escalation_0r5uh0g" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="EndEvent_specific2_interrupting_normal">
+      <bpmn:incoming>SequenceFlow_0exwdi2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1ra76av" sourceRef="CallActivity_13dg1lb" targetRef="Task_1ifxw0o" />
+    <bpmn:sequenceFlow id="SequenceFlow_1s1w90v" sourceRef="ExclusiveGateway_1wcltkh" targetRef="CallActivity_13dg1lb" />
+    <bpmn:callActivity id="CallActivity_0ax2t94" calledElement="CallActivity-Escalation-Test-Sub">
+      <bpmn:incoming>SequenceFlow_14zh7re</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1q5t764</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="EndEvent_specific2_noninterrupting_normal">
+      <bpmn:incoming>SequenceFlow_0ua7azh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_specific2_noninterrupting_escalated">
+      <bpmn:incoming>SequenceFlow_0ty2h2e</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_specific2_noninterrupting_missingvariable">
+      <bpmn:incoming>SequenceFlow_1sq53x5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1q5t764" sourceRef="CallActivity_0ax2t94" targetRef="Task_0bk3rj7" />
+    <bpmn:sequenceFlow id="SequenceFlow_0sqyooa" sourceRef="BoundaryEvent_0gjbt5g" targetRef="Task_1xu2qoc" />
+    <bpmn:sequenceFlow id="SequenceFlow_1qkwoqo" sourceRef="BoundaryEvent_0g6a5mg" targetRef="Task_1i7xyy1" />
+    <bpmn:boundaryEvent id="BoundaryEvent_0g6a5mg" cancelActivity="false" attachedToRef="CallActivity_0ax2t94">
+      <bpmn:outgoing>SequenceFlow_1qkwoqo</bpmn:outgoing>
+      <bpmn:escalationEventDefinition escalationRef="Escalation_0r5uh0g" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="BoundaryEvent_0gjbt5g" cancelActivity="false" attachedToRef="CallActivity_0ax2t94">
+      <bpmn:outgoing>SequenceFlow_0sqyooa</bpmn:outgoing>
+      <bpmn:escalationEventDefinition escalationRef="Escalation_18yknx4" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_14zh7re" sourceRef="ExclusiveGateway_1wcltkh" targetRef="CallActivity_0ax2t94" />
+    <bpmn:callActivity id="CallActivity_19a45v2" calledElement="CallActivity-Escalation-Test-Sub">
+      <bpmn:incoming>SequenceFlow_0how4sz</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_06tuy2y</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="CallActivity_0a3fw0d" calledElement="CallActivity-Escalation-Test-Sub">
+      <bpmn:incoming>SequenceFlow_09hcnsg</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oqcl5z</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="EndEvent_specific1_interrupting_normal">
+      <bpmn:incoming>SequenceFlow_0i2nsbv</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_specific1_interrupting_escalated">
+      <bpmn:incoming>SequenceFlow_1ud7tfa</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_specific1_noninterrupting_normal">
+      <bpmn:incoming>SequenceFlow_1sv1p07</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_specific1_noninterrupting_escalated">
+      <bpmn:incoming>SequenceFlow_044gv9a</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="BoundaryEvent_1x7d6w4" attachedToRef="CallActivity_19a45v2">
+      <bpmn:outgoing>SequenceFlow_078mvp0</bpmn:outgoing>
+      <bpmn:escalationEventDefinition escalationRef="Escalation_18yknx4" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="BoundaryEvent_05nb5ac" cancelActivity="false" attachedToRef="CallActivity_0a3fw0d">
+      <bpmn:outgoing>SequenceFlow_1lit4b3</bpmn:outgoing>
+      <bpmn:escalationEventDefinition escalationRef="Escalation_18yknx4" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_06tuy2y" sourceRef="CallActivity_19a45v2" targetRef="Task_19gs1rs" />
+    <bpmn:sequenceFlow id="SequenceFlow_078mvp0" sourceRef="BoundaryEvent_1x7d6w4" targetRef="Task_021v9mx" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oqcl5z" sourceRef="CallActivity_0a3fw0d" targetRef="Task_0b30iaa" />
+    <bpmn:sequenceFlow id="SequenceFlow_1lit4b3" sourceRef="BoundaryEvent_05nb5ac" targetRef="Task_0fphnb8" />
+    <bpmn:sequenceFlow id="SequenceFlow_0how4sz" sourceRef="ExclusiveGateway_1wcltkh" targetRef="CallActivity_19a45v2" />
+    <bpmn:sequenceFlow id="SequenceFlow_09hcnsg" sourceRef="ExclusiveGateway_1wcltkh" targetRef="CallActivity_0a3fw0d" />
+    <bpmn:endEvent id="EndEvent_general_interrupting_normal">
+      <bpmn:incoming>SequenceFlow_1347w9t</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_general_interrupting_escalated">
+      <bpmn:incoming>SequenceFlow_0lih4rm</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="CallActivity_0g6to6j" calledElement="CallActivity-Escalation-Test-Sub">
+      <bpmn:incoming>SequenceFlow_1svgn4k</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1gibvy0</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="SequenceFlow_1gibvy0" sourceRef="CallActivity_0g6to6j" targetRef="Task_15ttedj" />
+    <bpmn:sequenceFlow id="SequenceFlow_0cymhxo" sourceRef="BoundaryEvent_1ipby03" targetRef="Task_0ujttus" />
+    <bpmn:sequenceFlow id="SequenceFlow_1svgn4k" sourceRef="ExclusiveGateway_1wcltkh" targetRef="CallActivity_0g6to6j" />
+    <bpmn:boundaryEvent id="BoundaryEvent_1ipby03" attachedToRef="CallActivity_0g6to6j">
+      <bpmn:outgoing>SequenceFlow_0cymhxo</bpmn:outgoing>
+      <bpmn:escalationEventDefinition />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0lih4rm" sourceRef="Task_0ujttus" targetRef="EndEvent_general_interrupting_escalated" />
+    <bpmn:scriptTask id="Task_0ujttus" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_0cymhxo</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0lih4rm</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1347w9t" sourceRef="Task_15ttedj" targetRef="EndEvent_general_interrupting_normal" />
+    <bpmn:scriptTask id="Task_15ttedj" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_1gibvy0</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1347w9t</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1v1zuh1" sourceRef="Task_0ctsy5q" targetRef="EndEvent_general_noninterrupting_escalated" />
+    <bpmn:scriptTask id="Task_0ctsy5q" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_04o4ekt</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1v1zuh1</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0poxg37" sourceRef="Task_09hpbad" targetRef="EndEvent_general_noninterrupting_normal" />
+    <bpmn:scriptTask id="Task_09hpbad" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_1ah0nyw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0poxg37</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_072gxkd" sourceRef="Task_1l5un85" targetRef="EndEvent_specific2_interrupting_missingvariable" />
+    <bpmn:scriptTask id="Task_1l5un85" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_0oox1qd</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_072gxkd</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1smtf8a" sourceRef="Task_1xxsdf3" targetRef="EndEvent_specific2_interrupting_escalated" />
+    <bpmn:scriptTask id="Task_1xxsdf3" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_00n7udr</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1smtf8a</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0exwdi2" sourceRef="Task_1ifxw0o" targetRef="EndEvent_specific2_interrupting_normal" />
+    <bpmn:scriptTask id="Task_1ifxw0o" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_1ra76av</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0exwdi2</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1sq53x5" sourceRef="Task_1i7xyy1" targetRef="EndEvent_specific2_noninterrupting_missingvariable" />
+    <bpmn:scriptTask id="Task_1i7xyy1" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_1qkwoqo</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1sq53x5</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0ty2h2e" sourceRef="Task_1xu2qoc" targetRef="EndEvent_specific2_noninterrupting_escalated" />
+    <bpmn:scriptTask id="Task_1xu2qoc" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_0sqyooa</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0ty2h2e</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0ua7azh" sourceRef="Task_0bk3rj7" targetRef="EndEvent_specific2_noninterrupting_normal" />
+    <bpmn:scriptTask id="Task_0bk3rj7" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_1q5t764</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0ua7azh</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1ud7tfa" sourceRef="Task_021v9mx" targetRef="EndEvent_specific1_interrupting_escalated" />
+    <bpmn:scriptTask id="Task_021v9mx" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_078mvp0</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1ud7tfa</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0i2nsbv" sourceRef="Task_19gs1rs" targetRef="EndEvent_specific1_interrupting_normal" />
+    <bpmn:scriptTask id="Task_19gs1rs" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_06tuy2y</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0i2nsbv</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_044gv9a" sourceRef="Task_0fphnb8" targetRef="EndEvent_specific1_noninterrupting_escalated" />
+    <bpmn:scriptTask id="Task_0fphnb8" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_1lit4b3</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_044gv9a</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1sv1p07" sourceRef="Task_0b30iaa" targetRef="EndEvent_specific1_noninterrupting_normal" />
+    <bpmn:scriptTask id="Task_0b30iaa" scriptFormat="python">
+      <bpmn:incoming>SequenceFlow_1oqcl5z</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1sv1p07</bpmn:outgoing>
+      <bpmn:script>a = 1</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmn:escalation id="Escalation_18yknx4" name="Escalation_1s9cu2e" escalationCode="test-escalation" />
+  <bpmn:escalation id="Escalation_0r5uh0g" name="Escalation_378cp9h" escalationCode="no-variable-present" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CallActivity-Escalation-Test">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="54" y="640" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="27" y="676" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_16zp7m1_di" bpmnElement="SequenceFlow_16zp7m1">
+        <di:waypoint xsi:type="dc:Point" x="90" y="658" />
+        <di:waypoint xsi:type="dc:Point" x="152" y="658" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="76" y="637" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ParallelGateway_01sthui_di" bpmnElement="ExclusiveGateway_1wcltkh">
+        <dc:Bounds x="152" y="633" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="132" y="687" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_18111r7_di" bpmnElement="EndEvent_general_noninterrupting_normal">
+        <dc:Bounds x="783" y="944" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="984" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ah0nyw_di" bpmnElement="SequenceFlow_1ah0nyw">
+        <di:waypoint xsi:type="dc:Point" x="550" y="962" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="962" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="539" y="941" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BoundaryEvent_0i3o6hq_di" bpmnElement="BoundaryEvent_0qerug4">
+        <dc:Bounds x="532" y="984" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="505" y="1024" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0w1m2cp_di" bpmnElement="EndEvent_general_noninterrupting_escalated">
+        <dc:Bounds x="783" y="1042" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="1082" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_04o4ekt_di" bpmnElement="SequenceFlow_04o4ekt">
+        <di:waypoint xsi:type="dc:Point" x="550" y="1020" />
+        <di:waypoint xsi:type="dc:Point" x="550" y="1060" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="1060" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="520" y="1034" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="CallActivity_1qebjcb_di" bpmnElement="Task_1x5aq4g">
+        <dc:Bounds x="450" y="922" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1kda3po_di" bpmnElement="SequenceFlow_1kda3po">
+        <di:waypoint xsi:type="dc:Point" x="177" y="683" />
+        <di:waypoint xsi:type="dc:Point" x="177" y="962" />
+        <di:waypoint xsi:type="dc:Point" x="450" y="962" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="147" y="816.5" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="CallActivity_13dg1lb_di" bpmnElement="CallActivity_13dg1lb">
+        <dc:Bounds x="450" y="618" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_0whl2pv_di" bpmnElement="BoundaryEvent_081wgw6">
+        <dc:Bounds x="532" y="680" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="505" y="720" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1ppvn2x_di" bpmnElement="EndEvent_specific2_interrupting_escalated">
+        <dc:Bounds x="783" y="740" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="819" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_00n7udr_di" bpmnElement="SequenceFlow_00n7udr">
+        <di:waypoint xsi:type="dc:Point" x="550" y="716" />
+        <di:waypoint xsi:type="dc:Point" x="550" y="758" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="758" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="520" y="731" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_05gt1am_di" bpmnElement="EndEvent_specific2_interrupting_missingvariable">
+        <dc:Bounds x="783" y="843" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="883" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0oox1qd_di" bpmnElement="SequenceFlow_0oox1qd">
+        <di:waypoint xsi:type="dc:Point" x="500" y="716" />
+        <di:waypoint xsi:type="dc:Point" x="500" y="861" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="861" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="470" y="782.5" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BoundaryEvent_062iwgv_di" bpmnElement="BoundaryEvent_00sji6t">
+        <dc:Bounds x="482" y="680" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="455" y="720" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0f7f5ck_di" bpmnElement="EndEvent_specific2_interrupting_normal">
+        <dc:Bounds x="783" y="640" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="680" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ra76av_di" bpmnElement="SequenceFlow_1ra76av">
+        <di:waypoint xsi:type="dc:Point" x="550" y="658" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="658" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="539" y="637" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1s1w90v_di" bpmnElement="SequenceFlow_1s1w90v">
+        <di:waypoint xsi:type="dc:Point" x="202" y="658" />
+        <di:waypoint xsi:type="dc:Point" x="326" y="658" />
+        <di:waypoint xsi:type="dc:Point" x="326" y="658" />
+        <di:waypoint xsi:type="dc:Point" x="450" y="658" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="296" y="652" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="CallActivity_0ax2t94_di" bpmnElement="CallActivity_0ax2t94">
+        <dc:Bounds x="450" y="339" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1dkik2l_di" bpmnElement="EndEvent_specific2_noninterrupting_normal">
+        <dc:Bounds x="783" y="361" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="401" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_10rggia_di" bpmnElement="EndEvent_specific2_noninterrupting_escalated">
+        <dc:Bounds x="783" y="461" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="501" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1xpa4z6_di" bpmnElement="EndEvent_specific2_noninterrupting_missingvariable">
+        <dc:Bounds x="783" y="545" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="585" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q5t764_di" bpmnElement="SequenceFlow_1q5t764">
+        <di:waypoint xsi:type="dc:Point" x="550" y="379" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="379" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="539" y="358" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0sqyooa_di" bpmnElement="SequenceFlow_0sqyooa">
+        <di:waypoint xsi:type="dc:Point" x="550" y="437" />
+        <di:waypoint xsi:type="dc:Point" x="550" y="479" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="479" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="520" y="452" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1qkwoqo_di" bpmnElement="SequenceFlow_1qkwoqo">
+        <di:waypoint xsi:type="dc:Point" x="500" y="437" />
+        <di:waypoint xsi:type="dc:Point" x="500" y="563" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="563" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="470" y="494" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BoundaryEvent_1tpeicv_di" bpmnElement="BoundaryEvent_0g6a5mg">
+        <dc:Bounds x="482" y="401" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="455" y="441" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1a1a824_di" bpmnElement="BoundaryEvent_0gjbt5g">
+        <dc:Bounds x="532" y="401" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="505" y="441" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_14zh7re_di" bpmnElement="SequenceFlow_14zh7re">
+        <di:waypoint xsi:type="dc:Point" x="177" y="633" />
+        <di:waypoint xsi:type="dc:Point" x="177" y="379" />
+        <di:waypoint xsi:type="dc:Point" x="450" y="379" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="147" y="500" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="CallActivity_19a45v2_di" bpmnElement="CallActivity_19a45v2">
+        <dc:Bounds x="450" y="113" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_0a3fw0d_di" bpmnElement="CallActivity_0a3fw0d">
+        <dc:Bounds x="450" y="-81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1e6t6ds_di" bpmnElement="EndEvent_specific1_interrupting_normal">
+        <dc:Bounds x="783" y="135" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="711" y="175" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0l38pci_di" bpmnElement="EndEvent_specific1_interrupting_escalated">
+        <dc:Bounds x="783" y="248" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="711" y="288" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0p2ffno_di" bpmnElement="EndEvent_specific1_noninterrupting_normal">
+        <dc:Bounds x="783" y="-59" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="-19" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1v94uq5_di" bpmnElement="EndEvent_specific1_noninterrupting_escalated">
+        <dc:Bounds x="783" y="36" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="76" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_1x7d6w4_di" bpmnElement="BoundaryEvent_1x7d6w4">
+        <dc:Bounds x="532" y="175" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="505" y="215" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_05nb5ac_di" bpmnElement="BoundaryEvent_05nb5ac">
+        <dc:Bounds x="532" y="-19" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="550" y="21" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_06tuy2y_di" bpmnElement="SequenceFlow_06tuy2y">
+        <di:waypoint xsi:type="dc:Point" x="550" y="153" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="153" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="539" y="132" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_078mvp0_di" bpmnElement="SequenceFlow_078mvp0">
+        <di:waypoint xsi:type="dc:Point" x="550" y="211" />
+        <di:waypoint xsi:type="dc:Point" x="550" y="266" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="266" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="520" y="232.5" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oqcl5z_di" bpmnElement="SequenceFlow_1oqcl5z">
+        <di:waypoint xsi:type="dc:Point" x="550" y="-41" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="-41" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="539" y="-62" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1lit4b3_di" bpmnElement="SequenceFlow_1lit4b3">
+        <di:waypoint xsi:type="dc:Point" x="550" y="17" />
+        <di:waypoint xsi:type="dc:Point" x="550" y="54" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="54" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="520" y="29.5" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0how4sz_di" bpmnElement="SequenceFlow_0how4sz">
+        <di:waypoint xsi:type="dc:Point" x="177" y="633" />
+        <di:waypoint xsi:type="dc:Point" x="177" y="153" />
+        <di:waypoint xsi:type="dc:Point" x="450" y="153" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="147" y="387" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_09hcnsg_di" bpmnElement="SequenceFlow_09hcnsg">
+        <di:waypoint xsi:type="dc:Point" x="177" y="633" />
+        <di:waypoint xsi:type="dc:Point" x="177" y="-41" />
+        <di:waypoint xsi:type="dc:Point" x="450" y="-41" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="147" y="290" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0aejlap_di" bpmnElement="EndEvent_general_interrupting_normal">
+        <dc:Bounds x="783" y="1132" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="1172" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0njdhjf_di" bpmnElement="EndEvent_general_interrupting_escalated">
+        <dc:Bounds x="783" y="1228" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="756" y="1268" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_0g6to6j_di" bpmnElement="CallActivity_0g6to6j">
+        <dc:Bounds x="450" y="1110" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1gibvy0_di" bpmnElement="SequenceFlow_1gibvy0">
+        <di:waypoint xsi:type="dc:Point" x="550" y="1150" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="1150" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="584" y="1129" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0cymhxo_di" bpmnElement="SequenceFlow_0cymhxo">
+        <di:waypoint xsi:type="dc:Point" x="550" y="1208" />
+        <di:waypoint xsi:type="dc:Point" x="550" y="1246" />
+        <di:waypoint xsi:type="dc:Point" x="618" y="1246" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="565" y="1221" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1svgn4k_di" bpmnElement="SequenceFlow_1svgn4k">
+        <di:waypoint xsi:type="dc:Point" x="177" y="683" />
+        <di:waypoint xsi:type="dc:Point" x="177" y="1150" />
+        <di:waypoint xsi:type="dc:Point" x="450" y="1150" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="192" y="910.5" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BoundaryEvent_00xzram_di" bpmnElement="BoundaryEvent_1ipby03">
+        <dc:Bounds x="532" y="1172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="550" y="1212" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0lih4rm_di" bpmnElement="SequenceFlow_0lih4rm">
+        <di:waypoint xsi:type="dc:Point" x="718" y="1246" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="1246" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="1225" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_14ss3xc_di" bpmnElement="Task_0ujttus">
+        <dc:Bounds x="618" y="1206" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1347w9t_di" bpmnElement="SequenceFlow_1347w9t">
+        <di:waypoint xsi:type="dc:Point" x="718" y="1150" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="1150" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="1129" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0c7r9ey_di" bpmnElement="Task_15ttedj">
+        <dc:Bounds x="618" y="1110" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1v1zuh1_di" bpmnElement="SequenceFlow_1v1zuh1">
+        <di:waypoint xsi:type="dc:Point" x="718" y="1060" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="1060" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="1039" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0rbr5ov_di" bpmnElement="Task_0ctsy5q">
+        <dc:Bounds x="618" y="1020" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0poxg37_di" bpmnElement="SequenceFlow_0poxg37">
+        <di:waypoint xsi:type="dc:Point" x="718" y="962" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="962" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="941" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_1qg8503_di" bpmnElement="Task_09hpbad">
+        <dc:Bounds x="618" y="922" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_072gxkd_di" bpmnElement="SequenceFlow_072gxkd">
+        <di:waypoint xsi:type="dc:Point" x="718" y="861" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="861" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="840" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_1jdqb9j_di" bpmnElement="Task_1l5un85">
+        <dc:Bounds x="618" y="821" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1smtf8a_di" bpmnElement="SequenceFlow_1smtf8a">
+        <di:waypoint xsi:type="dc:Point" x="718" y="758" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="758" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="737" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_1haujj0_di" bpmnElement="Task_1xxsdf3">
+        <dc:Bounds x="618" y="718" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0exwdi2_di" bpmnElement="SequenceFlow_0exwdi2">
+        <di:waypoint xsi:type="dc:Point" x="718" y="658" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="658" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="637" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_1l5672n_di" bpmnElement="Task_1ifxw0o">
+        <dc:Bounds x="618" y="618" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sq53x5_di" bpmnElement="SequenceFlow_1sq53x5">
+        <di:waypoint xsi:type="dc:Point" x="718" y="563" />
+        <di:waypoint xsi:type="dc:Point" x="751" y="563" />
+        <di:waypoint xsi:type="dc:Point" x="751" y="563" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="563" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="766" y="557" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_15s0nu6_di" bpmnElement="Task_1i7xyy1">
+        <dc:Bounds x="618" y="523" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ty2h2e_di" bpmnElement="SequenceFlow_0ty2h2e">
+        <di:waypoint xsi:type="dc:Point" x="718" y="479" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="479" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="458" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0uyir4r_di" bpmnElement="Task_1xu2qoc">
+        <dc:Bounds x="618" y="439" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ua7azh_di" bpmnElement="SequenceFlow_0ua7azh">
+        <di:waypoint xsi:type="dc:Point" x="718" y="379" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="379" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="358" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_1k86ou1_di" bpmnElement="Task_0bk3rj7">
+        <dc:Bounds x="618" y="339" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ud7tfa_di" bpmnElement="SequenceFlow_1ud7tfa">
+        <di:waypoint xsi:type="dc:Point" x="718" y="266" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="266" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="245" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0v7xsvz_di" bpmnElement="Task_021v9mx">
+        <dc:Bounds x="618" y="226" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0i2nsbv_di" bpmnElement="SequenceFlow_0i2nsbv">
+        <di:waypoint xsi:type="dc:Point" x="718" y="153" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="153" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="132" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0gbvsax_di" bpmnElement="Task_19gs1rs">
+        <dc:Bounds x="618" y="113" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_044gv9a_di" bpmnElement="SequenceFlow_044gv9a">
+        <di:waypoint xsi:type="dc:Point" x="718" y="54" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="54" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="33" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0l3db86_di" bpmnElement="Task_0fphnb8">
+        <dc:Bounds x="618" y="14" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sv1p07_di" bpmnElement="SequenceFlow_1sv1p07">
+        <di:waypoint xsi:type="dc:Point" x="718" y="-41" />
+        <di:waypoint xsi:type="dc:Point" x="783" y="-41" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="750.5" y="-62" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ScriptTask_0bbrkgg_di" bpmnElement="Task_0b30iaa">
+        <dc:Bounds x="618" y="-81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Escalation boundary events attached to CallActivity tasks will be activated if subworkflow embedded in CallActivity reaches any escalation end event node.

Boundary events with and without escalation code filter are supported in both interrupting and non-interrupting variants.