### PR TITLE
Add support for date instead of only datetime

### DIFF
--- a/SpiffWorkflow/bpmn/specs/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/event_definitions.py
@@ -103,9 +103,12 @@ class TimerEventDefinition(CatchingEventDefinition):
         dt = my_task.workflow.script_engine.evaluate(my_task, self.dateTime)
         if dt is None:
             return False
-        if dt.tzinfo:
-            tz = dt.tzinfo
-            now = tz.fromutc(datetime.datetime.utcnow().replace(tzinfo=tz))
+        if isinstance(dt, datetime.datetime):
+            if dt.tzinfo:
+                tz = dt.tzinfo
+                now = tz.fromutc(datetime.datetime.utcnow().replace(tzinfo=tz))
+            else:
+                now = datetime.datetime.now()
         else:
-            now = datetime.datetime.now()
+            now = datetime.date.today()
         return now > dt


### PR DESCRIPTION
The event definitions assumed that timer objects would always have a time component, but when that was not the case it raised an exception:

`AttributeError: 'datetime.date' object has no attribute 'tzinfo' `

Note that as per page 304 of BPMN 2.0 specification, dates without times are valid on ISO-8601 and therefore acceptable.