### PR TITLE
Fix circular call / reference to president in nuclear.json

### DIFF
--- a/doc/custom-tasks/nuclear.json
+++ b/doc/custom-tasks/nuclear.json
@@ -67,7 +67,7 @@
                             ]
                         ]
                     ],
-                    "president"
+                    "nuclear_strike"
                 ]
             ]
         },


### PR DESCRIPTION
The cond_task_specs would continue call president even if `confirmation` attribute was set to `"yes"`.