### PR TITLE
Fix of return type hint in workflow.py

### DIFF
--- a/SpiffWorkflow/workflow.py
+++ b/SpiffWorkflow/workflow.py
@@ -176,8 +176,8 @@ class Workflow(object):
 
         :type name: str
         :param name: The name of a task spec.
-        :rtype: Task
-        :return: The task that relates to the spec with the given name.
+        :rtype: list[Task]
+        :returns: A list of tasks that relate to the spec with the given name.
         """
         return [task for task in self.get_tasks()
                 if task.task_spec.name == name]


### PR DESCRIPTION
Hi,
just a small fix of the return type hint for get_tasks_from_spec_name in workflow.py

Best,
Robert