### PR TITLE
Pmi - Remove some redundant code and make a method for updating task.data

### DIFF
--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -115,60 +115,8 @@ class TaskParser(object):
             self.task.documentation = self.parser._parse_documentation(
                 self.node, xpath=self.xpath, task_parser=self)
             
-            # get special task decorators from XML
-            multiinstanceElement = self.process_xpath('.//*[@id="%s"]/bpmn:multiInstanceLoopCharacteristics' % self.get_id())
-            standardLoopElement = self.process_xpath('.//*[@id="%s"]/bpmn:standardLoopCharacteristics' % self.get_id())
+            self._detect_multiinstance()
 
-            # initialize variables 
-            isMultiInstance = len(multiinstanceElement) > 0
-            isLoop = len(standardLoopElement) > 0 
-            multiinstance = False
-            isSequential = False
-            loopCountVar = None
-            completecondition = None
-            collectionText = None
-            elementVarText = None
-
-            # Fix up MultiInstance mixin to take care of both
-            # MultiInstance and standard Looping task
-            if isMultiInstance or isLoop:
-                multiinstance = True
-                if isMultiInstance:
-                    sequentialText = multiinstanceElement[0].get('isSequential')
-                    collectionText = multiinstanceElement[0].attrib.get('{' + CAMUNDA_MODEL_NS + '}collection')
-                    elementVarText = multiinstanceElement[0].attrib.get('{' + CAMUNDA_MODEL_NS + '}elementVariable')
-        
-                    if sequentialText == 'true':
-                        isSequential = True
-                    loopCardinality = self.process_xpath('.//*[@id="%s"]/bpmn:multiInstanceLoopCharacteristics/bpmn:loopCardinality' % self.get_id())
-                    if len(loopCardinality) > 0:
-                        loopcount = loopCardinality[0].text
-                    else:
-                        loopcount =1
-                    completionCondition = self.process_xpath('.//*[@id="%s"]/bpmn:multiInstanceLoopCharacteristics/bpmn:completionCondition' % self.get_id())
-                    if len(completionCondition) > 0:
-                        completecondition = completionCondition[0].text
-
-                else: # must be loop
-                    isSequential = True                    
-                    loopcount = STANDARDLOOPCOUNT # here we default to a sane numer of loops
-                    self.task.loopTask = True
-                LOG.debug("Task Name: %s - class %s"%(self.get_id(),self.task.__class__))
-                LOG.debug("   Task is MultiInstance: %s"%multiinstance)
-                LOG.debug("   MultiInstance is Sequential: %s"%isSequential)
-                LOG.debug("   Task has loopcount of: %s"%loopcount)
-                LOG.debug("   Class has name of : %s"%self.task.__class__.__name__)
-            # currently a safeguard that this isn't applied in any condition
-            # that we do not expect. This list can be exapanded at a later date
-            # To handle other use cases - don't forget the overridden test classes!
-            if multiinstance and isinstance(self.task, UserTask):
-                self.task.times = Attrib(loopcount)
-                self.task.collection = collectionText
-                self.task.elementVar = elementVarText
-                self.task.completioncondition = completecondition # we need to define what this is
-                self.task.isSequential = isSequential
-                # add some kind of limits here in terms of what kinds of classes we will allow to be multiinstance
-                self.task.__class__ = type(self.get_id() + '_class',(self.task.__class__,MultiInstanceTask),{})
             boundary_event_nodes = self.process_xpath(
                 './/bpmn:boundaryEvent[@attachedToRef="%s"]' % self.get_id())
             if boundary_event_nodes:

--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -63,38 +63,55 @@ class TaskParser(object):
         self.xpath = xpath_eval(node)
 
     def _detect_multiinstance(self):
+
+        # get special task decorators from XML
         multiinstanceElement = self.process_xpath('.//*[@id="%s"]/bpmn:multiInstanceLoopCharacteristics' % self.get_id())
+        standardLoopElement = self.process_xpath('.//*[@id="%s"]/bpmn:standardLoopCharacteristics' % self.get_id())
+
+
+        # initialize variables 
+        isMultiInstance = len(multiinstanceElement) > 0
+        isLoop = len(standardLoopElement) > 0 
         multiinstance = False
         isSequential = False
         loopCountVar = None
-        if len(multiinstanceElement) > 0:
+        completecondition = None
+        collectionText = None
+        elementVarText = None
+        
+        # Fix up MultiInstance mixin to take care of both
+        # MultiInstance and standard Looping task
+        if isMultiInstance or isLoop:
             multiinstance = True
-            sequentialText = multiinstanceElement[0].get('isSequential')
-            collectionText = multiinstanceElement[0].attrib.get('{' + CAMUNDA_MODEL_NS + '}collection')
-            elementVarText = multiinstanceElement[0].attrib.get('{' + CAMUNDA_MODEL_NS + '}elementVariable')
-            if sequentialText == 'true':
-                isSequential = True
-            loopCardinality = self.process_xpath('.//*[@id="%s"]/bpmn:multiInstanceLoopCharacteristics/bpmn:loopCardinality' % self.get_id())
-            if len(loopCardinality) > 0:
-                loopcount = loopCardinality[0].text
-            else:
-                loopcount =1
-            completionCondition = self.process_xpath('.//*[@id="%s"]/bpmn:multiInstanceLoopCharacteristics/bpmn:completionCondition' % self.get_id())
-            if len(completionCondition) > 0:
-                completecondition = completionCondition[0].text
-            else:
-                completecondition = None      # we still need to implement this section
+            if isMultiInstance:
+                sequentialText = multiinstanceElement[0].get('isSequential')
+                collectionText = multiinstanceElement[0].attrib.get('{' + CAMUNDA_MODEL_NS + '}collection')
+                elementVarText = multiinstanceElement[0].attrib.get('{' + CAMUNDA_MODEL_NS + '}elementVariable')
+                
+                if sequentialText == 'true':
+                    isSequential = True
+                loopCardinality = self.process_xpath('.//*[@id="%s"]/bpmn:multiInstanceLoopCharacteristics/bpmn:loopCardinality' % self.get_id())
+                if len(loopCardinality) > 0:
+                    loopcount = loopCardinality[0].text
+                else:
+                    loopcount =1
+                completionCondition = self.process_xpath('.//*[@id="%s"]/bpmn:multiInstanceLoopCharacteristics/bpmn:completionCondition' % self.get_id())
+                if len(completionCondition) > 0:
+                    completecondition = completionCondition[0].text
 
+            else: # must be loop
+                isSequential = True                    
+                loopcount = STANDARDLOOPCOUNT # here we default to a sane numer of loops
+                self.task.loopTask = True
             LOG.debug("Task Name: %s - class %s"%(self.get_id(),self.task.__class__))
             LOG.debug("   Task is MultiInstance: %s"%multiinstance)
             LOG.debug("   MultiInstance is Sequential: %s"%isSequential)
             LOG.debug("   Task has loopcount of: %s"%loopcount)
             LOG.debug("   Class has name of : %s"%self.task.__class__.__name__)
-
-        # currently a safeguard that this isn't applied in any condition
-        # that we do not expect. This list can be exapanded at a later date
-        # To handle other use cases - don't forget the overridden test classes!
-        if multiinstance and (self.task.__class__.__name__ in ['TestUserTask','UserTask']):
+            # currently a safeguard that this isn't applied in any condition
+            # that we do not expect. This list can be exapanded at a later date
+            # To handle other use cases - don't forget the overridden test classes!
+        if multiinstance and isinstance(self.task, UserTask):
             self.task.times = Attrib(loopcount)
             self.task.collection = collectionText
             self.task.elementVar = elementVarText
@@ -102,6 +119,13 @@ class TaskParser(object):
             self.task.isSequential = isSequential
             # add some kind of limits here in terms of what kinds of classes we will allow to be multiinstance
             self.task.__class__ = type(self.get_id() + '_class',(self.task.__class__,MultiInstanceTask),{})
+  
+
+
+
+
+
+        
 
 
     def parse_node(self):

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -202,9 +202,16 @@ class Task(object):
             self.task_spec.name,
             self.get_state_name(),
             hex(id(self)))
-    
-    def update_mi_collect_data(self,data):
-        self.mi_collect_data.update(data)
+
+    def update_data(self,data):
+        """ If the task.data needs to be updated from a UserTask form or 
+            a Script task then use this function rather than updating task.data
+            directly, otherwise MultiInstance tasks will not collect the 
+            data properly 
+        """
+        self.data.update(data)
+        self.mi_collect_data.update(data) # special variable that gets collected
+                                          # in a bpmn/MultiInstance task
 
     def terminate_loop(self):
         """Used in the case that we are working with a BPMN 'loop' task.

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -193,6 +193,7 @@ class Task(object):
         self.data = {}
         self.terminate_current_loop = False
         self.internal_data = {}
+        self.mi_collect_data = {}
         if parent is not None:
             self.parent._child_added_notify(self)
 
@@ -201,6 +202,9 @@ class Task(object):
             self.task_spec.name,
             self.get_state_name(),
             hex(id(self)))
+    
+    def update_mi_collect_data(self,data):
+        self.mi_collect_data.update(data)
 
     def terminate_loop(self):
         """Used in the case that we are working with a BPMN 'loop' task.

--- a/doc/bpmn.rst
+++ b/doc/bpmn.rst
@@ -20,8 +20,9 @@ A reasonable subset of the BPMN notation is supported, including the following e
   6. Exclusive Gateway
   7. Inclusive Gateway (converging only)
   8. Parallel Gateway
-  9. Intermediate Catch Events (Timer and Message)
-  10. Boundary Events (Timer and Message, interrupting and non-interrupting)
+  9. MultiInstance & Variants
+  10. Intermediate Catch Events (Timer and Message)
+  11. Boundary Events (Timer and Message, interrupting and non-interrupting)
 
 .. figure:: figures/action-management.png
    :alt: Example BPMN Workflow
@@ -30,3 +31,92 @@ A reasonable subset of the BPMN notation is supported, including the following e
 
 Please refer to http://www.bpmn.org/ for details on BPMN and to the API documentation for instructions on the
 use of the BPMN implementation.
+
+MultiInstance Notes
+-------------------
+
+A subset of MultiInstance and Looping Tasks are supported. Notably,
+the completion condition is not currently supported. 
+
+The following definitions should prove helpful
+
+**loopCardinality** - This variable can be a text representation of a
+number - for example '2' or it can be the name of a variable in
+task.data that resolves to a text representatoin of a number.
+It can also be a collection such as a list or a dictionary. In the
+case that it is a list, the loop cardinality is equal to the length of
+the list and in the case of a dictionary, it is equal to the list of
+the keys of the dictionary.
+
+**Collection** This is the name of the collection that is created from
+the data generated when the task is run. Examples of this would be
+form data that is generated from a UserTask or data that is generated
+from a script that is run. Currently the collection is built up to be
+a dictionary with a numeric key that corresponds to the place in the
+loopCardinality. For example, if we set the loopCardinality to be a
+list such as ['a','b','c] the resulting collection would be {1:'result
+from a',2:'result from b',3:'result from c'} - and this would be true
+even if it is a parallel MultiInstance where it was filled out in a
+different order. 
+
+**Element Variable** This is the variable name for the current
+iteration of the MultiInstance. In the case of the loopCardinality
+being just a number, this would be 1,2,3, . . .  If the
+loopCardinality variable is mapped to a collection it would be either
+the list value from that position, or it would be the value from the
+dictionary where the keys are in sorted order.
+
+Example:
+  In a sequential MultiInstance, loop cardinality is ['a','b','c'] and elementVariable is 'myvar'
+  then in the case of a sequential multiinstance the first call would
+  have 'myvar':'a' in the first run of the task and 'myvar':'b' in the
+  second. 
+
+Example:
+  In a Parallel MultiInstance, Loop cardinality is a variable that contains
+  {'a':'A','b':'B','c':'C'} and elementVariable is 'myvar' - when the multiinstance is ready, there
+  will be 3 tasks. If we chooose the second task, the task.data will
+  contain 'myvar':'B'
+
+Updating Data
+------------
+
+While there may be some MultiInstances that will not result in any
+data, most of the time there will be some kind of data generated that
+will be collected from the MultiInstance. A good example of this is a
+UserTask that has an associated form or a script that will do a lookup
+on a variable.
+
+Each time the MultiInstance task generates data, the method
+task.update_data(data) should be called where data is the data
+generated. The 'data' variable that is passed in is assumed to be a
+dictionary. Calling task.update_data(...) will ensure that the
+MultiInstance gets the correct data to include in the collection. The
+task.data is also updated with the dictionary passed to this method.
+
+Looping Tasks
+-------------
+
+A looping task sets the cardinality to 25 which is assumed to be a
+sane maximum value. The looping task will add to the collection each
+time it is processed assuming data is updated as outlined in the
+previous paragraph.
+
+To halt the looping the task.terminate_loop()
+
+Each time task.complete() is called (or
+workflow.complete_task_by_id(task.id) ), the task will again present
+as READY until either the cardinality is exausted, or
+task.terminate_loop() is called.
+
+**Caveats**
+-----------
+
+At the current time a sequential MultiInstance behaves more like a
+Looping Task than a MultiInstance - A true MultiInstace would actually
+create multiple copies of the task in the task tree - currently only
+one task is created and it is repeated the number of the
+loopCardinality 
+
+
+

--- a/tests/SpiffWorkflow/camunda/MultiInstanceArrayTest.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceArrayTest.py
@@ -43,7 +43,7 @@ class MultiInstanceArrayTest(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEquals("FamilyMemberTask", task.task_spec.name)
             task.data.update({"FirstName": "The Funk"})
-            task.internal_data.update({"FirstName": "The Funk"})
+            task.update_mi_collect_data({"FirstName": "The Funk"})
             self.workflow.complete_task_from_id(task.id)
             if save_restore: self.save_restore()
 
@@ -52,7 +52,7 @@ class MultiInstanceArrayTest(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEquals("FamilyMemberBday", task.task_spec.name)
             task.data.update({"Birthdate": "10/05/1985"})
-            task.internal_data.update({"Birthdate": "10/05/1985"})
+            task.update_mi_collect_data({"Birthdate": "10/05/1985"})
             self.workflow.complete_task_from_id(task.id)
             if save_restore: self.save_restore()
 

--- a/tests/SpiffWorkflow/camunda/MultiInstanceArrayTest.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceArrayTest.py
@@ -34,7 +34,7 @@ class MultiInstanceArrayTest(BaseTestCase):
         # Set initial array size to 3 in the first user form.
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEquals("Activity_FamSize", task.task_spec.name)
-        task.data.update({"FamilySize": 3})
+        task.update_data({"FamilySize": 3})
         self.workflow.complete_task_from_id(task.id)
         if save_restore: self.save_restore()
 
@@ -42,8 +42,7 @@ class MultiInstanceArrayTest(BaseTestCase):
         for i in range(3):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEquals("FamilyMemberTask", task.task_spec.name)
-            task.data.update({"FirstName": "The Funk"})
-            task.update_mi_collect_data({"FirstName": "The Funk"})
+            task.update_data({"FirstName": "The Funk"})
             self.workflow.complete_task_from_id(task.id)
             if save_restore: self.save_restore()
 
@@ -51,8 +50,7 @@ class MultiInstanceArrayTest(BaseTestCase):
         for i in range(3):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEquals("FamilyMemberBday", task.task_spec.name)
-            task.data.update({"Birthdate": "10/05/1985"})
-            task.update_mi_collect_data({"Birthdate": "10/05/1985"})
+            task.update_data({"Birthdate": "10/05/1985"})
             self.workflow.complete_task_from_id(task.id)
             if save_restore: self.save_restore()
 

--- a/tests/SpiffWorkflow/camunda/MultiInstanceParallelArrayTest.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceParallelArrayTest.py
@@ -38,7 +38,7 @@ class MultiInstanceParallelArrayTest(BaseTestCase):
         # Set initial array size to 3 in the first user form.
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEquals("Activity_FamSize", task.task_spec.name)
-        task.data.update({"FamilySize": 3})
+        task.update_data({"FamilySize": 3})
         self.workflow.complete_task_from_id(task.id)
         if save_restore: self.save_restore()
         self.workflow.do_engine_steps()
@@ -50,8 +50,7 @@ class MultiInstanceParallelArrayTest(BaseTestCase):
             self.assertEquals(len(tasks),1) # still with sequential MI
             task = tasks[0]
             self.assertEquals("FamilyMemberTask", task.task_spec.name)
-            task.data.update({"FirstName": "The Funk"+str(i)})
-            task.update_mi_collect_data({"FirstName": "The Funk"+str(i)})
+            task.update_data({"FirstName": "The Funk"+str(i)})
             self.workflow.complete_task_from_id(task.id)
             if save_restore:
                 self.save_restore()
@@ -64,8 +63,7 @@ class MultiInstanceParallelArrayTest(BaseTestCase):
             task = random.choice(tasks)
             x = task.internal_data['runtimes'] -1
             self.assertEquals("FamilyMemberBday", task.task_spec.name)
-            task.data.update({"Birthdate": "10/05/1985"+str(x)})
-            task.update_mi_collect_data({"Birthdate": "10/05/1985"+str(x)})
+            task.update_data({"Birthdate": "10/05/1985"+str(x)})
             self.workflow.complete_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore:

--- a/tests/SpiffWorkflow/camunda/MultiInstanceParallelArrayTest.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceParallelArrayTest.py
@@ -51,7 +51,7 @@ class MultiInstanceParallelArrayTest(BaseTestCase):
             task = tasks[0]
             self.assertEquals("FamilyMemberTask", task.task_spec.name)
             task.data.update({"FirstName": "The Funk"+str(i)})
-            task.internal_data.update({"FirstName": "The Funk"+str(i)})
+            task.update_mi_collect_data({"FirstName": "The Funk"+str(i)})
             self.workflow.complete_task_from_id(task.id)
             if save_restore:
                 self.save_restore()
@@ -65,7 +65,7 @@ class MultiInstanceParallelArrayTest(BaseTestCase):
             x = task.internal_data['runtimes'] -1
             self.assertEquals("FamilyMemberBday", task.task_spec.name)
             task.data.update({"Birthdate": "10/05/1985"+str(x)})
-            task.internal_data.update({"Birthdate": "10/05/1985"+str(x)})
+            task.update_mi_collect_data({"Birthdate": "10/05/1985"+str(x)})
             self.workflow.complete_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore:


### PR DESCRIPTION
All MultiInstance task data is now in task.mi_collect_data  

* a new task method update_data has been included that takes care of updating this variable as well as task.data - if the task is not a MI, this variable is ignored but still allows the MI task to collect the data properly

* because we are no longer using internal_data, I do not need to filter the results of that - removed that method

* I previously added a check to see if we already had a gateway set up as an output, this serves the same function as setting the 'augmented' flag on internal data, so I removed that. 