### PR TITLE
Mi dot notation

### DIFF
--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -25,7 +25,7 @@ from .ValidationException import ValidationException
 from ..specs.UserTask import UserTask
 from ..specs.BoundaryEvent import _BoundaryEventParent
 from ..specs.MultiInstanceTask import MultiInstanceTask
-from ...operators import Attrib
+from ...operators import Attrib,PathAttrib
 from .util import xpath_eval, one
 
 LOG = logging.getLogger(__name__)
@@ -112,7 +112,12 @@ class TaskParser(object):
             # that we do not expect. This list can be exapanded at a later date
             # To handle other use cases - don't forget the overridden test classes!
         if multiinstance and isinstance(self.task, UserTask):
-            self.task.times = Attrib(loopcount)
+            loopcount = loopcount.replace('.','/') # make dot notation compatible
+                                                   # with bmpmn path notation. 
+            if loopcount.find('/') >=0:
+                self.task.times = PathAttrib(loopcount)
+            else:
+                self.task.times = Attrib(loopcount)
             self.task.collection = collectionText
             self.task.elementVar = elementVarText
             self.task.completioncondition = completecondition # we need to define what this is

--- a/SpiffWorkflow/dmn/engine/DMNEngine.py
+++ b/SpiffWorkflow/dmn/engine/DMNEngine.py
@@ -1,18 +1,11 @@
 import logging
 from argparse import Namespace
 from collections import namedtuple
-
+from ...operators import DotDict
 from decimal import Decimal
 import datetime
 
 
-class DotDict(dict):
-    """dot.notation access to dictionary attributes"""
-    def __getattr__(*args):
-        val = dict.get(*args)
-        return DotDict(val) if type(val) is dict else val
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
 
 class DMNEngine:
     """

--- a/SpiffWorkflow/operators.py
+++ b/SpiffWorkflow/operators.py
@@ -84,6 +84,7 @@ class PathAttrib(Term):
 
     def __init__(self, path):
         self.path = path
+        self.name = path
 
     def serialize(self, serializer):
         """

--- a/SpiffWorkflow/operators.py
+++ b/SpiffWorkflow/operators.py
@@ -31,6 +31,15 @@ class Term(object):
     """
     pass
 
+class DotDict(dict):
+    """dot.notation access to dictionary attributes"""
+    def __getattr__(*args):
+        val = dict.get(*args)
+        return DotDict(val) if type(val) is dict else val
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+
 
 class Attrib(Term):
 


### PR DESCRIPTION
This allows us to both use dot notation and path notation in the loopCardinality of MI tasks and LoopTasks 