### PR TITLE
Expand SerialMultiInstance into separate processes & fix for exclusive gateway w/default into ParallelMultiInstance

### DIFF
--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -122,7 +122,6 @@ class TaskParser(object):
             # date To handle other use cases - don't forget the overridden
             # test classes!
         if multiinstance and isinstance(self.task, UserTask):
-
             loopcount = loopcount.replace('.',
                                           '/')  # make dot notation compatible
             # with bmpmn path notation.

--- a/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
+++ b/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
@@ -318,17 +318,10 @@ class MultiInstanceTask(TaskSpec):
             # this is different from PMI because the children all link together, not to
             # the gateways on both ends.
             # first let's check for a task in the task spec tree
-            if self.name[-2:] == "_0":
-                print('caught you!')
             expanded = getattr(self, 'expanded', 1)
             if split_n >= expanded:
                 setattr(self, 'expanded', split_n)
-            if (expanded == split_n) and \
-                runtimes > 1 and \
-                '_' in my_task.task_spec.id and \
-                (int(my_task.task_spec.id[-1])) != (runtimes -2):
-                print(my_task.internal_data)
-                print(my_task.task_spec.id)
+
 
             if not (expanded == split_n):
 
@@ -386,8 +379,6 @@ class MultiInstanceTask(TaskSpec):
                         # have the task spec in the right place.
 
                         new_task_spec = copy.copy(proto_task_spec)
-                        if x == 0:
-                            print ('try to catch issue')
                         new_task_spec.name = new_task_spec.name + "_%d" % x
                         new_task_spec.id = str(new_task_spec.id) + "_%d" % x
                         my_task.workflow.spec.task_specs[new_task_spec.name] = new_task_spec # add to registry

--- a/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
+++ b/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
@@ -171,7 +171,7 @@ class MultiInstanceTask(TaskSpec):
             we don't do it again.
         """
 
-        if my_task.parent.task_spec.name[:7] == 'Gateway':
+        if my_task.parent.task_spec.name[:11] == 'Gateway_for':
             LOG.debug("MI Recovering from save/restore")
             return
         LOG.debug("MI being augmented")
@@ -189,6 +189,11 @@ class MultiInstanceTask(TaskSpec):
 
         # Set up the parent task and insert it into the workflow
         my_task.parent.task_spec.outputs = []
+        # in the case that our parent is a gateway with a default route,
+        # we need to ensure that the default route is empty
+        # so that connect can set it up properly
+        my_task.parent.task_spec.default_task_spec = None
+
         my_task.parent.task_spec.connect(start_gw_spec)
         my_task.parent.children = [start_gw]
         start_gw.parent = my_task.parent

--- a/SpiffWorkflow/serializer/dict.py
+++ b/SpiffWorkflow/serializer/dict.py
@@ -582,6 +582,8 @@ class DictionarySerializer(Serializer):
     def deserialize_task(self, workflow, s_state):
         assert isinstance(workflow, Workflow)
         task_spec = workflow.get_task_spec_from_name(s_state['task_spec'])
+        print('sstate = ' ,s_state['task_spec'])
+        print('internal = ' ,s_state['internal_data'])
         if s_state['internal_data'].get('runtimes', None) is not None \
         and s_state['internal_data']['runtimes'] > 1 and \
         len(task_spec.inputs) > 1 and \

--- a/SpiffWorkflow/serializer/dict.py
+++ b/SpiffWorkflow/serializer/dict.py
@@ -594,7 +594,6 @@ class DictionarySerializer(Serializer):
             # in order to patch things up correctly, we need to append in the correct order
             # I'm really hoping that things get added to save list in saved order
             # otherwise I'll have some problems.
-            print("Copying",newtaskname)
             task_spec = workflow.get_task_spec_from_name(newtaskname)
             new_task_spec = copy.copy(task_spec)
             new_task_spec.name = oldtaskname
@@ -609,8 +608,6 @@ class DictionarySerializer(Serializer):
             for item in inter_out:
                 item.inputs = [new_task_spec]
             task_spec = new_task_spec
-        print('sstate = ' ,s_state['task_spec'])
-        print('internal = ' ,s_state['internal_data'])
         if s_state['internal_data'].get('runtimes', None) is not None \
         and s_state['internal_data']['runtimes'] > 1 and \
         len(task_spec.inputs) > 1 and \

--- a/SpiffWorkflow/serializer/dict.py
+++ b/SpiffWorkflow/serializer/dict.py
@@ -581,7 +581,34 @@ class DictionarySerializer(Serializer):
 
     def deserialize_task(self, workflow, s_state):
         assert isinstance(workflow, Workflow)
-        task_spec = workflow.get_task_spec_from_name(s_state['task_spec'])
+        splits = s_state['task_spec'].split('_')
+        oldtaskname = s_state['task_spec']
+        task_spec = workflow.get_task_spec_from_name(oldtaskname)
+        if task_spec is None and \
+            splits[-1].isdigit():
+            num = int(splits[-1])
+            if num == 0:
+                newtaskname = '_'.join(splits[:-1])
+            else:
+                newtaskname = '_'.join(splits[:-1]) + "_%d"%(num-1)
+            # in order to patch things up correctly, we need to append in the correct order
+            # I'm really hoping that things get added to save list in saved order
+            # otherwise I'll have some problems.
+            print("Copying",newtaskname)
+            task_spec = workflow.get_task_spec_from_name(newtaskname)
+            new_task_spec = copy.copy(task_spec)
+            new_task_spec.name = oldtaskname
+            if isinstance(new_task_spec.id,int):
+                new_task_spec.id = "%d_%d"%(new_task_spec.id,num)
+            else:
+                new_task_spec.id = '_'.join(new_task_spec.id.split('_')[:-1])+"_%d"%num
+            workflow.spec.task_specs[oldtaskname] = new_task_spec
+            inter_out = task_spec.outputs
+            task_spec.outputs=[new_task_spec]
+            new_task_spec.outputs = inter_out
+            for item in inter_out:
+                item.inputs = [new_task_spec]
+            task_spec = new_task_spec
         print('sstate = ' ,s_state['task_spec'])
         print('internal = ' ,s_state['internal_data'])
         if s_state['internal_data'].get('runtimes', None) is not None \
@@ -594,6 +621,11 @@ class DictionarySerializer(Serializer):
             task_spec.inputs[1].outputs.append(task_spec)
             task_spec.outputs[0].inputs.append(task_spec)
         task = Task(workflow, task_spec)
+
+        if getattr(task_spec,'isSequential',False) and \
+            s_state['internal_data'].get('splits') is not None:
+            task.task_spec.expanded = s_state['internal_data']['splits']
+
 
         # id
         task.id = s_state['id']
@@ -618,7 +650,6 @@ class DictionarySerializer(Serializer):
 
         # internal_data
         task.internal_data = s_state['internal_data']
-
         return task
 
     def _deserialize_task_children(self, task, s_state):

--- a/SpiffWorkflow/specs/WorkflowSpec.py
+++ b/SpiffWorkflow/specs/WorkflowSpec.py
@@ -62,7 +62,7 @@ class WorkflowSpec(object):
         :rtype:  TaskSpec
         :returns: The task spec with the given name.
         """
-        return self.task_specs[name]
+        return self.task_specs.get(name)
 
     def validate(self):
         """Checks integrity of workflow and reports any problems with it.

--- a/tests/SpiffWorkflow/camunda/DefaultGatewayPMITest.py
+++ b/tests/SpiffWorkflow/camunda/DefaultGatewayPMITest.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import, division
+
+from __future__ import division, absolute_import
+import sys
+import os
+import unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+from SpiffWorkflow.exceptions import WorkflowException
+__author__ = 'matth'
+
+from tests.SpiffWorkflow.camunda.BaseTestCase import BaseTestCase
+
+
+class DefaultGatewayPMITest(BaseTestCase):
+    """The example bpmn diagram tests both a set cardinality from user input
+    as well as looping over an existing array."""
+
+    def setUp(self):
+        self.spec = self.load_workflow_spec(
+            'data/default_gateway_pmi.bpmn',
+            'DefaultGateway')
+
+    def testRunThroughHappy(self):
+        self.actual_test(False)
+
+    def testRunThroughSaveRestore(self):
+        self.actual_test(True)
+
+
+
+
+    def actual_test(self, save_restore=False):
+
+        self.workflow = BpmnWorkflow(self.spec)
+        self.workflow.do_engine_steps()
+
+        # Set initial array size to 3 in the first user form.
+        task = self.workflow.get_ready_user_tasks()[0]
+        self.assertEqual("DoStuff", task.task_spec.name)
+        task.update_data({"morestuff": 'Yep'})
+        self.workflow.complete_task_from_id(task.id)
+        self.workflow.do_engine_steps()
+        if save_restore: self.save_restore()
+
+        # Set the names of the 3 family members.
+        for i in range(3):
+            task = self.workflow.get_ready_user_tasks()[0]
+            self.assertEqual("GetMoreStuff", task.task_spec.name)
+
+
+            task.update_data({"stuff.addstuff": "Stuff %d"%i})
+            self.workflow.complete_task_from_id(task.id)
+            if save_restore: self.save_restore()
+            self.workflow.do_engine_steps()
+
+        if save_restore: self.save_restore()
+        self.assertTrue(self.workflow.is_completed())
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(DefaultGatewayPMITest)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/camunda/ExclusiveGatewayPMITest.py
+++ b/tests/SpiffWorkflow/camunda/ExclusiveGatewayPMITest.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import, division
+
+from __future__ import division, absolute_import
+import sys
+import os
+import unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+from SpiffWorkflow.exceptions import WorkflowException
+__author__ = 'matth'
+
+from tests.SpiffWorkflow.camunda.BaseTestCase import BaseTestCase
+
+
+class ExclusiveGatewayPMITest(BaseTestCase):
+    """The example bpmn diagram tests both a set cardinality from user input
+    as well as looping over an existing array."""
+
+    def setUp(self):
+        self.spec = self.load_workflow_spec(
+            'data/default_gateway_pmi.bpmn',
+            'DefaultGateway')
+
+    def testRunThroughHappy(self):
+        self.actual_test(False)
+
+    def testRunThroughSaveRestore(self):
+        self.actual_test(True)
+
+    def testRunThroughHappyNo(self):
+        self.actual_test(False,'No')
+
+    def testRunThroughSaveRestoreNo(self):
+        self.actual_test(True,'No')
+
+
+
+    def actual_test(self, save_restore=False,response='Yes'):
+
+        self.workflow = BpmnWorkflow(self.spec)
+        self.workflow.do_engine_steps()
+
+        # Set initial array size to 3 in the first user form.
+        task = self.workflow.get_ready_user_tasks()[0]
+        self.assertEqual("DoStuff", task.task_spec.name)
+        task.update_data({"morestuff": response})
+        self.workflow.complete_task_from_id(task.id)
+        self.workflow.do_engine_steps()
+        if save_restore: self.save_restore()
+
+        # Set the names of the 3 family members.
+        if response == 'Yes':
+            for i in range(3):
+                task = self.workflow.get_ready_user_tasks()[0]
+                self.assertEqual("GetMoreStuff", task.task_spec.name)
+
+
+                task.update_data({"stuff.addstuff": "Stuff %d"%i})
+                self.workflow.complete_task_from_id(task.id)
+                if save_restore: self.save_restore()
+                self.workflow.do_engine_steps()
+
+        if save_restore: self.save_restore()
+        self.assertTrue(self.workflow.is_completed())
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(ExclusiveGatewayPMITest)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/camunda/MultiInstanceArrayTest.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceArrayTest.py
@@ -73,22 +73,40 @@ class MultiInstanceArrayTest(BaseTestCase):
                                         'is_parallel_mi': False,
                                         'mi_count': 3,
                                         'mi_index': i+1})
-            self.assertEqual("FamilyMemberTask", task.task_spec.name)
+
+            if i > 0:
+                self.assertEqual("FamilyMemberTask"+"_%d"%(i-1), task.task_spec.name)
+            else:
+                self.assertEqual("FamilyMemberTask", task.task_spec.name)
+
+
             task.update_data({"FamilyMember": {"FirstName": "The Funk #%i" % i}})
             self.workflow.complete_task_from_id(task.id)
             if save_restore: self.save_restore()
+            self.workflow.do_engine_steps()
 
         self.assertEqual({1: {'FirstName': 'The Funk #0'},
                           2: {'FirstName': 'The Funk #1'},
                           3: {'FirstName': 'The Funk #2'}},
                          task.data["Family"]["Members"])
+        #### NB - start here
+        ###  Data is not correctly getting to the next task upon complete of the last task
+        ###  after do_engine_steps, the next task in the list should be the same as task.data
+        ###  but it is not.
+
+        ### invalid copy of data?? ## appears that parent is not hooked up correctly
+
         # Set the birthdays of the 3 family members.
         for i in range(3):
             task = self.workflow.get_ready_user_tasks()[0]
-            self.assertEqual("FamilyMemberBday", task.task_spec.name)
+            if i > 0:
+                self.assertEqual("FamilyMemberBday"+"_%d"%(i-1), task.task_spec.name)
+            else:
+                self.assertEqual("FamilyMemberBday", task.task_spec.name)
             task.update_data({"CurrentFamilyMember": {"Birthdate": "10/0%i/1985" % i}})
             self.workflow.complete_task_from_id(task.id)
             if save_restore: self.save_restore()
+            self.workflow.do_engine_steps()
 
         self.workflow.do_engine_steps()
         if save_restore: self.save_restore()
@@ -117,7 +135,10 @@ class MultiInstanceArrayTest(BaseTestCase):
         # Set the names of the 3 family members.
         for i in range(3):
             task = self.workflow.get_ready_user_tasks()[0]
-            self.assertEqual("FamilyMemberTask", task.task_spec.name)
+            if i > 0:
+                self.assertEqual("FamilyMemberTask"+"_%d"%(i-1), task.task_spec.name)
+            else:
+                self.assertEqual("FamilyMemberTask", task.task_spec.name)
             task.update_data({"FamilyMember": {"FirstName": "The Funk #%i" % i}})
             self.workflow.complete_task_from_id(task.id)
             if save_restore: self.save_restore()
@@ -155,7 +176,10 @@ class MultiInstanceArrayTest(BaseTestCase):
         # Set the names of the 3 family members.
         for i in range(3):
             task = self.workflow.get_ready_user_tasks()[0]
-            self.assertEqual("FamilyMemberTask", task.task_spec.name)
+            if i > 0:
+                self.assertEqual("FamilyMemberTask"+"_%d"%(i-1), task.task_spec.name)
+            else:
+                self.assertEqual("FamilyMemberTask", task.task_spec.name)
             task.update_data({"FamilyMember": {"FirstName": "The Funk #%i" % i}})
             self.workflow.complete_task_from_id(task.id)
             if save_restore: self.save_restore()
@@ -176,8 +200,10 @@ class MultiInstanceArrayTest(BaseTestCase):
                     "a": {'FirstName': 'The Funk #0'},
                     "b": {'FirstName': 'The Funk #1'},
                     "c": {'FirstName': 'The Funk #2'}}
-
-            self.assertEqual("FamilyMemberBday", task.task_spec.name)
+            if (i > 0):
+                self.assertEqual("FamilyMemberBday"+"_%d"%(i-1), task.task_spec.name)
+            else:
+                self.assertEqual("FamilyMemberBday", task.task_spec.name)
             task.update_data(
                 {"CurrentFamilyMember": {"Birthdate": "10/0%i/1985" % i}})
             self.workflow.complete_task_from_id(task.id)

--- a/tests/SpiffWorkflow/camunda/MultiInstanceParallelArrayTest.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceParallelArrayTest.py
@@ -60,7 +60,10 @@ class MultiInstanceParallelArrayTest(BaseTestCase):
             tasks = self.workflow.get_ready_user_tasks()
             self.assertEqual(len(tasks),1) # still with sequential MI
             task = tasks[0]
-            self.assertEqual("FamilyMemberTask", task.task_spec.name)
+            if i > 0:
+                self.assertEqual("FamilyMemberTask"+"_%d"%(i-1), task.task_spec.name)
+            else:
+                self.assertEqual("FamilyMemberTask", task.task_spec.name)
             task.update_data({"FamilyMember": {"FirstName": "The Funk #%i" % i}})
             self.workflow.complete_task_from_id(task.id)
             self.workflow.do_engine_steps()

--- a/tests/SpiffWorkflow/camunda/MultiInstanceParallelArrayTest.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceParallelArrayTest.py
@@ -77,14 +77,14 @@ class MultiInstanceParallelArrayTest(BaseTestCase):
             task = random.choice(tasks)
             x = task.internal_data['runtimes'] -1
             self.assertEqual("FamilyMemberBday", task.task_spec.name)
-            self.assertEquals({"FirstName": "The Funk #%i" % x},
+            self.assertEqual({"FirstName": "The Funk #%i" % x},
                               task.data["CurrentFamilyMember"])
             task.update_data(
                 {"CurrentFamilyMember": {"Birthdate": "10/05/1985" + str(x)}})
             self.workflow.do_engine_steps()
             self.workflow.complete_task_from_id(task.id)
             # The data should still be available on the current task.
-            self.assertEquals({'FirstName': "The Funk #%i" % x,
+            self.assertEqual({'FirstName': "The Funk #%i" % x,
                                'Birthdate': '10/05/1985' + str(x)},
                               self.workflow.get_task(task.id)
                               .data['CurrentFamilyMember'])

--- a/tests/SpiffWorkflow/camunda/ResetTokenMITest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenMITest.py
@@ -40,9 +40,9 @@ class ResetTokenTestMI(BaseTestCase):
                   'task_data': {'do_step':'Yes'}},
                  {'taskname': 'FormA',
                   'task_data': {'current': {'A' : 'x'}}},
-                 {'taskname': 'FormA',
+                 {'taskname': 'FormA_0',
                   'task_data': {'current': {'A' : 'y'}}},
-                 {'taskname': 'FormA',
+                 {'taskname': 'FormA_1',
                   'task_data': {'current': {'A' : 'z'}}}
                  ]
         for step in steps:
@@ -59,9 +59,9 @@ class ResetTokenTestMI(BaseTestCase):
 
         steps = [{'taskname': 'FormA',
                   'task_data': {'current': {'A': 'a1'}}},
-                 {'taskname': 'FormA',
+                 {'taskname': 'FormA_0',
                   'task_data': {'current': {'A': 'a2'}}},
-                 {'taskname': 'FormA',
+                 {'taskname': 'FormA_1',
                   'task_data': {'current': {'A': 'a3'}}},
                  {'taskname': 'FormC',
                   'task_data': {'C': 'c'}}

--- a/tests/SpiffWorkflow/camunda/ResetTokenMITest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenMITest.py
@@ -77,7 +77,6 @@ class ResetTokenTestMI(BaseTestCase):
 
         self.assertTrue(self.workflow.is_completed())
         self.assertEqual({'do_step': 'Yes',
-                          'current': 3,
                           'output': {1: {'A': 'a1'},
                                      2: {'A': 'a2'},
                                      3: {'A': 'a3'}},

--- a/tests/SpiffWorkflow/camunda/data/default_gateway_pmi.bpmn
+++ b/tests/SpiffWorkflow/camunda/data/default_gateway_pmi.bpmn
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1n0u11m" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <bpmn:process id="DefaultGateway" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1wis1un</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="DoStuff" name="Do Stuff?" camunda:formKey="morestuffform">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="morestuff" label="Do we need to do more stuff?" type="string" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1wis1un</bpmn:incoming>
+      <bpmn:outgoing>Flow_144jxvd</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1wis1un" sourceRef="StartEvent_1" targetRef="DoStuff" />
+    <bpmn:exclusiveGateway id="Gateway_1yn93jn" default="Flow_1riszc2">
+      <bpmn:incoming>Flow_144jxvd</bpmn:incoming>
+      <bpmn:outgoing>Flow_1riszc2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0xdvee4</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_144jxvd" sourceRef="DoStuff" targetRef="Gateway_1yn93jn" />
+    <bpmn:sequenceFlow id="Flow_1riszc2" sourceRef="Gateway_1yn93jn" targetRef="GetMoreStuff" />
+    <bpmn:endEvent id="Event_1xfyeiq">
+      <bpmn:incoming>Flow_13ncefd</bpmn:incoming>
+      <bpmn:incoming>Flow_0xdvee4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_13ncefd" sourceRef="GetMoreStuff" targetRef="Event_1xfyeiq" />
+    <bpmn:userTask id="GetMoreStuff" name="Add More Stuff">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="stuff.addstuff" label="Add More Stuff" type="string" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1riszc2</bpmn:incoming>
+      <bpmn:outgoing>Flow_13ncefd</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics camunda:collection="collectstuff" camunda:elementVariable="stuff">
+        <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">3</bpmn:loopCardinality>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0xdvee4" name="No" sourceRef="Gateway_1yn93jn" targetRef="Event_1xfyeiq">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">morestuff == 'No'</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="DefaultGateway">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10nt4mt_di" bpmnElement="DoStuff">
+        <dc:Bounds x="260" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1wis1un_di" bpmnElement="Flow_1wis1un">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="260" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Gateway_1yn93jn_di" bpmnElement="Gateway_1yn93jn" isMarkerVisible="true">
+        <dc:Bounds x="405" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_144jxvd_di" bpmnElement="Flow_144jxvd">
+        <di:waypoint x="360" y="117" />
+        <di:waypoint x="405" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1riszc2_di" bpmnElement="Flow_1riszc2">
+        <di:waypoint x="455" y="117" />
+        <di:waypoint x="520" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1xfyeiq_di" bpmnElement="Event_1xfyeiq">
+        <dc:Bounds x="692" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13ncefd_di" bpmnElement="Flow_13ncefd">
+        <di:waypoint x="620" y="117" />
+        <di:waypoint x="692" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0msdtf4_di" bpmnElement="GetMoreStuff">
+        <dc:Bounds x="520" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0xdvee4_di" bpmnElement="Flow_0xdvee4">
+        <di:waypoint x="430" y="142" />
+        <di:waypoint x="430" y="240" />
+        <di:waypoint x="710" y="240" />
+        <di:waypoint x="710" y="135" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="563" y="222" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/camunda/data/exclusive_gateway_pmi.bpmn
+++ b/tests/SpiffWorkflow/camunda/data/exclusive_gateway_pmi.bpmn
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1n0u11m" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <bpmn:process id="DefaultGateway" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1wis1un</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="DoStuff" name="Do Stuff?" camunda:formKey="morestuffform">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="morestuff" label="Do we need to do more stuff?" type="string" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1wis1un</bpmn:incoming>
+      <bpmn:outgoing>Flow_144jxvd</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1wis1un" sourceRef="StartEvent_1" targetRef="DoStuff" />
+    <bpmn:exclusiveGateway id="Gateway_1yn93jn">
+      <bpmn:incoming>Flow_144jxvd</bpmn:incoming>
+      <bpmn:outgoing>Flow_1riszc2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0xdvee4</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_144jxvd" sourceRef="DoStuff" targetRef="Gateway_1yn93jn" />
+    <bpmn:sequenceFlow id="Flow_1riszc2" name="Yes" sourceRef="Gateway_1yn93jn" targetRef="GetMoreStuff">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">morestuff == 'Yes'</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_1xfyeiq">
+      <bpmn:incoming>Flow_13ncefd</bpmn:incoming>
+      <bpmn:incoming>Flow_0xdvee4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_13ncefd" sourceRef="GetMoreStuff" targetRef="Event_1xfyeiq" />
+    <bpmn:userTask id="GetMoreStuff" name="Add More Stuff">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="stuff.addstuff" label="Add More Stuff" type="string" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1riszc2</bpmn:incoming>
+      <bpmn:outgoing>Flow_13ncefd</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics camunda:collection="collectstuff" camunda:elementVariable="stuff">
+        <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">3</bpmn:loopCardinality>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0xdvee4" name="No" sourceRef="Gateway_1yn93jn" targetRef="Event_1xfyeiq">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">morestuff == 'No'</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="DefaultGateway">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10nt4mt_di" bpmnElement="DoStuff">
+        <dc:Bounds x="260" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1wis1un_di" bpmnElement="Flow_1wis1un">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="260" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Gateway_1yn93jn_di" bpmnElement="Gateway_1yn93jn" isMarkerVisible="true">
+        <dc:Bounds x="405" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_144jxvd_di" bpmnElement="Flow_144jxvd">
+        <di:waypoint x="360" y="117" />
+        <di:waypoint x="405" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1riszc2_di" bpmnElement="Flow_1riszc2">
+        <di:waypoint x="455" y="117" />
+        <di:waypoint x="520" y="117" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="478" y="99" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1xfyeiq_di" bpmnElement="Event_1xfyeiq">
+        <dc:Bounds x="692" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13ncefd_di" bpmnElement="Flow_13ncefd">
+        <di:waypoint x="620" y="117" />
+        <di:waypoint x="692" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0msdtf4_di" bpmnElement="GetMoreStuff">
+        <dc:Bounds x="520" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0xdvee4_di" bpmnElement="Flow_0xdvee4">
+        <di:waypoint x="430" y="142" />
+        <di:waypoint x="430" y="240" />
+        <di:waypoint x="710" y="240" />
+        <di:waypoint x="710" y="135" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="563" y="222" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Previously, Serial Multi Instance only retained one task that it repeated (i.e. looping task) - this worked but wasn't correct bpmn and clashed with how we wanted to represent it on the front end.

Now when you have a cardinality (including a collection) it will create as many inline tasks as are needed to service each item in the list. 

There are several things that we may want to revisit:

a) I've got separate code in the dict.py that patches things up for when we have reloaded both the task_spec tree (i.e. the workflow bpmn) and the task tree (i.e. save/restore) 
b) This code is related to (but strangely quite different from) the code that we used for PMI - and they are both in roughly the same places - it may be useful to form a plan to refactor this and move it to a central location.
c) the SMI code creates the new ad-hoc tasks with the original task name with a suffix (i.e. '_0') which allows the save/restore to look up the task name if it is already in the workflow, and determine that it isn't there if it is not. PMI doesn't do this, it just repeats the task name - we may want to do something similar 
d) There has not been a lot of testing around what happens if you (1) delete an item out of the list - does this play nice ? or (b) increase the length of the list (i.e. if you reset_token and mutate the list)
e) in many cases it feels a little hackish to look at task names to see if we have set this up yet or not, but there is no way to have it in task.data because of the predict loop that happens directly after loading the workflow and before you load the previous task tree. I was having a lot of problems with recursive task generation  (i.e. PMITask_0_0 where it should discover that PMITask_0 is there and use it instead)
