### PR TITLE
Cr connect 108 extract feel expression

### DIFF
--- a/SpiffWorkflow/bpmn/BpmnFeelScriptEngine.py
+++ b/SpiffWorkflow/bpmn/BpmnFeelScriptEngine.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, absolute_import
+from builtins import object
+# Copyright (C) 2012 Matthew Hampton
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301  USA
+from SpiffWorkflow.exceptions import WorkflowTaskExecException
+
+from .FeelLikeScriptEngine import FeelLikeScriptEngine
+from ..operators import Operator
+
+
+class BpmnFeelScriptEngine(FeelLikeScriptEngine):
+    """
+    Used during execution of a BPMN workflow to evaluate condition / value
+    expressions. These are used by Gateways, and by Catching Events
+    (non-message ones).
+
+    Also used to execute scripts.
+
+    If you are uncomfortable with the use of eval() and exec, then you should
+    provide a specialised subclass that parses and executes the scripts /
+    expressions in a mini-language of your own.
+    """
+
+    def evaluate(self, task, expression):
+        """
+        Evaluate the given expression, within the context of the given task and
+        return the result.
+        """
+        try:
+            if isinstance(expression, Operator):
+                # I am assuming that this takes care of some kind of XML
+                # expression judging from the contents of operators.py
+                return expression._matches(task)
+            else:
+                return super().evaluate(expression, **task.data)
+        except Exception as e:
+            raise WorkflowTaskExecException(task,
+                                            "Error evaluating expression "
+                                            "'%s', %s" % (expression, str(e)))
+

--- a/SpiffWorkflow/bpmn/DMNPythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/DMNPythonScriptEngine.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from builtins import object
+import ast
+import re
+import operator
+import datetime
+from datetime import timedelta
+from decimal import Decimal
+from SpiffWorkflow.workflow import WorkflowException
+from .PythonScriptEngine import PythonScriptEngine
+from box import Box
+# Copyright (C) 2020 Kelly McDonald
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301  USA
+
+class DMNPythonScriptEngine(PythonScriptEngine):
+    """
+    This simply overrides the python script engine to do some specific things for
+    DMN - I left the underlying PythonScriptEngine with everything in place so it
+    will play nice with the existing FeelLikeScriptEngine
+    """
+    def __init__(self):
+        pass
+
+    def eval_dmn_expression(self, inputExpr, matchExpr, **kwargs):
+        """
+        Here we need to handle a few things such as if it is an equality or if
+        the equality has already been taken care of. For now, we just assume it is equality.
+        """
+
+
+
+        if matchExpr is None:
+            return True
+
+        nolhs = False
+        if '?' in matchExpr:
+            nolhs = True
+            matchExpr = matchExpr.replace('?', 'dmninputexpr')
+
+        rhs, needsEquals = self.validateExpression(matchExpr)
+
+        extra = {
+            'datetime': datetime,
+            'timedelta': timedelta,
+            'Decimal': Decimal,
+            'Box': Box
+        }
+
+        lhs, lhsNeedsEquals = self.validateExpression(inputExpr)
+        if not lhsNeedsEquals:
+            raise WorkflowException("Input Expression '%s' is malformed"%inputExpr)
+        if nolhs:
+            dmninputexpr = self.evaluate(lhs, externalMethods= extra, **kwargs)
+            extra = {'dmninputexpr':dmninputexpr,
+                     'datetime':datetime,
+                     'timedelta':timedelta,
+                     'Decimal':Decimal,
+                     'Box':Box
+            }
+            return self.evaluate(rhs,externalMethods=extra, **kwargs)
+        if needsEquals:
+           expression = lhs + ' == ' + rhs
+        else:
+            expression = lhs + rhs
+
+        return self.evaluate(expression, externalMethods=extra, **kwargs)
+

--- a/SpiffWorkflow/bpmn/FeelLikeScriptEngine.py
+++ b/SpiffWorkflow/bpmn/FeelLikeScriptEngine.py
@@ -1,0 +1,338 @@
+# -*- coding: utf-8 -*-
+from builtins import object
+import ast
+import re
+import datetime
+import operator
+from datetime import timedelta
+from decimal import Decimal
+from SpiffWorkflow.workflow import WorkflowException
+from .PythonScriptEngine import PythonScriptEngine
+from box import Box
+# Copyright (C) 2020 Kelly McDonald
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301  USA
+
+def feelConvertTime(datestr,parsestr):
+    return datetime.datetime.strptime(datestr,parsestr)
+
+class FeelInterval():
+    def __init__(self, begin, end, leftOpen=False, rightOpen=False):
+        # pesky thing with python floats and Decimal comparison
+        if isinstance(begin,float):
+            begin = Decimal("%0.5f"%begin)
+        if isinstance(end, float):
+            end = Decimal("%0.5f" % end)
+
+        self.startInterval = begin
+        self.endInterval = end
+        self.leftOpen = leftOpen
+        self.rightOpen = rightOpen
+
+    def __eq__(self, other):
+        if self.leftOpen:
+            lhs = other > self.startInterval
+        else:
+            lhs = other >= self.startInterval
+        if self.rightOpen:
+            rhs = other < self.endInterval
+        else:
+            rhs = other <= self.endInterval
+        return lhs and rhs
+
+class FeelContains():
+    def __init__(self, testItem,invert=False ):
+        self.test = testItem
+        self.invert = invert
+    def __eq__(self, other):
+        has = False
+        if isinstance(other,dict):
+            has = self.test in list(other.keys())
+        else:
+            has = self.test in list(other)
+        if self.invert:
+            return not has
+        else:
+            return has
+
+class FeelNot():
+    def __init__(self, testItem):
+        self.test = testItem
+
+    def __eq__(self, other):
+        if other == self.test:
+            return False
+        else:
+            return True
+
+def feelConcatenate(*lst):
+    ilist = []
+    for l in lst:
+        ilist = ilist + l
+    return ilist
+
+def feelAppend(lst,item):
+    newlist = lst[:]  # get a copy
+    newlist.append(item)
+    return newlist
+
+def feelNow():
+    return datetime.datetime.now()
+
+def feelGregorianDOW(date):
+    # we assume date is either date in Y-m-d format
+    # or it is of datetime class
+    if isinstance(date,str):
+        date = datetime.datetime.strptime(date,'%Y-%m-%d')
+    return date.isoweekday()%7
+
+
+def transformDuration(duration,td):
+    if duration:
+        return td * float(duration)
+    else:
+        return timedelta(seconds=0)
+
+def lookupPart(code,base):
+    x= re.search("([0-9.]+)"+code,base)
+    if x:
+        return x.group(1)
+    else:
+        return None
+
+def feelFilter(var,a,b,op,column=None):
+    """
+    here we are trying to cover some of the basic test cases,
+    dict, list of dicts and list.
+    """
+    opmap = {'=':operator.eq,
+             '<':operator.lt,
+             '>':operator.gt,
+             '<=':operator.le,
+             '>=':operator.ge,
+             '!=':operator.ne}
+    #print('eval b',a,b,op,column)
+    b = eval(b)
+    # if it is a list and we are referring to 'item' then we
+    # expect the variable to be a simple list
+    if (isinstance(var,list)) and a == 'item':
+        return [x for x in var if opmap[op](x,b)]
+    # if it is a dictionary, and the keys refer to dictionaries,
+    # then we convert it to a list of dictionaries with the elements
+    # all having {'key':key,<rest of dict>}
+    # if it is a dictionary and the key refers to a non-dict, then
+    # we conver to a dict having {'key':key,'value':value}
+    if (isinstance(var,dict)):
+        newvar = []
+        for key in var.keys():
+            if isinstance(var[key],dict):
+                newterm = var[key]
+                newterm.update({'key':key})
+                newvar.append(newterm)
+            else:
+                newvar.append({'key':key,'value':var[key]})
+        var = newvar
+
+    #print (var)
+    #print(column)
+    if column!=None:
+        return [x.get(column) for x in var if opmap[op](x.get(a), b)]
+    else:
+        return [x for x in var if opmap[op](x.get(a), b)]
+
+
+
+def feelParseISODuration(input):
+    """
+    Given an ISO duration designation
+    such as :
+        P0Y1M2DT3H2S
+    and convert it into a python timedelta
+
+    Abbreviations may be made as in :
+
+       PT30S
+
+    NB:
+    Months are defined as 30 days currently - as I am dreading getting into
+    Date arithmetic edge cases.
+
+    """
+    if input[0] != 'P':
+        raise Exception("Oh Crap!")
+    input = input[1:]
+    days, time = input.split("T")
+    lookups = [("Y",days,timedelta(days=365)),
+               ("M", days, timedelta(days=30)),
+               ("W", days, timedelta(days=7)),
+               ("D", days, timedelta(days=1)),
+               ("H", time, timedelta(seconds=60*60)),
+               ("M", time, timedelta(seconds=60)),
+               ("S", time, timedelta(seconds=1)),
+               ]
+    totaltime = [transformDuration(lookupPart(x[0],x[1]),x[2]) for x in lookups]
+    return sum(totaltime,timedelta(seconds=0))
+
+
+
+
+
+
+
+# Order Matters!!
+fixes = [(r'string\s+length\((.+?)\)','len(\\1)'),
+         (r'count\((.+?)\)','len(\1)'),
+         (r'concatenate\((.+?)\)','feelConcatenate(\\1)'),
+         (r'append\((.+?),(.+?)\)','feelAppend(\\1,\\2)'), # again will not work with literal list
+         (r'list\s+contains\((.+?),(.+?)\)','\\2 in \\1'), # list contains(['a','b','stupid,','c'],'stupid,') will break
+         (r'contains\((.+?),(.+?)\)','\\2 in \\1'), # contains('my stupid, stupid comment','stupid') will break
+         (r'not\s+?contains\((.+?)\)','FeelContains(\\1,invert=True)'), # not  contains('something')
+         (r'not\((.+?)\)','FeelNot(\\1)'),   # not('x')
+
+         (r'now\(\)','feelNow()'),
+         (r'contains\((.+?)\)', 'FeelContains(\\1)'), # contains('x')
+         # date  and time (<datestr>)
+         (r'date\s+?and\s+?time\s*\((.+?)\)', 'feelConvertTime(\\1,"%Y-%m-%dT%H:%M:%S")'),
+         (r'date\s*\((.+?)\)', 'feelConvertTime(\\1,"%Y-%m-%d)'),  # date (<datestring>)
+         (r'day\s+of\s+\week\((.+?)\)','feelGregorianDOW(\\1)'),
+         (r'\[([^\[\]]+?)[.]{2}([^\[\]]+?)\]','FeelInterval(\\1,\\2)'),                # closed interval on both sides
+         (r'[\]\(]([^\[\]\(\)]+?)[.]{2}([^\[\]\)\(]+?)\]','FeelInterval(\\1,\\2,leftOpen=True)'),  # open lhs
+         (r'\[([^\[\]\(\)]+?)[.]{2}([^\[\]\(\)]+?)[\[\)]','FeelInterval(\\1,\\2,rightOpen=True)'), # open rhs
+         # I was having problems with this matching a "P" somewhere in another expression
+         # so I added a bunch of different cases that should isolate this.
+         (r'^(P(([0-9.]+Y)?([0-9.]+M)?([0-9.]+W)?([0-9.]+D)?)?(T([0-9.]+H)?([0-9.]+M)?([0-9.]+S)?)?)$',
+          'feelParseISODuration("\\1")'), ## Parse ISO Duration convert to timedelta - standalone
+         (r'^(P(([0-9.]+Y)?([0-9.]+M)?([0-9.]+W)?([0-9.]+D)?)?(T([0-9.]+H)?([0-9.]+M)?([0-9.]+S)?)?)\s',
+          'feelParseISODuration("\\1") '),  ## Parse ISO Duration convert to timedelta beginning
+         (r'\s(P(([0-9.]+Y)?([0-9.]+M)?([0-9.]+W)?([0-9.]+D)?)?(T([0-9.]+H)?([0-9.]+M)?([0-9.]+S)?)?)\s',
+          ' feelParseISODuration("\\1") '),  ## Parse ISO Duration convert to timedelta in context
+         (r'\s(P(([0-9.]+Y)?([0-9.]+M)?([0-9.]+W)?([0-9.]+D)?)?(T([0-9.]+H)?([0-9.]+M)?([0-9.]+S)?)?)$',
+          ' feelParseISODuration("\\1")'),  ## Parse ISO Duration convert to timedelta end
+
+         (r'(.+)\[(\S+)?(<=)(.+)]\.(\S+)', 'feelFilter(\\1,"\\2","\\4","\\3","\\5")'),  # implement a simple filter
+         (r'(.+)\[(\S+)?(>=)(.+)]\.(\S+)', 'feelFilter(\\1,"\\2","\\4","\\3","\\5")'),  # implement a simple filter
+         (r'(.+)\[(\S+)?(!=)(.+)]\.(\S+)', 'feelFilter(\\1,"\\2","\\4","\\3","\\5")'),  # implement a simple filter
+         (r'(.+)\[(\S+)?([=<>])(.+)]\.(\S+)', 'feelFilter(\\1,"\\2",\\4,"\\3","\\5")'),  # implement a simple filter
+         (r'(.+)\[(\S+)?(<=)(.+)]', 'feelFilter(\\1,"\\2","\\4","\\3")'),  # implement a simple filter
+         (r'(.+)\[(\S+)?(>=)(.+)]', 'feelFilter(\\1,"\\2","\\4","\\3")'),  # implement a simple filter
+         (r'(.+)\[(\S+)?(!=)(.+)]', 'feelFilter(\\1,"\\2","\\4","\\3")'),  # implement a simple filter
+         (r'(.+)\[(\S+)?([=<>])(.+)]','feelFilter(\\1,"\\2","\\4","\\3")'), # implement a simple filter
+         (r'[\]\(]([^\[\]\(\)]+?)[.]{2}([^\[\]\(\)]+?)[\[\)]',
+                'FeelInterval(\\1,\\2,rightOpen=True,leftOpen=True)'), # open both
+
+
+         # parse dot.dict for several different edge cases
+         # make sure that it begins with a letter character - otherwise we
+         # may get float numbers.
+         # will not work for cases where we do something like:
+         #               x contains(this.dotdict.item)
+         # and it may be difficult, because we do not want to replace for the case of
+         #               somedict.keys()  - because that is actually in the tests.
+         # however, it would be fixed by doing:
+         #              x contains( this.dotdict.item )
+
+         ('true','True'),
+         ('false','False')
+         ]
+externalFuncs = {
+    'feelConvertTime':feelConvertTime,
+    'FeelInterval':FeelInterval,
+    'FeelNot':FeelNot,
+    'Decimal':Decimal,
+    'feelConcatenate': feelConcatenate,
+    'feelAppend': feelAppend,
+    'feelFilter': feelFilter,
+    'feelNow': feelNow,
+    'FeelContains': FeelContains,
+    'datetime':datetime,
+    'feelParseISODuration': feelParseISODuration,
+    'feelGregorianDOW':feelGregorianDOW,
+}
+
+default_header = """
+
+
+
+"""
+class FeelLikeScriptEngine(PythonScriptEngine):
+    """
+    This should serve as a base for all scripting & expression evaluation
+    operations that are done within both BPMN and BMN. Eventually it will also
+    serve as a base for FEEL expressions as well
+
+    If you are uncomfortable with the use of eval() and exec, then you should
+    provide a specialised subclass that parses and executes the scripts /
+    expressions in a mini-language of your own.
+    """
+    def __init__(self):
+        pass
+
+    def patch_expression(self,invalid_python,lhs=''):
+        if invalid_python is None:
+            return None
+        proposed_python = invalid_python
+        for transformation in fixes:
+            if isinstance(transformation[1],str):
+                proposed_python = re.sub(transformation[0],transformation[1],proposed_python)
+            else:
+                for x in re.findall(transformation[0],proposed_python):
+                    if '.' in(x):
+                        proposed_python = proposed_python.replace(x,transformation[1](x))
+        if lhs is not None:
+            proposed_python = lhs + proposed_python
+        return proposed_python
+
+    def validateExpression (self,text):
+        if text is None:
+            return
+        try:
+            # this should work if we can just do a straight equality
+            revised_text = self.patch_expression(text)
+            ast.parse(revised_text)
+            return revised_text,True
+        except:
+            try:
+                revised_text = self.patch_expression(text, 's ') # if we have problems parsing, then we introduce a
+                # variable on the left hand side and try that and see if that parses. If so, then we know that
+                # we do not need to introduce an equality operator later in the dmn
+                ast.parse(revised_text)
+                return revised_text[2:],False
+            except Exception as e:
+                raise Exception("error parsing expression "+text + " " +
+                                str(e))
+
+
+
+
+    def evaluate(self, expression,externalMethods={}, **kwargs):
+        """
+        Evaluate the given expression, within the context of the given task and
+        return the result.
+        """
+        externalMethods.update(externalFuncs)
+        return super().evaluate(expression,externalMethods,**kwargs)
+
+
+    def execute(self, task, script, data,externalMethods={}):
+        """
+        Execute the script, within the context of the specified task
+        """
+        externalMethods.update(externalFuncs)
+        super(PythonScriptEngine).execute(task,script,externalMethods)
+
+
+
+

--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -25,252 +25,6 @@ from box import Box
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
 
-def feelConvertTime(datestr,parsestr):
-    return datetime.datetime.strptime(datestr,parsestr)
-
-class FeelInterval():
-    def __init__(self, begin, end, leftOpen=False, rightOpen=False):
-        # pesky thing with python floats and Decimal comparison
-        if isinstance(begin,float):
-            begin = Decimal("%0.5f"%begin)
-        if isinstance(end, float):
-            end = Decimal("%0.5f" % end)
-
-        self.startInterval = begin
-        self.endInterval = end
-        self.leftOpen = leftOpen
-        self.rightOpen = rightOpen
-
-    def __eq__(self, other):
-        if self.leftOpen:
-            lhs = other > self.startInterval
-        else:
-            lhs = other >= self.startInterval
-        if self.rightOpen:
-            rhs = other < self.endInterval
-        else:
-            rhs = other <= self.endInterval
-        return lhs and rhs
-
-class FeelContains():
-    def __init__(self, testItem,invert=False ):
-        self.test = testItem
-        self.invert = invert
-    def __eq__(self, other):
-        has = False
-        if isinstance(other,dict):
-            has = self.test in list(other.keys())
-        else:
-            has = self.test in list(other)
-        if self.invert:
-            return not has
-        else:
-            return has
-
-class FeelNot():
-    def __init__(self, testItem):
-        self.test = testItem
-
-    def __eq__(self, other):
-        if other == self.test:
-            return False
-        else:
-            return True
-
-def feelConcatenate(*lst):
-    ilist = []
-    for l in lst:
-        ilist = ilist + l
-    return ilist
-
-def feelAppend(lst,item):
-    newlist = lst[:]  # get a copy
-    newlist.append(item)
-    return newlist
-
-def feelNow():
-    return datetime.datetime.now()
-
-def feelGregorianDOW(date):
-    # we assume date is either date in Y-m-d format
-    # or it is of datetime class
-    if isinstance(date,str):
-        date = datetime.datetime.strptime(date,'%Y-%m-%d')
-    return date.isoweekday()%7
-
-
-def transformDuration(duration,td):
-    if duration:
-        return td * float(duration)
-    else:
-        return timedelta(seconds=0)
-
-def lookupPart(code,base):
-    x= re.search("([0-9.]+)"+code,base)
-    if x:
-        return x.group(1)
-    else:
-        return None
-
-def feelFilter(var,a,b,op,column=None):
-    """
-    here we are trying to cover some of the basic test cases,
-    dict, list of dicts and list.
-    """
-    opmap = {'=':operator.eq,
-             '<':operator.lt,
-             '>':operator.gt,
-             '<=':operator.le,
-             '>=':operator.ge,
-             '!=':operator.ne}
-    #print('eval b',a,b,op,column)
-    b = eval(b)
-    # if it is a list and we are referring to 'item' then we
-    # expect the variable to be a simple list
-    if (isinstance(var,list)) and a == 'item':
-        return [x for x in var if opmap[op](x,b)]
-    # if it is a dictionary, and the keys refer to dictionaries,
-    # then we convert it to a list of dictionaries with the elements
-    # all having {'key':key,<rest of dict>}
-    # if it is a dictionary and the key refers to a non-dict, then
-    # we conver to a dict having {'key':key,'value':value}
-    if (isinstance(var,dict)):
-        newvar = []
-        for key in var.keys():
-            if isinstance(var[key],dict):
-                newterm = var[key]
-                newterm.update({'key':key})
-                newvar.append(newterm)
-            else:
-                newvar.append({'key':key,'value':var[key]})
-        var = newvar
-
-    #print (var)
-    #print(column)
-    if column!=None:
-        return [x.get(column) for x in var if opmap[op](x.get(a), b)]
-    else:
-        return [x for x in var if opmap[op](x.get(a), b)]
-
-
-
-def feelParseISODuration(input):
-    """
-    Given an ISO duration designation
-    such as :
-        P0Y1M2DT3H2S
-    and convert it into a python timedelta
-
-    Abbreviations may be made as in :
-
-       PT30S
-
-    NB:
-    Months are defined as 30 days currently - as I am dreading getting into
-    Date arithmetic edge cases.
-
-    """
-    if input[0] != 'P':
-        raise Exception("Oh Crap!")
-    input = input[1:]
-    days, time = input.split("T")
-    lookups = [("Y",days,timedelta(days=365)),
-               ("M", days, timedelta(days=30)),
-               ("W", days, timedelta(days=7)),
-               ("D", days, timedelta(days=1)),
-               ("H", time, timedelta(seconds=60*60)),
-               ("M", time, timedelta(seconds=60)),
-               ("S", time, timedelta(seconds=1)),
-               ]
-    totaltime = [transformDuration(lookupPart(x[0],x[1]),x[2]) for x in lookups]
-    return sum(totaltime,timedelta(seconds=0))
-
-
-
-
-
-def expandDotDict(text):
-    parts = text.split('.')
-    suffix = ''.join(["['%s']"%x for x in parts[1:]])
-    prefix = parts[0]
-    return prefix+suffix
-
-
-# Order Matters!!
-fixes = [(r'string\s+length\((.+?)\)','len(\\1)'),
-         (r'count\((.+?)\)','len(\1)'),
-         (r'concatenate\((.+?)\)','feelConcatenate(\\1)'),
-         (r'append\((.+?),(.+?)\)','feelAppend(\\1,\\2)'), # again will not work with literal list
-         (r'list\s+contains\((.+?),(.+?)\)','\\2 in \\1'), # list contains(['a','b','stupid,','c'],'stupid,') will break
-         (r'contains\((.+?),(.+?)\)','\\2 in \\1'), # contains('my stupid, stupid comment','stupid') will break
-         (r'not\s+?contains\((.+?)\)','FeelContains(\\1,invert=True)'), # not  contains('something')
-         (r'not\((.+?)\)','FeelNot(\\1)'),   # not('x')
-
-         (r'now\(\)','feelNow()'),
-         (r'contains\((.+?)\)', 'FeelContains(\\1)'), # contains('x')
-         # date  and time (<datestr>)
-         (r'date\s+?and\s+?time\s*\((.+?)\)', 'feelConvertTime(\\1,"%Y-%m-%dT%H:%M:%S")'),
-         (r'date\s*\((.+?)\)', 'feelConvertTime(\\1,"%Y-%m-%d)'),  # date (<datestring>)
-         (r'day\s+of\s+\week\((.+?)\)','feelGregorianDOW(\\1)'),
-         (r'\[([^\[\]]+?)[.]{2}([^\[\]]+?)\]','FeelInterval(\\1,\\2)'),                # closed interval on both sides
-         (r'[\]\(]([^\[\]\(\)]+?)[.]{2}([^\[\]\)\(]+?)\]','FeelInterval(\\1,\\2,leftOpen=True)'),  # open lhs
-         (r'\[([^\[\]\(\)]+?)[.]{2}([^\[\]\(\)]+?)[\[\)]','FeelInterval(\\1,\\2,rightOpen=True)'), # open rhs
-         # I was having problems with this matching a "P" somewhere in another expression
-         # so I added a bunch of different cases that should isolate this.
-         (r'^(P(([0-9.]+Y)?([0-9.]+M)?([0-9.]+W)?([0-9.]+D)?)?(T([0-9.]+H)?([0-9.]+M)?([0-9.]+S)?)?)$',
-          'feelParseISODuration("\\1")'), ## Parse ISO Duration convert to timedelta - standalone
-         (r'^(P(([0-9.]+Y)?([0-9.]+M)?([0-9.]+W)?([0-9.]+D)?)?(T([0-9.]+H)?([0-9.]+M)?([0-9.]+S)?)?)\s',
-          'feelParseISODuration("\\1") '),  ## Parse ISO Duration convert to timedelta beginning
-         (r'\s(P(([0-9.]+Y)?([0-9.]+M)?([0-9.]+W)?([0-9.]+D)?)?(T([0-9.]+H)?([0-9.]+M)?([0-9.]+S)?)?)\s',
-          ' feelParseISODuration("\\1") '),  ## Parse ISO Duration convert to timedelta in context
-         (r'\s(P(([0-9.]+Y)?([0-9.]+M)?([0-9.]+W)?([0-9.]+D)?)?(T([0-9.]+H)?([0-9.]+M)?([0-9.]+S)?)?)$',
-          ' feelParseISODuration("\\1")'),  ## Parse ISO Duration convert to timedelta end
-
-         (r'(.+)\[(\S+)?(<=)(.+)]\.(\S+)', 'feelFilter(\\1,"\\2","\\4","\\3","\\5")'),  # implement a simple filter
-         (r'(.+)\[(\S+)?(>=)(.+)]\.(\S+)', 'feelFilter(\\1,"\\2","\\4","\\3","\\5")'),  # implement a simple filter
-         (r'(.+)\[(\S+)?(!=)(.+)]\.(\S+)', 'feelFilter(\\1,"\\2","\\4","\\3","\\5")'),  # implement a simple filter
-         (r'(.+)\[(\S+)?([=<>])(.+)]\.(\S+)', 'feelFilter(\\1,"\\2",\\4,"\\3","\\5")'),  # implement a simple filter
-         (r'(.+)\[(\S+)?(<=)(.+)]', 'feelFilter(\\1,"\\2","\\4","\\3")'),  # implement a simple filter
-         (r'(.+)\[(\S+)?(>=)(.+)]', 'feelFilter(\\1,"\\2","\\4","\\3")'),  # implement a simple filter
-         (r'(.+)\[(\S+)?(!=)(.+)]', 'feelFilter(\\1,"\\2","\\4","\\3")'),  # implement a simple filter
-         (r'(.+)\[(\S+)?([=<>])(.+)]','feelFilter(\\1,"\\2","\\4","\\3")'), # implement a simple filter
-         (r'[\]\(]([^\[\]\(\)]+?)[.]{2}([^\[\]\(\)]+?)[\[\)]',
-                'FeelInterval(\\1,\\2,rightOpen=True,leftOpen=True)'), # open both
-
-
-         # parse dot.dict for several different edge cases
-         # make sure that it begins with a letter character - otherwise we
-         # may get float numbers.
-         # will not work for cases where we do something like:
-         #               x contains(this.dotdict.item)
-         # and it may be difficult, because we do not want to replace for the case of
-         #               somedict.keys()  - because that is actually in the tests.
-         # however, it would be fixed by doing:
-         #              x contains( this.dotdict.item )
-
-
-
-         # (r'\s[a-zA-Z][a-zA-Z0-9_.\-]+?\s',expandDotDict),  # In the middle of a string
-         # (r'^[a-zA-Z][a-zA-Z0-9_.\-]+?\s',expandDotDict),   # at beginning with stuff after
-         # (r'^[a-zA-Z][a-zA-Z0-9_.\-]+?$',expandDotDict),    # all by itself & lonely :-(
-         # (r'\s[a-zA-Z][a-zA-Z0-9_.\-]+?$',expandDotDict),   # at the very end of a string
-         ('true','True'),
-         ('false','False')
-         ]
-externalFuncs = {
-    'feelConvertTime':feelConvertTime,
-    'FeelInterval':FeelInterval,
-    'FeelNot':FeelNot,
-    'Decimal':Decimal,
-    'feelConcatenate': feelConcatenate,
-    'feelAppend': feelAppend,
-    'feelFilter': feelFilter,
-    'feelNow': feelNow,
-    'FeelContains': FeelContains,
-    'datetime':datetime,
-    'feelParseISODuration': feelParseISODuration,
-    'feelGregorianDOW':feelGregorianDOW,
-}
 
 default_header = """
 
@@ -287,35 +41,20 @@ class PythonScriptEngine(object):
     provide a specialised subclass that parses and executes the scripts /
     expressions in a mini-language of your own.
     """
-    def __init__(selfs):
+    def __init__(self):
         pass
-
-    def patch_expression(self,invalid_python,lhs=''):
-        if invalid_python is None:
-            return None
-        proposed_python = invalid_python
-        for transformation in fixes:
-            if isinstance(transformation[1],str):
-                proposed_python = re.sub(transformation[0],transformation[1],proposed_python)
-            else:
-                for x in re.findall(transformation[0],proposed_python):
-                    if '.' in(x):
-                        proposed_python = proposed_python.replace(x,transformation[1](x))
-        if lhs is not None:
-            proposed_python = lhs + proposed_python
-        return proposed_python
 
     def validateExpression (self,text):
         if text is None:
             return
         try:
             # this should work if we can just do a straight equality
-            revised_text = self.patch_expression(text)
-            ast.parse(revised_text)
-            return revised_text,True
+            ast.parse(text)
+            return text,True
         except:
             try:
-                revised_text = self.patch_expression(text, 's ') # if we have problems parsing, then we introduce a
+                revised_text = 's ' + text  # if we have problems parsing,
+                # then we introduce a
                 # variable on the left hand side and try that and see if that parses. If so, then we know that
                 # we do not need to introduce an equality operator later in the dmn
                 ast.parse(revised_text)
@@ -354,7 +93,10 @@ class PythonScriptEngine(object):
         Execute the script, within the context of the specified task
         """
 
-        globals = {}
+
+        globals = {'timedelta':timedelta,
+                   'datetime':datetime}
+
         for x in data.keys():
             if isinstance(data[x],dict):
                 data[x] = Box(data[x])
@@ -362,24 +104,18 @@ class PythonScriptEngine(object):
                                    # this may cause a problem down the road if we
                                    # actually have a variable named 'task'
         globals.update(data)   # dict comprehensions cause problems when the variables are not viable.
-        globals.update(externalFuncs)
         globals.update(externalMethods)
         exec(script,globals,data)
-
-
-
-
-
 
 
     def _eval(self, expression,externalMethods={}, **kwargs):
         lcls = {}
         lcls.update(kwargs)
-        globals = {}
+        globals = {'timedelta':timedelta,
+                   'datetime':datetime}
         for x in lcls.keys():
             if isinstance(lcls[x], dict):
                 lcls[x] = Box(lcls[x])
         globals.update(lcls)
-        globals.update(externalFuncs)
         globals.update(externalMethods)
         return eval(expression,globals,lcls)

--- a/SpiffWorkflow/dmn/engine/DMNEngine.py
+++ b/SpiffWorkflow/dmn/engine/DMNEngine.py
@@ -49,7 +49,7 @@ class DMNEngine:
                 else:
                     inputVal = None
                 try:
-                    if not self.scriptEngine.eval_dmn_expression(inputVal, lhs, **local_data):
+                    if not input.scriptEngine.eval_dmn_expression(inputVal, lhs, **local_data):
                         return False
                 except NameError as e:
                     x = re.match("name '(.+)' is not defined",str(e))

--- a/SpiffWorkflow/dmn/engine/DMNEngine.py
+++ b/SpiffWorkflow/dmn/engine/DMNEngine.py
@@ -1,19 +1,19 @@
 import logging
 import Levenshtein
 import re
-from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.FeelLikeScriptEngine import FeelLikeScriptEngine
 
 
 class DMNEngine:
     """
-    Handles the prbocessing of a decision table.
+    Handles the processing of a decision table.
     """
 
 
     def __init__(self, decisionTable, debug=None):
         self.decisionTable = decisionTable
         self.debug = debug
-        self.scriptEngine = PythonScriptEngine()
+        self.scriptEngine = FeelLikeScriptEngine()
         self.logger = logging.getLogger('DMNEngine')
         if not self.logger.handlers:
             self.logger.addHandler(logging.StreamHandler())

--- a/SpiffWorkflow/dmn/engine/DMNEngine.py
+++ b/SpiffWorkflow/dmn/engine/DMNEngine.py
@@ -1,7 +1,7 @@
 import logging
 import Levenshtein
 import re
-from SpiffWorkflow.bpmn.FeelLikeScriptEngine import FeelLikeScriptEngine
+from SpiffWorkflow.bpmn.DMNPythonScriptEngine import DMNPythonScriptEngine
 
 
 class DMNEngine:
@@ -13,7 +13,7 @@ class DMNEngine:
     def __init__(self, decisionTable, debug=None):
         self.decisionTable = decisionTable
         self.debug = debug
-        self.scriptEngine = FeelLikeScriptEngine()
+        self.scriptEngine = DMNPythonScriptEngine()
         self.logger = logging.getLogger('DMNEngine')
         if not self.logger.handlers:
             self.logger.addHandler(logging.StreamHandler())

--- a/SpiffWorkflow/dmn/parser/DMNParser.py
+++ b/SpiffWorkflow/dmn/parser/DMNParser.py
@@ -8,6 +8,8 @@ from SpiffWorkflow.bpmn.parser.util import xpath_eval
 from SpiffWorkflow.dmn.specs.model import Decision, DecisionTable, InputEntry, \
     OutputEntry, Input, Output, Rule
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.FeelLikeScriptEngine import FeelLikeScriptEngine
+from SpiffWorkflow.bpmn.DMNPythonScriptEngine import DMNPythonScriptEngine
 
 DMN_NS = 'http://www.omg.org/spec/DMN/20151101/dmn.xsd'
 
@@ -40,7 +42,7 @@ class DMNParser(object):
         self.filename = filename
         self.doc_xpath = doc_xpath
         self.xpath = xpath_eval(self.node, {'dmn': DMN_NS})
-        self.scriptEngine = PythonScriptEngine()
+        self.scriptEngine = DMNPythonScriptEngine()
 
     def parse(self):
         self.decision = self._parse_decision(self.node)
@@ -114,6 +116,11 @@ class DMNParser(object):
         for inputExpression in xpath('dmn:inputExpression'):
 
             typeRef = inputExpression.attrib.get('typeRef', '')
+            scriptEngine = self.scriptEngine
+            engine = inputExpression.attrib.get('expressionLanguage')
+            if engine == 'feel':
+                scriptEngine = FeelLikeScriptEngine()
+
             expressionNode = inputExpression.find('{' + DMN_NS + '}text')
             if expressionNode is not None:
                 expression = expressionNode.text
@@ -124,6 +131,7 @@ class DMNParser(object):
                       inputElement.attrib.get('label', ''),
                       inputElement.attrib.get('name', ''),
                       expression,
+                      scriptEngine,
                       typeRef)
         return input
 

--- a/SpiffWorkflow/dmn/specs/model.py
+++ b/SpiffWorkflow/dmn/specs/model.py
@@ -18,11 +18,12 @@ class DecisionTable:
         self.rules = []
 
 class Input:
-    def __init__(self, id, label, name, expression, typeRef):
+    def __init__(self, id, label, name, expression, scriptEngine, typeRef):
         self.id = id
         self.label = label
         self.name = name
         self.expression = expression
+        self.scriptEngine = scriptEngine
         self.typeRef = typeRef
 
 class InputEntry:

--- a/tests/SpiffWorkflow/bpmn/PythonExpressionEngineTest.py
+++ b/tests/SpiffWorkflow/bpmn/PythonExpressionEngineTest.py
@@ -8,7 +8,7 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
-from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine, FeelInterval
+from SpiffWorkflow.bpmn.FeelLikeScriptEngine import FeelLikeScriptEngine, FeelInterval
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 import datetime
 
@@ -166,7 +166,7 @@ class PythonExpressionTest(BpmnWorkflowTestCase):
             ],
             "shared": []
         }
-        self.expressionEngine = PythonScriptEngine()
+        self.expressionEngine = FeelLikeScriptEngine()
 
     def testRunThroughExpressions(self):
         tests = [("string length('abcd')", 4, {}),

--- a/tests/SpiffWorkflow/bpmn/TimerDurationBoundaryTest.py
+++ b/tests/SpiffWorkflow/bpmn/TimerDurationBoundaryTest.py
@@ -8,7 +8,7 @@ import time
 from SpiffWorkflow.task import Task
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
-
+from SpiffWorkflow.bpmn.BpmnFeelScriptEngine import BpmnFeelScriptEngine
 __author__ = 'kellym'
 
 
@@ -29,6 +29,7 @@ class TimerDurationTest(BpmnWorkflowTestCase):
 
     def actual_test(self,save_restore = False):
         self.workflow = BpmnWorkflow(self.spec)
+        self.workflow.script_engine = BpmnFeelScriptEngine()
         ready_tasks = self.workflow.get_tasks(Task.READY)
         self.assertEqual(1, len(ready_tasks))
         self.workflow.complete_task_from_id(ready_tasks[0].id)
@@ -47,7 +48,9 @@ class TimerDurationTest(BpmnWorkflowTestCase):
             ready_tasks = self.workflow.get_tasks(Task.READY)
             if len(ready_tasks) < 1:
                 break
-            if save_restore: self.save_restore()
+            if save_restore:
+                self.save_restore()
+                self.workflow.script_engine = BpmnFeelScriptEngine()
             #self.assertEqual(1, len(self.workflow.get_tasks(Task.WAITING)))
             time.sleep(0.1)
             self.workflow.complete_task_from_id(ready_tasks[0].id)

--- a/tests/SpiffWorkflow/bpmn/data/MessageBoundary.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/MessageBoundary.bpmn
@@ -78,7 +78,7 @@
         <bpmn:incoming>Flow_11u0pgk</bpmn:incoming>
         <bpmn:outgoing>Flow_1rqk2v9</bpmn:outgoing>
         <bpmn:timerEventDefinition id="TimerEventDefinition_0bct7zl">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT.1S</bpmn:timeDuration>
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=.1)</bpmn:timeDuration>
         </bpmn:timerEventDefinition>
       </bpmn:intermediateCatchEvent>
       <bpmn:sequenceFlow id="Flow_1gs89vo" sourceRef="Event_0akpdke" targetRef="Activity_106f08z" />

--- a/tests/SpiffWorkflow/bpmn/data/timer-non-interrupt-boundary.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer-non-interrupt-boundary.bpmn
@@ -38,7 +38,7 @@
     <bpmn:boundaryEvent id="Event_0jyy8ao" name="BenchmarkTime" cancelActivity="false" attachedToRef="Activity_0e5qk4z">
       <bpmn:outgoing>Flow_03e1mfr</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_15a4lk2">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT.2S</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=.2)</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
     <bpmn:userTask id="GetReason" name="Delay Reason" camunda:formKey="DelayForm">

--- a/tests/SpiffWorkflow/bpmn/data/timer.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer.bpmn
@@ -12,7 +12,7 @@
       <bpmn:incoming>Flow_1pvkgnu</bpmn:incoming>
       <bpmn:outgoing>Flow_1elbn9u</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_1jrn73k">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT.25S</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=.25)</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
     <bpmn:manualTask id="Activity_1rbj8j1" name="Get Back To Work">

--- a/tests/SpiffWorkflow/dmn/FeelBoolDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelBoolDecisionTest.py
@@ -1,0 +1,31 @@
+import unittest
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelBoolDecisionTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = DecisionRunner('bool_decision_feel.dmn', debug='DEBUG')
+
+    def test_bool_decision_string_output1(self):
+        res = self.runner.decide(True)
+        self.assertEqual(res.description, 'Y Row Annotation')
+
+    def test_bool_decision_string_output2(self):
+        res = self.runner.decide(False)
+        self.assertEqual(res.description, 'N Row Annotation')
+
+    def test_bool_decision_string_output3(self):
+        res = self.runner.decide(None)
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelBoolDecisionTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelBusinessRuleTaskParserTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelBusinessRuleTaskParserTest.py
@@ -1,0 +1,52 @@
+import os
+import unittest
+
+from SpiffWorkflow import Task
+
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+
+from SpiffWorkflow.dmn.parser.BpmnDmnParser import BpmnDmnParser
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+class FeelBusinessRuleTaskParserTest(BpmnWorkflowTestCase):
+    PARSER_CLASS = BpmnDmnParser
+
+    def setUp(self):
+        parser = BpmnDmnParser()
+        bpmn = os.path.join(os.path.dirname(__file__), 'data', 'BpmnDmn',
+                            'ExclusiveGatewayIfElseAndDecision.bpmn')
+        dmn = os.path.join(os.path.dirname(__file__), 'data', 'BpmnDmn',
+                            'test_integer_decision_feel.dmn')
+        parser.add_bpmn_file(bpmn)
+        parser.add_dmn_file(dmn)
+        self.spec = parser.get_spec('Process_1')
+        self.workflow = BpmnWorkflow(self.spec)
+
+    def testConstructor(self):
+        pass  # this is accomplished through setup.
+
+    def testDmnHappy(self):
+        self.workflow = BpmnWorkflow(self.spec)
+        self.workflow.get_tasks(Task.READY)[0].set_data(x=3)
+        self.workflow.do_engine_steps()
+        self.assertDictEqual(self.workflow.data, {'x': 3, 'y': 'A'})
+        self.assertDictEqual(self.workflow.last_task.data, {'x': 3, 'y': 'A'})
+
+    def testDmnSaveRestore(self):
+        self.workflow = BpmnWorkflow(self.spec)
+        self.workflow.get_tasks(Task.READY)[0].set_data(x=3)
+        self.save_restore()
+        self.workflow.do_engine_steps()
+        self.save_restore()
+        self.assertDictEqual(self.workflow.data, {'x': 3, 'y': 'A'})
+        self.assertDictEqual(self.workflow.last_task.data, {'x': 3, 'y': 'A'})
+
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelBusinessRuleTaskParserTest)
+
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelDateDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelDateDecisionTest.py
@@ -1,0 +1,41 @@
+import unittest
+from datetime import datetime
+
+from SpiffWorkflow.dmn.parser.DMNParser import DMNParser
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelDateDecisionTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = DecisionRunner('date_decision_feel.dmn', debug='DEBUG')
+
+    def test_date_decision_string_output1(self):
+        res = self.runner.decide(datetime.strptime('2017-11-01T10:00:00', DMNParser.DT_FORMAT))
+        self.assertEqual(res.description, '111 Row Annotation')
+
+    def test_date_decision_string_output2(self):
+        res = self.runner.decide(datetime.strptime('2017-11-03T00:00:00', DMNParser.DT_FORMAT))
+        self.assertEqual(res.description, '311 Row Annotation')
+
+    def test_date_decision_string_output3(self):
+        res = self.runner.decide(datetime.strptime('2017-11-02T00:00:00', DMNParser.DT_FORMAT))
+        self.assertEqual(res.description, '<3.11 Row Annotation')
+
+    def test_date_decision_string_output4(self):
+        res = self.runner.decide(datetime.strptime('2017-11-04T00:00:00', DMNParser.DT_FORMAT))
+        self.assertEqual(res.description, '>3.11 Row Annotation')
+
+    def test_date_decision_string_output5(self):
+        res = self.runner.decide(datetime.strptime('2017-11-13T12:00:00', DMNParser.DT_FORMAT))
+        self.assertEqual(res.description, '>13.11<14.11 Row Annotation')
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelDateDecisionTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelDictDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelDictDecisionTest.py
@@ -1,0 +1,36 @@
+import unittest
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelDictDecisionTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = DecisionRunner('dict_decision_feel.dmn', debug='DEBUG')
+
+    def test_string_decision_string_output1(self):
+        data = {"allergies": {
+                "PEANUTS": {"delicious": True},
+                "SPAM": {"delicious": False}
+                }}
+        res = self.runner.decide(data)
+        self.assertEqual(res.description, 'They are allergic to peanuts')
+
+    def test_string_decision_string_output2(self):
+        data = {"allergies": {
+                "SpAm": {"delicious": False},
+                "SPAM": {"delicious": False}
+                }}
+        res = self.runner.decide(data)
+        self.assertEqual(res.description, 'They are not allergic to peanuts')
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelDictDecisionTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelDictDotNotationDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelDictDotNotationDecisionTest.py
@@ -1,0 +1,45 @@
+import unittest
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelDictDotNotationDecisionTestClass(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = DecisionRunner('dict_dot_notation_decision_feel.dmn', debug='DEBUG')
+
+    def test_string_decision_string_output1(self):
+        data = {"foods": {
+            "spam": {"delicious": False}
+        }}
+        res = self.runner.decide(data)
+        self.assertEqual(res.description, 'This person has a tongue, brain '
+                                          'or sense of smell.')
+
+    data = {"foods": {
+        "spam": {"delicious": False}
+    }}
+    def test_string_decision_string_output2(self):
+        data = {"foods": {
+            "spam": {"delicious": True}
+        }}
+        res = self.runner.decide(data)
+        self.assertEqual(res.description, 'This person is lacking many '
+                                          'critical decision making skills, '
+                                          'or is a viking.')
+
+    def test_string_decision_with_kwargs(self):
+        data = {"foods": {
+            "spam": {"delicious": False}
+        }}
+        res = self.runner.decide({}, **data)
+        self.assertEqual(res.description, 'This person has a tongue, brain '
+                                          'or sense of smell.')
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelDictDotNotationDecisionTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelIntegerDecisionComparisonTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelIntegerDecisionComparisonTest.py
@@ -1,0 +1,31 @@
+import unittest
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelIntegerDecisionComparisonTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = DecisionRunner('integer_decision_comparison_feel.dmn', debug='DEBUG')
+
+    def test_integer_decision_string_output1(self):
+        res = self.runner.decide(30)
+        self.assertEqual(res.description, '30 Row Annotation')
+
+    def test_integer_decision_string_output2(self):
+        res = self.runner.decide(24)
+        self.assertEqual(res.description, 'L Row Annotation')
+
+    def test_integer_decision_string_output3(self):
+        res = self.runner.decide(25)
+        self.assertEqual(res.description, 'H Row Annotation')
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelIntegerDecisionComparisonTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelIntegerDecisionRangeTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelIntegerDecisionRangeTest.py
@@ -1,0 +1,75 @@
+import unittest
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelIntegerDecisionRangeTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    def test_integer_decision_string_output_inclusive(self):
+        runner = DecisionRunner('integer_decision_range_inclusive_feel.dmn', debug='DEBUG')
+
+        res = runner.decide(100)
+        self.assertEqual(res.description, '100-110 Inclusive Annotation')
+
+        res = runner.decide(99)
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(110)
+        self.assertEqual(res.description, '100-110 Inclusive Annotation')
+
+        res = runner.decide(111)
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+    def test_integer_decision_string_output_exclusive(self):
+        runner = DecisionRunner('integer_decision_range_exclusive_feel.dmn', debug='DEBUG')
+
+        res = runner.decide(100)
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(101)
+        self.assertEqual(res.description, '100-110 Exclusive Annotation')
+
+        res = runner.decide(110)
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(109)
+        self.assertEqual(res.description, '100-110 Exclusive Annotation')
+
+    def test_integer_decision_string_output_excl_inclusive(self):
+        runner = DecisionRunner('integer_decision_range_excl_inclusive_feel.dmn', debug='DEBUG')
+
+        res = runner.decide(100)
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(101)
+        self.assertEqual(res.description, '100-110 ExclInclusive Annotation')
+
+        res = runner.decide(110)
+        self.assertEqual(res.description, '100-110 ExclInclusive Annotation')
+
+        res = runner.decide(111)
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+    def test_integer_decision_string_output_incl_exclusive(self):
+        runner = DecisionRunner('integer_decision_range_incl_exclusive_feel.dmn', debug='DEBUG')
+
+        res = runner.decide(100)
+        self.assertEqual(res.description, '100-110 InclExclusive Annotation')
+
+        res = runner.decide(99)
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(110)
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(109)
+        self.assertEqual(res.description, '100-110 InclExclusive Annotation')
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelIntegerDecisionRangeTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelKwargsParameterTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelKwargsParameterTest.py
@@ -1,0 +1,23 @@
+import unittest
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelStringDecisionTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = DecisionRunner('kwargs_parameter_feel.dmn', debug='DEBUG')
+
+    def test_string_decision_string_output1(self):
+        res = self.runner.decide(Gender='m')
+        self.assertEqual(res.description, 'm Row Annotation')
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelStringDecisionTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelListDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelListDecisionTest.py
@@ -1,0 +1,28 @@
+import unittest
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelListDecisionTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = DecisionRunner('list_decision_feel.dmn', debug='DEBUG')
+
+    def test_string_decision_string_output1(self):
+        res = self.runner.decide(["PEANUTS", "SPAM"])
+        self.assertEqual(res.description, 'They are allergic to peanuts')
+
+    def test_string_decision_string_output1(self):
+        res = self.runner.decide(["SPAM", "SPAM"])
+        self.assertEqual(res.description, 'They are not allergic to peanuts')
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelListDecisionTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelLongDoubleComparisonTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelLongDoubleComparisonTest.py
@@ -1,0 +1,33 @@
+import unittest
+
+from decimal import Decimal
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelLongOrDoubleDecisionTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = DecisionRunner('long_or_double_decision_comparison_feel.dmn', debug='DEBUG')
+
+    def test_long_or_double_decision_string_output1(self):
+        res = self.runner.decide(Decimal('30.5'))
+        self.assertEqual(res.description, '30.5 Row Annotation')
+
+    def test_long_or_double_decision_stringz_output2(self):
+        res = self.runner.decide(Decimal('25.3'))
+        self.assertEqual(res.description, 'L Row Annotation')
+
+    def test_long_or_double_decision_string_output3(self):
+        res = self.runner.decide(Decimal('25.4'))
+        self.assertEqual(res.description, 'H Row Annotation')
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelLongOrDoubleDecisionTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelLongOrDoubleRangeTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelLongOrDoubleRangeTest.py
@@ -1,0 +1,77 @@
+import unittest
+
+from decimal import Decimal
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelLongOrDoubleDecisionRangeTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    def test_long_or_double_decision_string_output_inclusive(self):
+        runner = DecisionRunner('long_or_double_decision_range_inclusive_feel.dmn', debug='DEBUG')
+
+        res = runner.decide(Decimal('100.05'))
+        self.assertEqual(res.description, '100.05-110.05 Inclusive Annotation')
+
+        res = runner.decide(Decimal('99'))
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(Decimal('110.05'))
+        self.assertEqual(res.description, '100.05-110.05 Inclusive Annotation')
+
+        res = runner.decide(Decimal('111'))
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+    def test_long_or_double_decision_string_output_exclusive(self):
+        runner = DecisionRunner('long_or_double_decision_range_exclusive_feel.dmn', debug='DEBUG')
+
+        res = runner.decide(Decimal('100.05'))
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(Decimal('101'))
+        self.assertEqual(res.description, '100.05-110.05 Exclusive Annotation')
+
+        res = runner.decide(Decimal('110.05'))
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(Decimal('109'))
+        self.assertEqual(res.description, '100.05-110.05 Exclusive Annotation')
+
+    def test_long_or_double_decision_string_output_excl_inclusive(self):
+        runner = DecisionRunner('long_or_double_decision_range_excl_inclusive_feel.dmn', debug='DEBUG')
+
+        res = runner.decide(Decimal('100.05'))
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(Decimal('101'))
+        self.assertEqual(res.description, '100.05-110.05 ExclInclusive Annotation')
+
+        res = runner.decide(Decimal('110.05'))
+        self.assertEqual(res.description, '100.05-110.05 ExclInclusive Annotation')
+
+        res = runner.decide(Decimal('111'))
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+    def test_long_or_double_decision_string_output_incl_exclusive(self):
+        runner = DecisionRunner('long_or_double_decision_range_incl_exclusive_feel.dmn', debug='DEBUG')
+
+        res = runner.decide(Decimal('100.05'))
+        self.assertEqual(res.description, '100.05-110.05 InclExclusive Annotation')
+
+        res = runner.decide(Decimal('99'))
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(Decimal('110.05'))
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+        res = runner.decide(Decimal('109'))
+        self.assertEqual(res.description, '100.05-110.05 InclExclusive Annotation')
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelLongOrDoubleDecisionRangeTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelNearMissNameTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelNearMissNameTest.py
@@ -1,0 +1,53 @@
+import unittest
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelNearMissTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.data = {
+            "Exclusive": [
+                {
+                    "ExclusiveSpaceRoomID": "121",
+                }
+            ],
+            "eXclusive": [
+                {
+                    "ExclusiveSpaceRoomID": "121",
+                }
+            ],
+            "EXCLUSIVE": [
+                {
+                    "ExclusiveSpaceRoomID": "121",
+                }
+            ],
+            "personnel": [
+                {
+                    "PersonnelType": "Faculty",
+                        "label": "Steven K Funkhouser (sf4d)",
+                        "value": "sf4d"
+                    }
+                ],
+
+            "shared": []
+        }
+
+        cls.runner = DecisionRunner('exclusive_feel.dmn', debug='DEBUG')
+
+    def test_string_decision_string_output1(self):
+        self.assertRaisesRegex(NameError,
+                               ".+\['Exclusive', 'eXclusive', 'EXCLUSIVE'\]\?",
+                               self.runner.decide,
+                               **self.data)
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelNearMissTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelStringDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelStringDecisionTest.py
@@ -1,0 +1,35 @@
+import unittest
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelStringDecisionTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = DecisionRunner('string_decision_feel.dmn', debug='DEBUG')
+
+    def test_string_decision_string_output1(self):
+        res = self.runner.decide('m')
+        self.assertEqual(res.description, 'm Row Annotation')
+
+    def test_string_decision_string_output2(self):
+        res = self.runner.decide('f')
+        self.assertEqual(res.description, 'f Row Annotation')
+
+    def test_string_decision_string_output3(self):
+        res = self.runner.decide('y')
+        self.assertEqual(res.description, 'NOT x Row Annotation')
+
+    def test_string_decision_string_output4(self):
+        res = self.runner.decide('x')
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelStringDecisionTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/FeelStringIntegerDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/FeelStringIntegerDecisionTest.py
@@ -1,0 +1,39 @@
+import unittest
+
+from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
+
+
+class FeelStringIntegerDecisionTestClass(unittest.TestCase):
+    """
+    Doc: https://docs.camunda.org/manual/7.7/user-guide/dmn-engine/
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = DecisionRunner('string_integer_decision_feel.dmn', debug='DEBUG')
+
+    def test_string_integer_decision_string_output1(self):
+        res = self.runner.decide('m', 30)
+        self.assertEqual(res.description, 'm30 Row Annotation')
+
+    def test_string_integer_decision_string_output2(self):
+        res = self.runner.decide('m', 24)
+        self.assertEqual(res.description, 'mL Row Annotation')
+
+    def test_string_integer_decision_string_output3(self):
+        res = self.runner.decide('m', 25)
+        self.assertEqual(res.description, 'mH Row Annotation')
+
+    def test_string_integer_decision_string_output4(self):
+        res = self.runner.decide('f', -1)
+        self.assertEqual(res.description, 'fL Row Annotation')
+
+    def test_string_integer_decision_string_output5(self):
+        res = self.runner.decide('x', 0)
+        self.assertEqual(res.description, 'ELSE Row Annotation')
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(FeelStringIntegerDecisionTestClass)
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/InvalidBusinessRuleTaskParserTest.py
+++ b/tests/SpiffWorkflow/dmn/InvalidBusinessRuleTaskParserTest.py
@@ -40,7 +40,7 @@ class BusinessRuleTaskParserTest(BpmnWorkflowTestCase):
             self.assertEquals("InvalidDecisionTaskId: Failed to execute "
                               "expression: 'spam' is '= 1' in the Row with "
                               "annotation 'This is complletely wrong.'"
-                              ", invalid syntax (<string>, line 5)",
+                              ", invalid syntax (<string>, line 1)",
                               str(we))
 
 def suite():

--- a/tests/SpiffWorkflow/dmn/data/BpmnDmn/test_integer_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/BpmnDmn/test_integer_decision_feel.dmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.4.1">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="x" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer">
+          <text></text>
+        </inputExpression>
+      </input>
+      <output id="output1" label="They Label Y" name="y" typeRef="string" />
+      <rule id="row-484867957-5">
+        <description>A Annotation</description>
+        <inputEntry id="UnaryTests_0vir5ok">
+          <text>3</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0dvud7t">
+          <text>"A"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-484867957-1">
+        <description>B Annotation</description>
+        <inputEntry id="UnaryTests_1ldsism">
+          <text>4</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_01n13q2">
+          <text>"B"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-484867957-3">
+        <description>C Annotation</description>
+        <inputEntry id="UnaryTests_0vf51t0">
+          <text>5</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0uvxx6a">
+          <text>"C"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>D Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text>&gt;= 6</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"D"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/InvalidBpmnDmn/invalid_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/InvalidBpmnDmn/invalid_decision_feel.dmn
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
-  <decision id="DictDecisionStringOutputTable" name="DictDotNotationDecisionStringOutput">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.4.1">
+  <decision id="InvalidDecisionId" name="InvalidDecision">
     <extensionElements>
       <biodi:bounds x="150" y="150" width="180" height="80" />
     </extensionElements>
     <decisionTable id="decisionTable">
-      <input id="input1" label="Spam is Delicious?">
-        <inputExpression id="inputExpression1" typeRef="boolean">
-          <text>foods.spam.delicious</text>
+      <input id="input1" label="Spam is Decimal?">
+        <inputExpression id="inputExpression1" typeRef="integer">
+          <text>spam</text>
         </inputExpression>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-484867957-5">
-        <description>This person is lacking many critical decision making skills, or is a viking.</description>
+        <description>This is complletely wrong.</description>
         <inputEntry id="UnaryTests_148tr41">
           <description>mGender Description</description>
-          <text>True</text>
+          <text>= 1</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0dvud7t">
           <text>"wrong"</text>
         </outputEntry>
       </rule>
       <rule id="DecisionRule_03tv1cj">
-        <description>This person has a tongue, brain or sense of smell.</description>
+        <description>so is this.</description>
         <inputEntry id="UnaryTests_0jrbm9a">
-          <text>False</text>
+          <text>&gt;= 100</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0irzqma">
-          <text>"correct, spam is not delicious"</text>
+          <text>"My cat's breath smells like cat food."</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/tests/SpiffWorkflow/dmn/data/bool_decision.dmn
+++ b/tests/SpiffWorkflow/dmn/data/bool_decision.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="IsItTrue">
@@ -8,24 +8,30 @@
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-484867957-7">
         <description>Y Row Annotation</description>
-        <inputEntry id="UnaryTests_0u4hmbg">        <text>true</text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["Yesss"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text>True</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"Yesss"</text>
+        </outputEntry>
       </rule>
       <rule id="row-683871130-2">
         <description>N Row Annotation</description>
-        <inputEntry id="UnaryTests_0ojl8ov">        <text>false</text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_0fifygd">        <text><![CDATA["Noooo"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0ojl8ov">
+          <text>False</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0fifygd">
+          <text>"Noooo"</text>
+        </outputEntry>
       </rule>
       <rule id="row-683871130-3">
         <description>ELSE Row Annotation</description>
-        <inputEntry id="UnaryTests_0tl5hup">        <text></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_1kybqmh">        <text><![CDATA["ELSE"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0tl5hup">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1kybqmh">
+          <text>"ELSE"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>

--- a/tests/SpiffWorkflow/dmn/data/bool_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/bool_decision_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="IsItTrue">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="boolean" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="boolean" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-484867957-7">

--- a/tests/SpiffWorkflow/dmn/data/bool_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/bool_decision_feel.dmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="IsItTrue">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="boolean" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="row-484867957-7">
+        <description>Y Row Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text>true</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["Yesss"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-683871130-2">
+        <description>N Row Annotation</description>
+        <inputEntry id="UnaryTests_0ojl8ov">        <text>false</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0fifygd">        <text><![CDATA["Noooo"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-683871130-3">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_0tl5hup">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_1kybqmh">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/date_decision.dmn
+++ b/tests/SpiffWorkflow/dmn/data/date_decision.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <decision id="DateDecisionStringOutputTable" name="DateDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="IsItTrue">
@@ -7,39 +7,49 @@
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-502775238-5">
-        <description><![CDATA[>13.11<14.11 Row Annotation]]></description>
-        <inputEntry id="UnaryTests_0q7rx4k">        <text><![CDATA[[date and time("2017-11-13T00:00:00")..date and time("2017-11-14T23:59:59")]]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_00m6gbt">        <text><![CDATA["between 13.11 and 14.11"]]></text>
-</outputEntry>
+        <description>&gt;13.11&lt;14.11 Row Annotation</description>
+        <inputEntry id="UnaryTests_0q7rx4k">
+          <text>datetime.datetime(2017,11,13) &lt;= ? &lt;= datetime.datetime(2017,11,14,23,59,59)</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_00m6gbt">
+          <text>"between 13.11 and 14.11"</text>
+        </outputEntry>
       </rule>
       <rule id="row-502775238-1">
         <description>111 Row Annotation</description>
-        <inputEntry id="UnaryTests_1do20j2">        <text><![CDATA[date and time("2017-11-01T10:00:00")]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_1ry9obz">        <text><![CDATA["01.11"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_1do20j2">
+          <text>datetime.datetime(2017,11,1,10)</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1ry9obz">
+          <text>"01.11"</text>
+        </outputEntry>
       </rule>
       <rule id="row-502775238-2">
         <description>311 Row Annotation</description>
-        <inputEntry id="UnaryTests_04t6ord">        <text><![CDATA[date and time("2017-11-03T00:00:00")]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_01qzmvd">        <text><![CDATA["03.11"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_04t6ord">
+          <text>datetime.datetime(2017,11,3)</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_01qzmvd">
+          <text>"03.11"</text>
+        </outputEntry>
       </rule>
       <rule id="row-502775238-3">
-        <description><![CDATA[<3.11 Row Annotation]]></description>
-        <inputEntry id="UnaryTests_0cqp9ng">        <text><![CDATA[< date and time("2017-11-03T00:00:00")]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_151jme3">        <text><![CDATA["before 03.11"]]></text>
-</outputEntry>
+        <description>&lt;3.11 Row Annotation</description>
+        <inputEntry id="UnaryTests_0cqp9ng">
+          <text>&lt; datetime.datetime(2017,11,3)</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_151jme3">
+          <text>"before 03.11"</text>
+        </outputEntry>
       </rule>
       <rule id="row-502775238-4">
-        <description><![CDATA[>3.11 Row Annotation]]></description>
-        <inputEntry id="UnaryTests_1ullm3d">        <text><![CDATA[> date and time("2017-11-03T00:00:00")]]></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_0wcu8m1">        <text><![CDATA["after 03.11"]]></text>
-</outputEntry>
+        <description>&gt;3.11 Row Annotation</description>
+        <inputEntry id="UnaryTests_1ullm3d">
+          <text>&gt; datetime.datetime(2017,11,3)</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0wcu8m1">
+          <text>"after 03.11"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>

--- a/tests/SpiffWorkflow/dmn/data/date_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/date_decision_feel.dmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="DateDecisionStringOutputTable" name="DateDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="IsItTrue">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="date" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="row-502775238-5">
+        <description><![CDATA[>13.11<14.11 Row Annotation]]></description>
+        <inputEntry id="UnaryTests_0q7rx4k">        <text><![CDATA[[date and time("2017-11-13T00:00:00")..date and time("2017-11-14T23:59:59")]]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_00m6gbt">        <text><![CDATA["between 13.11 and 14.11"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-502775238-1">
+        <description>111 Row Annotation</description>
+        <inputEntry id="UnaryTests_1do20j2">        <text><![CDATA[date and time("2017-11-01T10:00:00")]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_1ry9obz">        <text><![CDATA["01.11"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-502775238-2">
+        <description>311 Row Annotation</description>
+        <inputEntry id="UnaryTests_04t6ord">        <text><![CDATA[date and time("2017-11-03T00:00:00")]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_01qzmvd">        <text><![CDATA["03.11"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-502775238-3">
+        <description><![CDATA[<3.11 Row Annotation]]></description>
+        <inputEntry id="UnaryTests_0cqp9ng">        <text><![CDATA[< date and time("2017-11-03T00:00:00")]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_151jme3">        <text><![CDATA["before 03.11"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-502775238-4">
+        <description><![CDATA[>3.11 Row Annotation]]></description>
+        <inputEntry id="UnaryTests_1ullm3d">        <text><![CDATA[> date and time("2017-11-03T00:00:00")]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0wcu8m1">        <text><![CDATA["after 03.11"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/date_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/date_decision_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="DateDecisionStringOutputTable" name="DateDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="IsItTrue">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="date" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="date"  expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-502775238-5">

--- a/tests/SpiffWorkflow/dmn/data/dict_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/dict_decision_feel.dmn
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.4.1">
   <decision id="DictDecisionStringOutputTable" name="DictDecisionStringOutput">
     <extensionElements>
       <biodi:bounds x="150" y="150" width="180" height="80" />
     </extensionElements>
     <decisionTable id="decisionTable">
       <input id="input1" label="Allergy Keys">
-        <inputExpression id="inputExpression1" typeRef="string">
+        <inputExpression id="inputExpression1" typeRef="string" expressionLanguage="feel">
           <text>allergies.keys()</text>
         </inputExpression>
       </input>
@@ -15,7 +15,7 @@
         <description>They are allergic to peanuts</description>
         <inputEntry id="UnaryTests_148tr41">
           <description>mGender Description</description>
-          <text>"PEANUTS" in ?</text>
+          <text>contains("PEANUTS")</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0dvud7t">
           <text>"isPeanuts"</text>
@@ -24,7 +24,7 @@
       <rule id="DecisionRule_03tv1cj">
         <description>They are not allergic to peanuts</description>
         <inputEntry id="UnaryTests_0jrbm9a">
-          <text>"PEANUTS" not in ?</text>
+          <text>not contains("PEANUTS")</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0irzqma">
           <text>"IsNotPeanuts"</text>

--- a/tests/SpiffWorkflow/dmn/data/dict_dot_notation_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/dict_dot_notation_decision_feel.dmn
@@ -6,8 +6,8 @@
     </extensionElements>
     <decisionTable id="decisionTable">
       <input id="input1" label="Spam is Delicious?">
-        <inputExpression id="inputExpression1" typeRef="boolean">
-          <text>odd_foods.SPAM_LIKE.delicious</text>
+        <inputExpression id="inputExpression1" typeRef="boolean" expressionLanguage="feel">
+          <text>foods.spam.delicious</text>
         </inputExpression>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />

--- a/tests/SpiffWorkflow/dmn/data/dict_dot_notation_decision_weird_characters_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/dict_dot_notation_decision_weird_characters_feel.dmn
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.3">
   <decision id="DictDecisionStringOutputTable" name="DictDotNotationDecisionStringOutput">
     <extensionElements>
       <biodi:bounds x="150" y="150" width="180" height="80" />
     </extensionElements>
     <decisionTable id="decisionTable">
       <input id="input1" label="Spam is Delicious?">
-        <inputExpression id="inputExpression1" typeRef="boolean">
+        <inputExpression id="inputExpression1" typeRef="boolean" expressionLanguage="feel">
           <text>odd_foods.SPAM_LIKE.delicious</text>
         </inputExpression>
       </input>
@@ -15,7 +15,7 @@
         <description>This person is lacking many critical decision making skills, or is a viking.</description>
         <inputEntry id="UnaryTests_148tr41">
           <description>mGender Description</description>
-          <text>True</text>
+          <text>true</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0dvud7t">
           <text>"wrong"</text>
@@ -24,7 +24,7 @@
       <rule id="DecisionRule_03tv1cj">
         <description>This person has a tongue, brain or sense of smell.</description>
         <inputEntry id="UnaryTests_0jrbm9a">
-          <text>False</text>
+          <text>false</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0irzqma">
           <text>"correct, spam is not delicious"</text>

--- a/tests/SpiffWorkflow/dmn/data/exclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/exclusive_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="Decision_ExclusiveAMCheck" name="Exclusive AM Check">
     <decisionTable id="decisionTable_1">
       <input id="input_1" label="Number of Exclusive Spaces Without Area Monitor">
-        <inputExpression id="inputExpression_1" typeRef="integer" expressionLanguage="feel" expressionLanguage="feel">
+        <inputExpression id="inputExpression_1" typeRef="integer" expressionLanguage="feel">
           <text>sum([1 for x in exclusive if x.ExclusiveSpaceAMComputingID is None])</text>
         </inputExpression>
       </input>

--- a/tests/SpiffWorkflow/dmn/data/exclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/exclusive_feel.dmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="Definitions_06veek1" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <decision id="Decision_ExclusiveAMCheck" name="Exclusive AM Check">
+    <decisionTable id="decisionTable_1">
+      <input id="input_1" label="Number of Exclusive Spaces Without Area Monitor">
+        <inputExpression id="inputExpression_1" typeRef="integer" expressionLanguage="feel" expressionLanguage="feel">
+          <text>sum([1 for x in exclusive if x.ExclusiveSpaceAMComputingID is None])</text>
+        </inputExpression>
+      </input>
+      <output id="output_1" label="All Exclusive Area Monitors Entered" name="all_exclusive_area_monitor" typeRef="boolean" />
+      <rule id="DecisionRule_07162mr">
+        <description>No exclusive spaces without Area Monitor</description>
+        <inputEntry id="UnaryTests_1jqxc3u">
+          <text>0</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_16l50ps">
+          <text>true</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0ifa4wu">
+        <description>More than one exclusive space without an Area Monitor</description>
+        <inputEntry id="UnaryTests_0szbwxc">
+          <text>&gt; 0</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0td8sa6">
+          <text>false</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_comparison_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_comparison_feel.dmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="Age">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="row-484867957-5">
+        <description>30 Row Annotation</description>
+        <inputEntry id="UnaryTests_0vir5ok">        <text>30</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0dvud7t">        <text><![CDATA["30"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-1">
+        <description>L Row Annotation</description>
+        <inputEntry id="UnaryTests_1ldsism">        <text><![CDATA[< 25]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_01n13q2">        <text><![CDATA["low"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-3">
+        <description>H Row Annotation</description>
+        <inputEntry id="UnaryTests_0vf51t0">        <text><![CDATA[>= 25]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0uvxx6a">        <text><![CDATA["high"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_comparison_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_comparison_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-484867957-5">

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_excl_inclusive.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_excl_inclusive.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
@@ -8,17 +8,21 @@
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="table-341529265-2">
         <description>100-110 ExclInclusive Annotation</description>
-        <inputEntry id="UnaryTests_1x7wp9y">        <text>]100..110]</text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_1t3s8ih">        <text><![CDATA["100-110 ExclInclusive"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_1x7wp9y">
+          <text>100 &lt; ? &lt;= 110</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1t3s8ih">
+          <text>"100-110 ExclInclusive"</text>
+        </outputEntry>
       </rule>
       <rule id="row-484867957-7">
         <description>ELSE Row Annotation</description>
-        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"ELSE"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_excl_inclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_excl_inclusive_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="table-341529265-2">

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_excl_inclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_excl_inclusive_feel.dmn
@@ -3,16 +3,16 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" />
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
-      <rule id="row-650602887-1">
-        <description>100.05-110.05 Exclusive Annotation</description>
-        <inputEntry id="UnaryTests_06vadwt">
-          <text>Decimal('100.05') &lt; ? &lt; Decimal('110.05')</text>
+      <rule id="table-341529265-2">
+        <description>100-110 ExclInclusive Annotation</description>
+        <inputEntry id="UnaryTests_1x7wp9y">
+          <text>]100..110]</text>
         </inputEntry>
-        <outputEntry id="LiteralExpression_0kqckzk">
-          <text>"100.05-110.05 Exclusive"</text>
+        <outputEntry id="LiteralExpression_1t3s8ih">
+          <text>"100-110 ExclInclusive"</text>
         </outputEntry>
       </rule>
       <rule id="row-484867957-7">

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_exclusive.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_exclusive.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
@@ -8,17 +8,21 @@
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-650602887-1">
         <description>100-110 Exclusive Annotation</description>
-        <inputEntry id="UnaryTests_06vadwt">        <text>]100..110[</text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_0kqckzk">        <text><![CDATA["100-110 Exclusive"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_06vadwt">
+          <text>100 &lt; ? &lt; 110</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0kqckzk">
+          <text>"100-110 Exclusive"</text>
+        </outputEntry>
       </rule>
       <rule id="row-484867957-7">
         <description>ELSE Row Annotation</description>
-        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"ELSE"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_exclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_exclusive_feel.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="Age">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="row-650602887-1">
+        <description>100-110 Exclusive Annotation</description>
+        <inputEntry id="UnaryTests_06vadwt">        <text>]100..110[</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0kqckzk">        <text><![CDATA["100-110 Exclusive"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_exclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_exclusive_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-650602887-1">

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_incl_exclusive.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_incl_exclusive.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
@@ -8,17 +8,21 @@
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="table-341529265-1">
         <description>100-110 InclExclusive Annotation</description>
-        <inputEntry id="UnaryTests_19j7lob">        <text>[100..110[</text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_1fqeqhb">        <text><![CDATA["100-110 InclExclusive"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_19j7lob">
+          <text>100 &lt;= ? &lt; 110</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1fqeqhb">
+          <text>"100-110 InclExclusive"</text>
+        </outputEntry>
       </rule>
       <rule id="row-484867957-7">
         <description>ELSE Row Annotation</description>
-        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"ELSE"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_incl_exclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_incl_exclusive_feel.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="Age">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="table-341529265-1">
+        <description>100-110 InclExclusive Annotation</description>
+        <inputEntry id="UnaryTests_19j7lob">        <text>[100..110[</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_1fqeqhb">        <text><![CDATA["100-110 InclExclusive"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_incl_exclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_incl_exclusive_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="table-341529265-1">

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_inclusive.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_inclusive.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
@@ -8,17 +8,21 @@
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-650602887-2">
         <description>100-110 Inclusive Annotation</description>
-        <inputEntry id="UnaryTests_0b406cl">        <text>[100..110]</text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_07uniir">        <text><![CDATA["100-110 Inclusive"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0b406cl">
+          <text>100 &lt;= ? &lt;= 110</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_07uniir">
+          <text>"100-110 Inclusive"</text>
+        </outputEntry>
       </rule>
       <rule id="row-484867957-7">
         <description>ELSE Row Annotation</description>
-        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"ELSE"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_inclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_inclusive_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-650602887-2">

--- a/tests/SpiffWorkflow/dmn/data/integer_decision_range_inclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/integer_decision_range_inclusive_feel.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="Age">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="row-650602887-2">
+        <description>100-110 Inclusive Annotation</description>
+        <inputEntry id="UnaryTests_0b406cl">        <text>[100..110]</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_07uniir">        <text><![CDATA["100-110 Inclusive"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/kwargs_parameter_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/kwargs_parameter_feel.dmn
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.4.1">
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="input1" label="Gender">
-        <inputExpression id="inputExpression1" typeRef="string">
-          <text></text>
+        <inputExpression id="inputExpression1" typeRef="string" expressionLanguage="feel">
+          <text>Gender</text>
         </inputExpression>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
@@ -25,15 +25,6 @@
         </inputEntry>
         <outputEntry id="LiteralExpression_16njszh">
           <text>"isF"</text>
-        </outputEntry>
-      </rule>
-      <rule id="row-650602887-3">
-        <description>NOT x Row Annotation</description>
-        <inputEntry id="UnaryTests_1n7idt8">
-          <text>? != "x"</text>
-        </inputEntry>
-        <outputEntry id="LiteralExpression_15pr8b4">
-          <text>"notX"</text>
         </outputEntry>
       </rule>
       <rule id="row-484867957-7">

--- a/tests/SpiffWorkflow/dmn/data/list_decision.dmn
+++ b/tests/SpiffWorkflow/dmn/data/list_decision.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.4.1">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <decision id="ListDecisionStringOutputTable" name="ListDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="input1" label="allergies">
@@ -12,7 +12,7 @@
         <description>They are allergic to peanuts</description>
         <inputEntry id="UnaryTests_148tr41">
           <description>mGender Description</description>
-          <text>contains("PEANUTS")</text>
+          <text>"PEANUTS" in ?</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0dvud7t">
           <text>"isPeanuts"</text>
@@ -21,7 +21,7 @@
       <rule id="DecisionRule_03tv1cj">
         <description>They are not allergic to peanuts</description>
         <inputEntry id="UnaryTests_0jrbm9a">
-          <text>not contains("PEANUTS") </text>
+          <text>"PEANUTS" not in ?</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0irzqma">
           <text>"IsNotPeanuts"</text>

--- a/tests/SpiffWorkflow/dmn/data/list_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/list_decision_feel.dmn
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/1.0" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
-  <decision id="DictDecisionStringOutputTable" name="DictDecisionStringOutput">
-    <extensionElements>
-      <biodi:bounds x="150" y="150" width="180" height="80" />
-    </extensionElements>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.4.1">
+  <decision id="ListDecisionStringOutputTable" name="ListDecisionStringOutput">
     <decisionTable id="decisionTable">
-      <input id="input1" label="Allergy Keys">
-        <inputExpression id="inputExpression1" typeRef="string">
-          <text>allergies.keys()</text>
+      <input id="input1" label="allergies">
+        <inputExpression id="inputExpression1" typeRef="string" expressionLanguage="feel">
+          <text></text>
         </inputExpression>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
@@ -15,7 +12,7 @@
         <description>They are allergic to peanuts</description>
         <inputEntry id="UnaryTests_148tr41">
           <description>mGender Description</description>
-          <text>"PEANUTS" in ?</text>
+          <text>contains("PEANUTS")</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0dvud7t">
           <text>"isPeanuts"</text>
@@ -24,7 +21,7 @@
       <rule id="DecisionRule_03tv1cj">
         <description>They are not allergic to peanuts</description>
         <inputEntry id="UnaryTests_0jrbm9a">
-          <text>"PEANUTS" not in ?</text>
+          <text>not contains("PEANUTS") </text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0irzqma">
           <text>"IsNotPeanuts"</text>

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_comparison_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_comparison_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="LODDecisionStringOutputTable" name="LODDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="long" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="long" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-484867957-5">

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_comparison_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_comparison_feel.dmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="LODDecisionStringOutputTable" name="LODDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="Age">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="long" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="row-484867957-5">
+        <description>30.5 Row Annotation</description>
+        <inputEntry id="UnaryTests_0vir5ok">        <text>30.5</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0dvud7t">        <text><![CDATA["30.5"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-1">
+        <description>L Row Annotation</description>
+        <inputEntry id="UnaryTests_1ldsism">        <text><![CDATA[< 25.4]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_01n13q2">        <text><![CDATA["low"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-3">
+        <description>H Row Annotation</description>
+        <inputEntry id="UnaryTests_0vf51t0">        <text><![CDATA[>= 25.4]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0uvxx6a">        <text><![CDATA["high"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_excl_inclusive.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_excl_inclusive.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
@@ -8,17 +8,21 @@
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="table-341529265-2">
         <description>100.05-110.05 ExclInclusive Annotation</description>
-        <inputEntry id="UnaryTests_1x7wp9y">        <text>]100.05..110.05]</text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_1t3s8ih">        <text><![CDATA["100.05-110.05 ExclInclusive"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_1x7wp9y">
+          <text>Decimal('100.05') &lt; ? &lt;= Decimal('110.05')</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1t3s8ih">
+          <text>"100.05-110.05 ExclInclusive"</text>
+        </outputEntry>
       </rule>
       <rule id="row-484867957-7">
         <description>ELSE Row Annotation</description>
-        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"ELSE"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_excl_inclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_excl_inclusive_feel.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="Age">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="table-341529265-2">
+        <description>100.05-110.05 ExclInclusive Annotation</description>
+        <inputEntry id="UnaryTests_1x7wp9y">        <text>]100.05..110.05]</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_1t3s8ih">        <text><![CDATA["100.05-110.05 ExclInclusive"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_excl_inclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_excl_inclusive_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="table-341529265-2">

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_exclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_exclusive_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-650602887-1">

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_exclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_exclusive_feel.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="Age">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="row-650602887-1">
+        <description>100.05-110.05 Exclusive Annotation</description>
+        <inputEntry id="UnaryTests_06vadwt">        <text>]100.05..110.05[</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0kqckzk">        <text><![CDATA["100.05-110.05 Exclusive"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_incl_exclusive.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_incl_exclusive.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
@@ -8,17 +8,21 @@
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="table-341529265-1">
         <description>100.05-110.05 InclExclusive Annotation</description>
-        <inputEntry id="UnaryTests_19j7lob">        <text>[100.05..110.05[</text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_1fqeqhb">        <text><![CDATA["100.05-110.05 InclExclusive"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_19j7lob">
+          <text>100.05 &lt;= ? &lt; 110.05</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1fqeqhb">
+          <text>"100.05-110.05 InclExclusive"</text>
+        </outputEntry>
       </rule>
       <rule id="row-484867957-7">
         <description>ELSE Row Annotation</description>
-        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"ELSE"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_incl_exclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_incl_exclusive_feel.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="Age">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="table-341529265-1">
+        <description>100.05-110.05 InclExclusive Annotation</description>
+        <inputEntry id="UnaryTests_19j7lob">        <text>[100.05..110.05[</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_1fqeqhb">        <text><![CDATA["100.05-110.05 InclExclusive"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_incl_exclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_incl_exclusive_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="table-341529265-1">

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_inclusive.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_inclusive.dmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
@@ -8,17 +8,21 @@
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-650602887-2">
         <description>100.05-110.05 Inclusive Annotation</description>
-        <inputEntry id="UnaryTests_0b406cl">        <text>[100.05..110.05]</text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_07uniir">        <text><![CDATA["100.05-110.05 Inclusive"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0b406cl">
+          <text>Decimal('100.05') &lt;= ? &lt;= Decimal('110.05')</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_07uniir">
+          <text>"100.05-110.05 Inclusive"</text>
+        </outputEntry>
       </rule>
       <rule id="row-484867957-7">
         <description>ELSE Row Annotation</description>
-        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
-</inputEntry>
-        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
-</outputEntry>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"ELSE"</text>
+        </outputEntry>
       </rule>
     </decisionTable>
   </decision>

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_inclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_inclusive_feel.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="Age">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="row-650602887-2">
+        <description>100.05-110.05 Inclusive Annotation</description>
+        <inputEntry id="UnaryTests_0b406cl">        <text>[100.05..110.05]</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_07uniir">        <text><![CDATA["100.05-110.05 Inclusive"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_inclusive_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/long_or_double_decision_range_inclusive_feel.dmn
@@ -3,7 +3,7 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="double" expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-650602887-2">

--- a/tests/SpiffWorkflow/dmn/data/string_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/string_decision_feel.dmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="input1" label="Gender">
+        <inputExpression id="inputExpression1" typeRef="string">        <text></text expressionLanguage="feel">
+</inputExpression>
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="row-484867957-5">
+        <description>m Row Annotation</description>
+        <inputEntry id="UnaryTests_148tr41">
+          <description>mGender Description</description>
+          <text><![CDATA["m"]]></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0dvud7t">        <text><![CDATA["isM"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-2">
+        <description>f Row Annotation</description>
+        <inputEntry id="UnaryTests_197hyvw">        <text><![CDATA["f"]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_16njszh">        <text><![CDATA["isF"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-650602887-3">
+        <description>NOT x Row Annotation</description>
+        <inputEntry id="UnaryTests_1n7idt8">        <text><![CDATA[not("x")]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_15pr8b4">        <text><![CDATA["notX"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_1swc6fh">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/string_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/string_decision_feel.dmn
@@ -3,8 +3,9 @@
   <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="input1" label="Gender">
-        <inputExpression id="inputExpression1" typeRef="string">        <text></text expressionLanguage="feel">
-</inputExpression>
+        <inputExpression id="inputExpression1" typeRef="string" expressionLanguage="feel">
+          <text></text> 
+	</inputExpression>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-484867957-5">

--- a/tests/SpiffWorkflow/dmn/data/string_integer_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/string_integer_decision_feel.dmn
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="StrIntegerDecisionStringOutputTable" name="StrIntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="input1" label="Gender">
+        <inputExpression id="inputExpression1" typeRef="string">        <text></text expressionLanguage="feel">
+</inputExpression>
+      </input>
+      <input id="InputClause_1tm0ceq" label="Age">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+      </input>
+      <output id="output1" label="Result" name="" typeRef="string" />
+      <rule id="row-484867957-5">
+        <description>m30 Row Annotation</description>
+        <inputEntry id="UnaryTests_148tr41">
+          <description>mGender Description</description>
+          <text><![CDATA["m"]]></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0vir5ok">        <text>30</text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0dvud7t">        <text><![CDATA["30"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-1">
+        <description>mL Row Annotation</description>
+        <inputEntry id="UnaryTests_06l79c1">        <text><![CDATA["m"]]></text>
+</inputEntry>
+        <inputEntry id="UnaryTests_1ldsism">        <text><![CDATA[< 25]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_01n13q2">        <text><![CDATA["mLow"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-3">
+        <description>mH Row Annotation</description>
+        <inputEntry id="UnaryTests_0epikzx">        <text><![CDATA["m"]]></text>
+</inputEntry>
+        <inputEntry id="UnaryTests_0vf51t0">        <text><![CDATA[>= 25]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_0uvxx6a">        <text><![CDATA["mHigh"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-2">
+        <description>fL Row Annotation</description>
+        <inputEntry id="UnaryTests_197hyvw">        <text><![CDATA["f"]]></text>
+</inputEntry>
+        <inputEntry id="UnaryTests_0boy770">        <text><![CDATA[< 20]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_16njszh">        <text><![CDATA["fLow"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-4">
+        <description>fH Row Annotation</description>
+        <inputEntry id="UnaryTests_0iv5y6t">        <text><![CDATA["f"]]></text>
+</inputEntry>
+        <inputEntry id="UnaryTests_1jecoo3">        <text><![CDATA[>= 20]]></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_1fnfw23">        <text><![CDATA["fHigh"]]></text>
+</outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>ELSE Row Annotation</description>
+        <inputEntry id="UnaryTests_1swc6fh">        <text></text>
+</inputEntry>
+        <inputEntry id="UnaryTests_0u4hmbg">        <text></text>
+</inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">        <text><![CDATA["ELSE"]]></text>
+</outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/tests/SpiffWorkflow/dmn/data/string_integer_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/string_integer_decision_feel.dmn
@@ -3,11 +3,13 @@
   <decision id="StrIntegerDecisionStringOutputTable" name="StrIntegerDecisionStringOutput">
     <decisionTable id="decisionTable">
       <input id="input1" label="Gender">
-        <inputExpression id="inputExpression1" typeRef="string">        <text></text expressionLanguage="feel">
-</inputExpression>
+        <inputExpression id="inputExpression1" typeRef="string" expressionLanguage="feel">
+
+	<text></text>
+	</inputExpression>
       </input>
       <input id="InputClause_1tm0ceq" label="Age">
-        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" / expressionLanguage="feel">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer"  expressionLanguage="feel"/>
       </input>
       <output id="output1" label="Result" name="" typeRef="string" />
       <rule id="row-484867957-5">

--- a/tests/SpiffWorkflow/dmn/data/test_integer_decision_feel.dmn
+++ b/tests/SpiffWorkflow/dmn/data/test_integer_decision_feel.dmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.4.1">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="x" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer" expressionLanguage="feel">
+          <text>x</text>
+        </inputExpression>
+      </input>
+      <output id="output1" label="y" name="" typeRef="string" />
+      <rule id="row-484867957-5">
+        <description>A Annotation</description>
+        <inputEntry id="UnaryTests_0vir5ok">
+          <text>3</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0dvud7t">
+          <text>"A"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-484867957-1">
+        <description>B Annotation</description>
+        <inputEntry id="UnaryTests_1ldsism">
+          <text>4</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_01n13q2">
+          <text>"B"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-484867957-3">
+        <description>C Annotation</description>
+        <inputEntry id="UnaryTests_0vf51t0">
+          <text>5</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0uvxx6a">
+          <text>"C"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>D Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text>&gt;= 6</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"D"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>


### PR DESCRIPTION
Extract out FEEL scripting engine and make default for all scripting to be python. 

DMN may use a ? for the input variable and then should resolve into a true/false expression 

Examples: 
100 < ? < 105 
'something' not in ?  # if ? is a list of strings  

Also, DMN now honors the expression language so that if it is set to 'feel' it patches up some selected FEEL expressions into a python equivalent with an eye towards a real feel parser sometime in the future.  

if the expressionLanguage is not feel, then it falls back to python 