### PR TITLE
126 dmn dict update

### DIFF
--- a/SpiffWorkflow/dmn/specs/BusinessRuleTask.py
+++ b/SpiffWorkflow/dmn/specs/BusinessRuleTask.py
@@ -3,7 +3,8 @@ from SpiffWorkflow.exceptions import WorkflowTaskExecException
 from SpiffWorkflow.specs import Simple
 
 from SpiffWorkflow.bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
-
+from box import Box
+from ...util.deep_merge import DeepMerge
 
 class BusinessRuleTask(Simple, BpmnSpecMixin):
     """
@@ -25,7 +26,8 @@ class BusinessRuleTask(Simple, BpmnSpecMixin):
             self.res = self.dmnEngine.decide(**my_task.data)
             if self.res is not None:  # it is conceivable that no rules fire.
                 self.resDict = self.res.outputAsDict(my_task.data)
-                my_task.data.update(self.resDict)
+                my_task.data = DeepMerge.merge(my_task.data,self.resDict)
+
             super(BusinessRuleTask, self)._on_complete_hook(my_task)
         except Exception as e:
             raise WorkflowTaskExecException(my_task, str(e))

--- a/SpiffWorkflow/dmn/specs/model.py
+++ b/SpiffWorkflow/dmn/specs/model.py
@@ -63,7 +63,17 @@ class Rule:
             # try to use the id, but fall back to label if no name is provided.
             key = outputEntry.output.name or outputEntry.output.label
             if hasattr(outputEntry, "parsedRef"):
-                out[key] = PythonScriptEngine().evaluate(outputEntry.parsedRef,**data)
+                outvalue = PythonScriptEngine().evaluate(outputEntry.parsedRef,**data)
             else:
-                out[key] = ""
+                outvalue = ""
+            if '.' in key:
+                currentout = {}
+                subkeylist = list(reversed(key.split('.')))
+                for subkey in subkeylist[:-1]:
+                    currentout[subkey] = outvalue
+                    outvalue = currentout
+                    currentout = {}
+                out[subkeylist[-1]] = outvalue
+            else:
+                out[key] = outvalue
         return out

--- a/SpiffWorkflow/dmn/specs/model.py
+++ b/SpiffWorkflow/dmn/specs/model.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.util.deep_merge import DeepMerge
+
 
 class Decision:
     def __init__(self, id, name):
@@ -66,14 +68,19 @@ class Rule:
                 outvalue = PythonScriptEngine().evaluate(outputEntry.parsedRef,**data)
             else:
                 outvalue = ""
-            if '.' in key:
+            if '.' in key:         # we need to allow for dot notation in the DMN -
+                                   # I would use box to do this, but they didn't have a feature to build
+                                   # a dict based on a dot notation withoug eval
+                                   # so we build up a dictionary structure based on the key, and let the parent
+                                   # do a deep merge
                 currentout = {}
                 subkeylist = list(reversed(key.split('.')))
                 for subkey in subkeylist[:-1]:
                     currentout[subkey] = outvalue
                     outvalue = currentout
                     currentout = {}
-                out[subkeylist[-1]] = outvalue
+                basekey = subkeylist[-1]
+                out[basekey] = DeepMerge.merge(out.get(basekey,{}),outvalue)
             else:
                 out[key] = outvalue
         return out

--- a/tests/SpiffWorkflow/dmn/DMNDictTest.py
+++ b/tests/SpiffWorkflow/dmn/DMNDictTest.py
@@ -1,0 +1,49 @@
+import os
+import unittest
+
+from SpiffWorkflow import Task
+
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+
+from SpiffWorkflow.dmn.parser.BpmnDmnParser import BpmnDmnParser
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+class DMNDictTest(BpmnWorkflowTestCase):
+    PARSER_CLASS = BpmnDmnParser
+
+    def setUp(self):
+        parser = BpmnDmnParser()
+        bpmn = os.path.join(os.path.dirname(__file__), 'data', 'BpmnDmn',
+                            'dmndict.bpmn')
+        dmn = os.path.join(os.path.dirname(__file__), 'data', 'BpmnDmn',
+                            'dmndict.dmn')
+        parser.add_bpmn_file(bpmn)
+        parser.add_dmn_file(dmn)
+        self.expectedResult = {'inputvar': 1,  'pi': {'test': {'me': 'yup it worked'}, 'test2': {'other': 'yes'}}}
+        self.spec = parser.get_spec('start')
+        self.workflow = BpmnWorkflow(self.spec)
+
+    def testConstructor(self):
+        pass  # this is accomplished through setup.
+
+    def testDmnHappy(self):
+        self.workflow = BpmnWorkflow(self.spec)
+        self.workflow.do_engine_steps()
+        self.assertDictEqual(self.workflow.last_task.data, self.expectedResult)
+
+    def testDmnSaveRestore(self):
+        self.workflow = BpmnWorkflow(self.spec)
+        self.save_restore()
+        self.workflow.do_engine_steps()
+        self.save_restore()
+        self.assertDictEqual(self.workflow.last_task.data, self.expectedResult)
+
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(DMNDictTest)
+
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/data/BpmnDmn/dmndict.bpmn
+++ b/tests/SpiffWorkflow/dmn/data/BpmnDmn/dmndict.bpmn
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0w1uo0r" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <bpmn:process id="Process_0k7ga4b" name="start" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0k348ph</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0k348ph" sourceRef="StartEvent_1" targetRef="Activity_1wejtm3" />
+    <bpmn:scriptTask id="Activity_1wejtm3" name="Set up Variable">
+      <bpmn:incoming>Flow_0k348ph</bpmn:incoming>
+      <bpmn:outgoing>Flow_03rcoxc</bpmn:outgoing>
+      <bpmn:script>pi = {'test':{'me':'stupid var'}}
+inputvar = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:businessRuleTask id="Activity_0zug9f0" name="Look It Up" camunda:decisionRef="DMNDict">
+      <bpmn:incoming>Flow_03rcoxc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0pvahf7</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:sequenceFlow id="Flow_03rcoxc" sourceRef="Activity_1wejtm3" targetRef="Activity_0zug9f0" />
+    <bpmn:endEvent id="Event_0w8dkiu">
+      <bpmn:incoming>Flow_0pvahf7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0pvahf7" sourceRef="Activity_0zug9f0" targetRef="Event_0w8dkiu" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0k7ga4b">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0k348ph_di" bpmnElement="Flow_0k348ph">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="240" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_172h5vr_di" bpmnElement="Activity_1wejtm3">
+        <dc:Bounds x="240" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1cb776x_di" bpmnElement="Activity_0zug9f0">
+        <dc:Bounds x="380" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_03rcoxc_di" bpmnElement="Flow_03rcoxc">
+        <di:waypoint x="340" y="117" />
+        <di:waypoint x="380" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0w8dkiu_di" bpmnElement="Event_0w8dkiu">
+        <dc:Bounds x="522" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0pvahf7_di" bpmnElement="Flow_0pvahf7">
+        <di:waypoint x="480" y="117" />
+        <di:waypoint x="522" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/dmn/data/BpmnDmn/dmndict.dmn
+++ b/tests/SpiffWorkflow/dmn/data/BpmnDmn/dmndict.dmn
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" id="Definitions_0yjq2a6" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <decision id="DMNDict" name="Decision 1">
+    <decisionTable id="decisionTable_1">
+      <input id="input_1">
+        <inputExpression id="inputExpression_1" typeRef="string">
+          <text>inputvar</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_0gy0y5t">
+        <inputExpression id="LiteralExpression_19zm8xe" typeRef="string">
+          <text></text>
+        </inputExpression>
+      </input>
+      <output id="output_1" label="Dict" name="pi.test.me" typeRef="string" />
+      <output id="OutputClause_0q2n70u" label="pi.test2.other" typeRef="string" />
+      <rule id="DecisionRule_1ai0obb">
+        <inputEntry id="UnaryTests_0q21xde">
+          <text>1</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_1i8rjqk">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_176nuh6">
+          <text>'yup it worked'</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1un6u7d">
+          <text>"yes"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_196hvi1">
+        <inputEntry id="UnaryTests_0cdk9qt">
+          <text>2</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0wt3lz9">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0sfxtys">
+          <text>'didnt expect this'</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1yydiab">
+          <text>"No"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0e6bx10">
+        <inputEntry id="UnaryTests_172x2jc">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_12q8xsl">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1ckh2r5">
+          <text></text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0zz2mo8">
+          <text></text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>


### PR DESCRIPTION
This fixes the problem with trying to update a dot notation dictionary from within DMN - tested for multiple dictionaries using the same base key i.e. 

x.y.z = something
x.y.a = something else

- should work if the dictionary is present previously or not.