### PR TITLE
Add the ability for a BusinessRuleTask or a ScriptTask to be a multii…

### DIFF
--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -90,6 +90,16 @@ class PythonScriptEngine(object):
         exp,valid = self.validateExpression(expression)
         return self._eval(exp, **kwargs,externalMethods=externalMethods)
 
+    def convertToBox(self,data):
+        for x in data.keys():
+            if isinstance(data[x],dict):
+                data[x] = Box(data[x])
+
+    def convertFromBox(self,data):
+        for x in data.keys():
+            if isinstance(data[x],Box):
+                data[x] = data[x].to_dict()
+
     def execute(self, task, script, data,externalMethods={}):
         """
         Execute the script, within the context of the specified task
@@ -98,15 +108,14 @@ class PythonScriptEngine(object):
 
         globals = self.globals
 
-        for x in data.keys():
-            if isinstance(data[x],dict):
-                data[x] = Box(data[x])
+        self.convertToBox(data)
         #data.update({'task':task}) # one of our legacy tests is looking at task.
                                    # this may cause a problem down the road if we
                                    # actually have a variable named 'task'
         globals.update(data)   # dict comprehensions cause problems when the variables are not viable.
         globals.update(externalMethods)
         exec(script,globals,data)
+        self.convertFromBox(data)
 
 
     def _eval(self, expression,externalMethods={}, **kwargs):

--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -22,9 +22,11 @@ import logging
 import sys
 import traceback
 from .ValidationException import ValidationException
+from ..specs.ScriptTask import ScriptTask
 from ..specs.UserTask import UserTask
 from ..specs.BoundaryEvent import _BoundaryEventParent
 from ..specs.MultiInstanceTask import getDynamicMIClass
+from ...dmn.specs.BusinessRuleTask import BusinessRuleTask
 from ...operators import Attrib, PathAttrib
 from .util import xpath_eval, one
 
@@ -121,7 +123,7 @@ class TaskParser(object):
             # that we do not expect. This list can be exapanded at a later
             # date To handle other use cases - don't forget the overridden
             # test classes!
-        if multiinstance and isinstance(self.task, UserTask):
+        if multiinstance and isinstance(self.task, (UserTask,BusinessRuleTask,ScriptTask)):
             loopcount = loopcount.replace('.',
                                           '/')  # make dot notation compatible
             # with bmpmn path notation.

--- a/tests/SpiffWorkflow/dmn/MultiInstanceDMNTest.py
+++ b/tests/SpiffWorkflow/dmn/MultiInstanceDMNTest.py
@@ -1,0 +1,50 @@
+import os
+import unittest
+
+from box import Box
+
+from SpiffWorkflow import Task
+
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+
+from SpiffWorkflow.dmn.parser.BpmnDmnParser import BpmnDmnParser
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+class MultiInstanceDMNTest(BpmnWorkflowTestCase):
+    PARSER_CLASS = BpmnDmnParser
+
+    def setUp(self):
+        parser = BpmnDmnParser()
+        bpmn = os.path.join(os.path.dirname(__file__), 'data', 'BpmnDmn',
+                            'DMNMultiInstance.bpmn')
+        dmn = os.path.join(os.path.dirname(__file__), 'data', 'BpmnDmn',
+                            'test_integer_decision_multi.dmn')
+        parser.add_bpmn_file(bpmn)
+        parser.add_dmn_file(dmn)
+        self.spec = parser.get_spec('Process_1')
+        self.workflow = BpmnWorkflow(self.spec)
+
+    def testConstructor(self):
+        pass  # this is accomplished through setup.
+
+    def testDmnHappy(self):
+        self.workflow = BpmnWorkflow(self.spec)
+        self.workflow.do_engine_steps()
+        self.assertEqual(self.workflow.data['stuff']['E']['y'], 'D')
+
+
+    def testDmnSaveRestore(self):
+        self.workflow = BpmnWorkflow(self.spec)
+        self.save_restore()
+        self.workflow.do_engine_steps()
+        self.save_restore()
+        self.assertEqual(self.workflow.data['stuff']['E']['y'], 'D')
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(MultiInstanceDMNTest)
+
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/dmn/data/BpmnDmn/DMNMultiInstance.bpmn
+++ b/tests/SpiffWorkflow/dmn/data/BpmnDmn/DMNMultiInstance.bpmn
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1b29lxw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_0n32cxd">
+      <bpmn:incoming>Flow_0fusz9y</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_06fnqj2" sourceRef="Task_067fajl" targetRef="Activity_0w0chd2" />
+    <bpmn:businessRuleTask id="Task_067fajl" name="Else Decision Table" camunda:decisionRef="IntegerDecisionStringOutputTable">
+      <bpmn:incoming>Flow_09ciw49</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_06fnqj2</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true" camunda:collection="stuff" camunda:elementVariable="item" />
+    </bpmn:businessRuleTask>
+    <bpmn:sequenceFlow id="Flow_1b29lxw" sourceRef="StartEvent_1" targetRef="Activity_0qh0jpg" />
+    <bpmn:sequenceFlow id="Flow_0fusz9y" sourceRef="Activity_0w0chd2" targetRef="EndEvent_0n32cxd" />
+    <bpmn:scriptTask id="Activity_0w0chd2" name="Print Stuff">
+      <bpmn:incoming>SequenceFlow_06fnqj2</bpmn:incoming>
+      <bpmn:outgoing>Flow_0fusz9y</bpmn:outgoing>
+      <bpmn:script>print('EndScript')
+print(stuff)</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_09ciw49" sourceRef="Activity_0qh0jpg" targetRef="Task_067fajl" />
+    <bpmn:scriptTask id="Activity_0qh0jpg" name="Setup">
+      <bpmn:documentation>This is a test
+of documentation</bpmn:documentation>
+      <bpmn:incoming>Flow_1b29lxw</bpmn:incoming>
+      <bpmn:outgoing>Flow_09ciw49</bpmn:outgoing>
+      <bpmn:script>stuff={'A': {'x': 3},                                                               
+       'B': {'x': 4},                                                              
+       'C': {'x': 5},                                                               
+       'D': {'x': 6},                                                        
+       'E': {'x': 7}}</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="122" y="106" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="164" y="322" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0n32cxd_di" bpmnElement="EndEvent_0n32cxd">
+        <dc:Bounds x="822" y="106" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="933" y="505" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_06fnqj2_di" bpmnElement="SequenceFlow_06fnqj2">
+        <di:waypoint x="460" y="124" />
+        <di:waypoint x="540" y="124" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="850" y="462" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BusinessRuleTask_1ipm12w_di" bpmnElement="Task_067fajl">
+        <dc:Bounds x="360" y="84" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1b29lxw_di" bpmnElement="Flow_1b29lxw">
+        <di:waypoint x="158" y="124" />
+        <di:waypoint x="210" y="124" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fusz9y_di" bpmnElement="Flow_0fusz9y">
+        <di:waypoint x="640" y="124" />
+        <di:waypoint x="822" y="124" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1uk7uyi_di" bpmnElement="Activity_0w0chd2">
+        <dc:Bounds x="540" y="84" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_09ciw49_di" bpmnElement="Flow_09ciw49">
+        <di:waypoint x="310" y="124" />
+        <di:waypoint x="360" y="124" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1v5khzq_di" bpmnElement="Activity_0qh0jpg">
+        <dc:Bounds x="210" y="84" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/dmn/data/BpmnDmn/test_integer_decision_multi.dmn
+++ b/tests/SpiffWorkflow/dmn/data/BpmnDmn/test_integer_decision_multi.dmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_1jblnbx" name="definitions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <decision id="IntegerDecisionStringOutputTable" name="IntegerDecisionStringOutput">
+    <decisionTable id="decisionTable">
+      <input id="InputClause_1tm0ceq" label="x" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_04o7chw" typeRef="integer">
+          <text>item.x</text>
+        </inputExpression>
+      </input>
+      <output id="output1" label="They Label Y" name="item.y" typeRef="string" />
+      <rule id="row-484867957-5">
+        <description>A Annotation</description>
+        <inputEntry id="UnaryTests_0vir5ok">
+          <text>3</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0dvud7t">
+          <text>"A"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-484867957-1">
+        <description>B Annotation</description>
+        <inputEntry id="UnaryTests_1ldsism">
+          <text>4</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_01n13q2">
+          <text>"B"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-484867957-3">
+        <description>C Annotation</description>
+        <inputEntry id="UnaryTests_0vf51t0">
+          <text>5</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0uvxx6a">
+          <text>"C"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-484867957-7">
+        <description>D Annotation</description>
+        <inputEntry id="UnaryTests_0u4hmbg">
+          <text>&gt;= 6</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_19qgvg3">
+          <text>"D"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>


### PR DESCRIPTION
…nstance.

Fix problem with serialize/deserialze where a Box object was in the data. This happened because we were converting any dict object in the data into a Box object before we evaluate python code as a convenience to the configurators. The solution was to convert them back to dictionaries right after the python expression engine ran.

Lastly, there was a bug for MI that was looking for a class of sometaskname_999 because these some nasty amalgam of a mi class and the underlying base class - typically camunda will give a class a name of Task_xxxxx where xxxx is an alphanumeric - but in this case it was Task_99xxx so it was finding that _99 part and striping the underscore. I may want to make this even less likely to clash See ticket # 254 about this

This fixes:250