### PR TITLE
Because we were using a version of the Camunda parser, we were using …

### DIFF
--- a/SpiffWorkflow/camunda/parser/UserTaskParser.py
+++ b/SpiffWorkflow/camunda/parser/UserTaskParser.py
@@ -18,7 +18,9 @@ class UserTaskParser(TaskParser):
     def create_task(self):
         form = self.get_form()
         return self.spec_class(self.spec, self.get_task_spec_name(), form,
-                               lane=self.get_lane(), description=self.node.get('name', None))
+                               lane=self.get_lane(),
+                               position=self.process_parser.get_coord(self.get_id()),
+                               description=self.node.get('name', None))
 
     def get_form(self):
         """Camunda provides a simple form builder, this will extract the


### PR DESCRIPTION
…a different version of UserTaskParser - the camunda one wasn't updating the position of the task when it was creating the task, so there wasn't any good information on the task to order it properly.

Fixes #309