### PR TITLE
326 multi file data store

### DIFF
--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -26,9 +26,11 @@ from ..specs.ScriptTask import ScriptTask
 from ..specs.UserTask import UserTask
 from ..specs.BoundaryEvent import _BoundaryEventParent
 from ..specs.MultiInstanceTask import getDynamicMIClass
+from ..specs.CallActivity import CallActivity
 from ...dmn.specs.BusinessRuleTask import BusinessRuleTask
 from ...operators import Attrib, PathAttrib
 from .util import xpath_eval, one
+from ...specs.SubWorkflow import SubWorkflow
 
 LOG = logging.getLogger(__name__)
 
@@ -123,7 +125,7 @@ class TaskParser(object):
             # that we do not expect. This list can be exapanded at a later
             # date To handle other use cases - don't forget the overridden
             # test classes!
-        if multiinstance and isinstance(self.task, (UserTask,BusinessRuleTask,ScriptTask)):
+        if multiinstance and isinstance(self.task, (UserTask,BusinessRuleTask,ScriptTask,CallActivity,SubWorkflow)):
             loopcount = loopcount.replace('.',
                                           '/')  # make dot notation compatible
             # with bmpmn path notation.
@@ -158,6 +160,7 @@ class TaskParser(object):
             #       MultiInstanceTask,self.task.__class__ ), {})
             self.task.multiInstance = multiinstance
             self.task.isSequential = isSequential
+
             if isLoop:
                 self.task.expanded = 25
             else:

--- a/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
+++ b/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
@@ -472,7 +472,10 @@ class MultiInstanceTask(TaskSpec):
 
     def _on_complete_hook(self, my_task):
         classes = self._build_class_names()
-        if my_task.task_spec.prevtaskclass in classes.keys():
+        terminate = self._get_loop_completion(my_task)
+        if my_task.task_spec.prevtaskclass in classes.keys() \
+            and not terminate:
+
             super()._on_complete_hook(my_task)
 
 

--- a/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
+++ b/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
@@ -8,11 +8,14 @@ import string
 from builtins import range
 from uuid import uuid4
 import re
+
+from .CallActivity import CallActivity
 from .ParallelGateway import ParallelGateway
 from .ScriptTask import ScriptTask
 from ...dmn.specs.BusinessRuleTask import BusinessRuleTask
 from ...exceptions import WorkflowException, WorkflowTaskExecException
 from ...operators import valueof, is_number
+from ...specs import SubWorkflow
 from ...specs.base import TaskSpec
 from ...util.impl import get_class
 # Copyright (C) 2020 Sartography
@@ -113,6 +116,14 @@ class MultiInstanceTask(TaskSpec):
             []):
             raise WorkflowTaskExecException(my_task,
                                     'If we are updating a collection, then the collection must be a dictionary.')
+
+    def _get_loop_completion(self,my_task):
+        if not self.completioncondition == None:
+            terminate = my_task.workflow.script_engine.evaluate(my_task,self.completioncondition)
+            if terminate:
+                my_task.terminate_current_loop = True
+            return terminate
+        return False
 
     def _get_count(self, my_task):
         """
@@ -446,13 +457,17 @@ class MultiInstanceTask(TaskSpec):
                         current_task_spec = new_task_spec
 
         outputs += self.outputs
-        if my_task._is_definite():
-            my_task._sync_children(outputs, Task.FUTURE)
+        if isinstance(my_task.task_spec,CallActivity):
+            super(MultiInstanceTask,self)._predict_hook(my_task)
+            #CallActivity()._predict_hook(my_task)
         else:
-            my_task._sync_children(outputs, Task.LIKELY)
+            if my_task._is_definite():
+                my_task._sync_children(outputs, Task.FUTURE)
+            else:
+                my_task._sync_children(outputs, Task.LIKELY)
 
     def _build_class_names(self):
-        classes = [BusinessRuleTask,ScriptTask]
+        classes = [BusinessRuleTask,ScriptTask,CallActivity,SubWorkflow]
         return {x.__module__ + "."+x.__name__:x for x in classes}
 
     def _on_complete_hook(self, my_task):
@@ -479,7 +494,7 @@ class MultiInstanceTask(TaskSpec):
         if self.collection is not None and \
             self.times.name == self.collection.name:
             keys = list(collect.keys())
-            if len(keys)<runtimes:
+            if len(keys) < runtimes:
                 msg = f"There is a mismatch between runtimes and the number " \
                       f"items in the collection, please check for empty " \
                       f"collection {self.collection.name}."
@@ -496,7 +511,7 @@ class MultiInstanceTask(TaskSpec):
         LOG.debug(my_task.task_spec.name + 'complete hook')
         my_task.data = DeepMerge.merge(my_task.data,
                                        gendict(colvarname.split('/'), collect))
-
+        #self._get_loop_completion(my_task)
         if (runtimes < runcount) and not \
             my_task.terminate_current_loop and \
             self.loopTask:
@@ -538,7 +553,8 @@ class MultiInstanceTask(TaskSpec):
         outputs = []
         outputs += self.outputs
 
-        my_task._sync_children(outputs, Task.FUTURE)
+        if not isinstance(my_task.task_spec,CallActivity):
+            my_task._sync_children(outputs, Task.FUTURE)
 
         for child in my_task.children:
             child.task_spec._update(child)

--- a/SpiffWorkflow/navigation.py
+++ b/SpiffWorkflow/navigation.py
@@ -3,6 +3,7 @@ import copy
 from . import WorkflowException
 from .bpmn.specs.EndEvent import EndEvent
 from .bpmn.specs.ExclusiveGateway import ExclusiveGateway
+from .bpmn.specs.IntermediateThrowEvent import IntermediateThrowEvent
 from .bpmn.specs.ManualTask import ManualTask
 from .bpmn.specs.NoneTask import NoneTask
 from .bpmn.specs.ParallelGateway import ParallelGateway
@@ -52,7 +53,7 @@ class NavItem(object):
                  ScriptTask, StartTask, EndEvent, StartEvent,
                  MultiInstanceTask, StartEvent, SequenceFlow,
                  ExclusiveGateway, ParallelGateway, CallActivity,
-                 UnstructuredJoin, NoneTask, BoundaryEvent]
+                 UnstructuredJoin, NoneTask, BoundaryEvent, IntermediateThrowEvent]
         spec_type = None
         for t in types:
             if isinstance(spec, t):

--- a/SpiffWorkflow/specs/SubWorkflow.py
+++ b/SpiffWorkflow/specs/SubWorkflow.py
@@ -128,7 +128,8 @@ class SubWorkflow(TaskSpec):
         # Assign variables, if so requested.
         for child in my_task.children:
             if subworkflow.last_task is not None:
-                child.data.update(subworkflow.last_task.data)
+                my_task.data.update(subworkflow.data)
+                #child.data.update(subworkflow.last_task.data)
             if child.task_spec in self.outputs:
                 for assignment in self.out_assign:
                     assignment.assign(subworkflow, child)

--- a/SpiffWorkflow/specs/SubWorkflow.py
+++ b/SpiffWorkflow/specs/SubWorkflow.py
@@ -128,8 +128,7 @@ class SubWorkflow(TaskSpec):
         # Assign variables, if so requested.
         for child in my_task.children:
             if subworkflow.last_task is not None:
-                my_task.data.update(subworkflow.data)
-                #child.data.update(subworkflow.last_task.data)
+                child.data.update(subworkflow.last_task.data)
             if child.task_spec in self.outputs:
                 for assignment in self.out_assign:
                     assignment.assign(subworkflow, child)

--- a/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
+++ b/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import, division
+
+from __future__ import division, absolute_import
+import unittest
+
+from SpiffWorkflow.bpmn.BpmnScriptEngine import BpmnScriptEngine
+from SpiffWorkflow.task import Task
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+__author__ = 'matth'
+
+def my_custom_function(txt):
+    return str(txt).upper()
+
+class CustomBpmnScriptEngine(BpmnScriptEngine):
+    """This is a custom script processor that can be easily injected into Spiff Workflow.
+    It will execute python code read in from the bpmn.  It will also make any scripts in the
+     scripts directory available for execution. """
+
+
+    def execute(self, task, script, data):
+        augmentMethods = {'custom_function': my_custom_function}
+        super().execute(task, script, data, externalMethods=augmentMethods)
+    def eval(self, exp, data):
+        return super()._eval(exp, {}, **data)
+
+
+
+
+class CustomInlineScriptTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        self.spec = self.load_spec()
+
+    def load_spec(self):
+        return self.load_workflow_spec('custom_function_test.bpmn', 'ScriptTest')
+
+    def testRunThroughHappy(self):
+        script_engine = CustomBpmnScriptEngine()
+        self.workflow = BpmnWorkflow(self.spec,script_engine=script_engine)
+        self.workflow.do_engine_steps()
+        data = self.workflow.last_task.data
+        self.assertEqual(data['c1'], 'HELLO')
+        self.assertEqual(data['c2'], 'GOODBYE')
+
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(CustomInlineScriptTest)
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/bpmn/SubWorkflowMultiTest.py
+++ b/tests/SpiffWorkflow/bpmn/SubWorkflowMultiTest.py
@@ -18,19 +18,20 @@ class SubWorkflowMultiTest(BpmnWorkflowTestCase):
         self.spec = self.load_spec()
 
     def load_spec(self):
+        # for now we are testing the completion condition
+        # There is also a test bpmn sub_workflow_multi.bpmn that tests the exact same
+        # thing, except for the script is in a call activity. This is currently not working the way
+        # we want it to, but it should
         return self.load_workflow_spec('sub_workflow_multi1.bpmn', 'ScriptTest')
 
     def testRunThroughHappy(self):
         self.workflow = BpmnWorkflow(self.spec)
         self.workflow.do_engine_steps()
 
-
-        print(self.workflow.is_completed())
         data = self.workflow.last_task.data
 
-        print(data)
-        self.assertEqual(data['c1'], 'HELLO')
-        self.assertEqual(data['c2'], 'GOODBYE')
+        self.assertEqual(data['coll'], {1: {'a': 1}, 2: {'a': 2}, 3: {'a': 3}})
+
 
 
 

--- a/tests/SpiffWorkflow/bpmn/SubWorkflowMultiTest.py
+++ b/tests/SpiffWorkflow/bpmn/SubWorkflowMultiTest.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import, division
+
+from __future__ import division, absolute_import
+import unittest
+
+from SpiffWorkflow.bpmn.BpmnScriptEngine import BpmnScriptEngine
+from SpiffWorkflow.task import Task
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+__author__ = 'matth'
+
+
+class SubWorkflowMultiTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        self.spec = self.load_spec()
+
+    def load_spec(self):
+        return self.load_workflow_spec('sub_workflow_multi1.bpmn', 'ScriptTest')
+
+    def testRunThroughHappy(self):
+        self.workflow = BpmnWorkflow(self.spec)
+        self.workflow.do_engine_steps()
+
+
+        print(self.workflow.is_completed())
+        data = self.workflow.last_task.data
+
+        print(data)
+        self.assertEqual(data['c1'], 'HELLO')
+        self.assertEqual(data['c2'], 'GOODBYE')
+
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(SubWorkflowMultiTest)
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/bpmn/data/ScriptTestBox.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/ScriptTestBox.bpmn
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_015ooho" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <bpmn:process id="Process_1l85e0n" name="ScriptTest" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0dsbqk4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0dsbqk4" sourceRef="StartEvent_1" targetRef="Activity_1y303ko" />
+    <bpmn:scriptTask id="Activity_1y303ko" name="FirstScript">
+      <bpmn:incoming>Flow_0dsbqk4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1izwhjx</bpmn:outgoing>
+      <bpmn:script>testvar = {'a':1,'b':2}
+testvar2 = [{'x':1,'y':'a'},
+            {'x':2,'y':'b'},
+             {'x':3,'y':'c'}]</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_12boxg0">
+      <bpmn:incoming>Flow_1rbktuo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1izwhjx" sourceRef="Activity_1y303ko" targetRef="Activity_0kky4xd" />
+    <bpmn:sequenceFlow id="Flow_1rbktuo" sourceRef="Activity_0kky4xd" targetRef="Event_12boxg0" />
+    <bpmn:scriptTask id="Activity_0kky4xd" name="SecondScript">
+      <bpmn:incoming>Flow_1izwhjx</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rbktuo</bpmn:outgoing>
+      <bpmn:script>testvar.new = 'Test'
+sample = [x.y for x in testvar2 if x.x &gt; 1]</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1l85e0n">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0dsbqk4_di" bpmnElement="Flow_0dsbqk4">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="310" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1y551f5_di" bpmnElement="Activity_1y303ko">
+        <dc:Bounds x="310" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_12boxg0_di" bpmnElement="Event_12boxg0">
+        <dc:Bounds x="752" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1izwhjx_di" bpmnElement="Flow_1izwhjx">
+        <di:waypoint x="410" y="117" />
+        <di:waypoint x="500" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rbktuo_di" bpmnElement="Flow_1rbktuo">
+        <di:waypoint x="600" y="117" />
+        <di:waypoint x="752" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_02xvo3k_di" bpmnElement="Activity_0kky4xd">
+        <dc:Bounds x="500" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/custom_function_test.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/custom_function_test.bpmn
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_015ooho" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <bpmn:process id="Process_1l85e0n" name="ScriptTest" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0dsbqk4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0dsbqk4" sourceRef="StartEvent_1" targetRef="Activity_1y303ko" />
+    <bpmn:scriptTask id="Activity_1y303ko" name="FirstScript">
+      <bpmn:incoming>Flow_0dsbqk4</bpmn:incoming>
+      <bpmn:outgoing>Flow_089pzz7</bpmn:outgoing>
+      <bpmn:script>c1 = custom_function('hello')</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_12boxg0">
+      <bpmn:incoming>Flow_08hqius</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_16u5jzz">
+      <bpmn:incoming>Flow_089pzz7</bpmn:incoming>
+      <bpmn:outgoing>Flow_08hqius</bpmn:outgoing>
+      <bpmn:startEvent id="Event_1u4mcv3">
+        <bpmn:outgoing>Flow_14l2ton</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_14l2ton" sourceRef="Event_1u4mcv3" targetRef="Activity_1kkxlz7" />
+      <bpmn:endEvent id="Event_0y42ecd">
+        <bpmn:incoming>Flow_06gypww</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_06gypww" sourceRef="Activity_1kkxlz7" targetRef="Event_0y42ecd" />
+      <bpmn:scriptTask id="Activity_1kkxlz7" name="Second Script">
+        <bpmn:incoming>Flow_14l2ton</bpmn:incoming>
+        <bpmn:outgoing>Flow_06gypww</bpmn:outgoing>
+        <bpmn:script>c2 = custom_function('goodbye')</bpmn:script>
+      </bpmn:scriptTask>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_089pzz7" sourceRef="Activity_1y303ko" targetRef="Activity_16u5jzz" />
+    <bpmn:sequenceFlow id="Flow_08hqius" sourceRef="Activity_16u5jzz" targetRef="Event_12boxg0" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1l85e0n">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0dsbqk4_di" bpmnElement="Flow_0dsbqk4">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="310" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1y551f5_di" bpmnElement="Activity_1y303ko">
+        <dc:Bounds x="310" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_12boxg0_di" bpmnElement="Event_12boxg0">
+        <dc:Bounds x="1032" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16u5jzz_di" bpmnElement="Activity_16u5jzz" isExpanded="true">
+        <dc:Bounds x="510" y="50" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u4mcv3_di" bpmnElement="Event_1u4mcv3">
+        <dc:Bounds x="550" y="132" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_14l2ton_di" bpmnElement="Flow_14l2ton">
+        <di:waypoint x="586" y="150" />
+        <di:waypoint x="640" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0y42ecd_di" bpmnElement="Event_0y42ecd">
+        <dc:Bounds x="802" y="132" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_06gypww_di" bpmnElement="Flow_06gypww">
+        <di:waypoint x="740" y="150" />
+        <di:waypoint x="802" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1v1rg9x_di" bpmnElement="Activity_1kkxlz7">
+        <dc:Bounds x="640" y="110" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_089pzz7_di" bpmnElement="Flow_089pzz7">
+        <di:waypoint x="410" y="117" />
+        <di:waypoint x="460" y="117" />
+        <di:waypoint x="460" y="150" />
+        <di:waypoint x="510" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08hqius_di" bpmnElement="Flow_08hqius">
+        <di:waypoint x="860" y="150" />
+        <di:waypoint x="946" y="150" />
+        <di:waypoint x="946" y="117" />
+        <di:waypoint x="1032" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/sub_workflow_multi.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/sub_workflow_multi.bpmn
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_015ooho" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <bpmn:process id="Process_1l85e0n" name="ScriptTest" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0dsbqk4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0dsbqk4" sourceRef="StartEvent_1" targetRef="Activity_0umlasr" />
+    <bpmn:endEvent id="Event_12boxg0">
+      <bpmn:incoming>Flow_18e9qgr</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_16u5jzz">
+      <bpmn:incoming>Flow_1ona7kk</bpmn:incoming>
+      <bpmn:outgoing>Flow_18e9qgr</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true" camunda:collection="c1" camunda:elementVariable="a">
+        <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">5</bpmn:loopCardinality>
+        <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">done==True</bpmn:completionCondition>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:scriptTask id="Activity_1kkxlz7" name="Second Script">
+        <bpmn:incoming>Flow_14l2ton</bpmn:incoming>
+        <bpmn:outgoing>Flow_06gypww</bpmn:outgoing>
+        <bpmn:script>x = {'a':a}
+if a==3:
+   done=True
+a=x</bpmn:script>
+      </bpmn:scriptTask>
+      <bpmn:endEvent id="Event_0y42ecd">
+        <bpmn:incoming>Flow_06gypww</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:startEvent id="Event_1u4mcv3">
+        <bpmn:outgoing>Flow_14l2ton</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_06gypww" sourceRef="Activity_1kkxlz7" targetRef="Event_0y42ecd" />
+      <bpmn:sequenceFlow id="Flow_14l2ton" sourceRef="Event_1u4mcv3" targetRef="Activity_1kkxlz7" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_18e9qgr" sourceRef="Activity_16u5jzz" targetRef="Event_12boxg0" />
+    <bpmn:sequenceFlow id="Flow_1ona7kk" sourceRef="Activity_0umlasr" targetRef="Activity_16u5jzz" />
+    <bpmn:scriptTask id="Activity_0umlasr" name="init">
+      <bpmn:incoming>Flow_0dsbqk4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ona7kk</bpmn:outgoing>
+      <bpmn:script>done=False</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1l85e0n">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0dsbqk4_di" bpmnElement="Flow_0dsbqk4">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="250" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_12boxg0_di" bpmnElement="Event_12boxg0">
+        <dc:Bounds x="1032" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16u5jzz_di" bpmnElement="Activity_16u5jzz" isExpanded="true">
+        <dc:Bounds x="510" y="77" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1v1rg9x_di" bpmnElement="Activity_1kkxlz7">
+        <dc:Bounds x="640" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0y42ecd_di" bpmnElement="Event_0y42ecd">
+        <dc:Bounds x="802" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u4mcv3_di" bpmnElement="Event_1u4mcv3">
+        <dc:Bounds x="550" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_06gypww_di" bpmnElement="Flow_06gypww">
+        <di:waypoint x="740" y="177" />
+        <di:waypoint x="802" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14l2ton_di" bpmnElement="Flow_14l2ton">
+        <di:waypoint x="586" y="177" />
+        <di:waypoint x="640" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18e9qgr_di" bpmnElement="Flow_18e9qgr">
+        <di:waypoint x="860" y="177" />
+        <di:waypoint x="1032" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ona7kk_di" bpmnElement="Flow_1ona7kk">
+        <di:waypoint x="350" y="177" />
+        <di:waypoint x="510" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_18x5yaj_di" bpmnElement="Activity_0umlasr">
+        <dc:Bounds x="250" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/sub_workflow_multi1.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/sub_workflow_multi1.bpmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_015ooho" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <bpmn:process id="Process_1l85e0n" name="ScriptTest" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0dsbqk4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0dsbqk4" sourceRef="StartEvent_1" targetRef="Activity_16giml8" />
+    <bpmn:endEvent id="Event_12boxg0">
+      <bpmn:incoming>Flow_1lbqsop</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:scriptTask id="Activity_1kkxlz7" name="Second Script">
+      <bpmn:incoming>Flow_0n1o8w6</bpmn:incoming>
+      <bpmn:outgoing>Flow_1lbqsop</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true" camunda:collection="coll" camunda:elementVariable="a">
+        <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">5</bpmn:loopCardinality>
+        <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">done==True</bpmn:completionCondition>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:script>x = {'a':a}
+if a==3:
+   done=True
+a=x</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1lbqsop" sourceRef="Activity_1kkxlz7" targetRef="Event_12boxg0" />
+    <bpmn:sequenceFlow id="Flow_0n1o8w6" sourceRef="Activity_16giml8" targetRef="Activity_1kkxlz7" />
+    <bpmn:scriptTask id="Activity_16giml8" name="init">
+      <bpmn:incoming>Flow_0dsbqk4</bpmn:incoming>
+      <bpmn:outgoing>Flow_0n1o8w6</bpmn:outgoing>
+      <bpmn:script>done=False</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1l85e0n">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="109" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0dsbqk4_di" bpmnElement="Flow_0dsbqk4">
+        <di:waypoint x="188" y="127" />
+        <di:waypoint x="250" y="127" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_12boxg0_di" bpmnElement="Event_12boxg0">
+        <dc:Bounds x="632" y="109" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1v1rg9x_di" bpmnElement="Activity_1kkxlz7">
+        <dc:Bounds x="440" y="87" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1lbqsop_di" bpmnElement="Flow_1lbqsop">
+        <di:waypoint x="540" y="127" />
+        <di:waypoint x="632" y="127" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n1o8w6_di" bpmnElement="Flow_0n1o8w6">
+        <di:waypoint x="350" y="127" />
+        <di:waypoint x="440" y="127" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0fx0yfe_di" bpmnElement="Activity_16giml8">
+        <dc:Bounds x="250" y="87" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/camunda/data/multi_instance_array.bpmn
+++ b/tests/SpiffWorkflow/camunda/data/multi_instance_array.bpmn
@@ -40,7 +40,6 @@
       <bpmn:outgoing>Flow_0659lqh</bpmn:outgoing>
       <bpmn:multiInstanceLoopCharacteristics isSequential="true" camunda:collection="Family.Members" camunda:elementVariable="FamilyMember">
         <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">Family.Size</bpmn:loopCardinality>
-        <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">test completion</bpmn:completionCondition>
       </bpmn:multiInstanceLoopCharacteristics>
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_0bplvtg" sourceRef="StartEvent_1" targetRef="Activity_FamSize" />

--- a/tests/SpiffWorkflow/camunda/data/multi_instance_array_parallel.bpmn
+++ b/tests/SpiffWorkflow/camunda/data/multi_instance_array_parallel.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0p4zkct" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.4.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0p4zkct" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
   <bpmn:process id="MultiInstanceArray" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0bplvtg</bpmn:outgoing>
@@ -36,7 +36,6 @@
       <bpmn:outgoing>Flow_0659lqh</bpmn:outgoing>
       <bpmn:multiInstanceLoopCharacteristics isSequential="true" camunda:collection="FamilyMembers" camunda:elementVariable="FamilyMember">
         <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">FamilySize</bpmn:loopCardinality>
-        <bpmn:completionCondition xsi:type="bpmn:tFormalExpression">test completion</bpmn:completionCondition>
       </bpmn:multiInstanceLoopCharacteristics>
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_0bplvtg" sourceRef="StartEvent_1" targetRef="Activity_FamSize" />
@@ -49,7 +48,7 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0659lqh</bpmn:incoming>
       <bpmn:outgoing>Flow_0ncqf54</bpmn:outgoing>
-      <bpmn:multiInstanceLoopCharacteristics isSequential="false" camunda:collection="FamilyMemberBirthday" camunda:elementVariable="CurrentFamilyMember">
+      <bpmn:multiInstanceLoopCharacteristics camunda:collection="FamilyMemberBirthday" camunda:elementVariable="CurrentFamilyMember">
         <bpmn:loopCardinality xsi:type="bpmn:tFormalExpression">FamilyMembers</bpmn:loopCardinality>
       </bpmn:multiInstanceLoopCharacteristics>
     </bpmn:userTask>


### PR DESCRIPTION
This will allow us to run a call activity as a multi-instance and honors a completion condition 

The collection of the Element Variable that is modified from 'within' a call activity is not currently working and will likely be painful to correct due to the way we have implemented call activities. 

This should, however, allow us to :    
1) loop through a SubWorkflow
2) have a form for a file and any metadata that should go with that file and 
3) attach that metadata to the uploaded file in a script in that call activity . . . and
4) say that we are done uploading files and 'bail out' of the multi instance using the completion condition 