### PR TITLE
Fix for MI CallActivity #341

### DIFF
--- a/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
+++ b/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
@@ -558,9 +558,8 @@ class MultiInstanceTask(TaskSpec):
 
         if not isinstance(my_task.task_spec,CallActivity):
             my_task._sync_children(outputs, Task.FUTURE)
-
-        for child in my_task.children:
-            child.task_spec._update(child)
+            for child in my_task.children:
+                child.task_spec._update(child)
 
         # If removed, add the element_var_data back onto this task.
         if(element_var_data):


### PR DESCRIPTION
This small change keeps it from setting all children to 'ready' and fixes the issue we were having with call-activity or SubWorkflow in conjunction with multi-instance