### PR TITLE
Clean up areas that set a task state to use one of the 2 functions th…

### DIFF
--- a/SpiffWorkflow/bpmn/parser/task_parsers.py
+++ b/SpiffWorkflow/bpmn/parser/task_parsers.py
@@ -24,7 +24,7 @@ from .util import first, one
 from ..specs.event_definitions import (TimerEventDefinition,
                                        MessageEventDefinition,
                                        SignalEventDefinition,
-                                       CancelEventDefinition)
+                                       CancelEventDefinition, CycleTimerEventDefinition)
 from lxml import etree
 import copy
 from SpiffWorkflow.exceptions import WorkflowException
@@ -42,9 +42,13 @@ class StartEventParser(TaskParser):
         isMessageCatchingEvent = self.xpath('.//bpmn:messageEventDefinition')
         isSignalCatchingEvent = self.xpath('.//bpmn:signalEventDefinition')
         isCancelCatchingEvent = self.xpath('.//bpmn:cancelEventDefinition')
+        isTimerCatchingEvent = self.xpath('.//bpmn:timerEventDefinition')
+
         if (len(isMessageCatchingEvent) > 0)\
-                or (len(isSignalCatchingEvent) > 0)\
-                or (len(isCancelCatchingEvent) > 0):
+                or (len(isSignalCatchingEvent) > 0) \
+                or (len(isCancelCatchingEvent) > 0) \
+                or (len(isTimerCatchingEvent) > 0)\
+                :
             # we need to fix this up to wait on an event
 
             self.__class__ = type(self.get_id() + '_class', (
@@ -408,8 +412,7 @@ class IntermediateCatchEventParser(TaskParser):
         # in the case that it is a cycle - for now, it is an error
         timeCycle = first(self.xpath('.//bpmn:timeCycle'))
         if timeCycle is not None:
-            raise NotImplementedError('Cycle Time Definition is not currently supported.')
-            return TimerEventDefinition(
+            return CycleTimerEventDefinition(
             self.node.get('name'),timeCycle.text)
 #            self.parser.parse_condition(
 #                   timeCycle.text, None, None, None, None, self))

--- a/SpiffWorkflow/bpmn/specs/UnstructuredJoin.py
+++ b/SpiffWorkflow/bpmn/specs/UnstructuredJoin.py
@@ -142,7 +142,7 @@ class UnstructuredJoin(Join, BpmnSpecMixin):
                 self.entered_event.emit(my_task.workflow, my_task)
                 task._ready()
             else:
-                task.state = Task.COMPLETED
+                task._set_state(Task.COMPLETED)
                 task._drop_children()
 
 

--- a/SpiffWorkflow/specs/Celery.py
+++ b/SpiffWorkflow/specs/Celery.py
@@ -250,7 +250,7 @@ class Celery(TaskSpec):
         if not self._start(my_task):
             if not my_task._has_state(Task.WAITING):
                 LOG.debug("'%s' going to WAITING state" % my_task.get_name())
-                my_task.state = Task.WAITING
+                my_task._set_state(Task.WAITING)
             return
         super(Celery, self)._update_hook(my_task)
 

--- a/SpiffWorkflow/specs/Execute.py
+++ b/SpiffWorkflow/specs/Execute.py
@@ -72,7 +72,7 @@ class Execute(TaskSpec):
 
     def _update_hook(self, my_task):
         if not self._start(my_task):
-            my_task.state = Task.WAITING
+            my_task._set_state(Task.WAITING)
             return
         super(Execute, self)._update_hook(my_task)
 

--- a/SpiffWorkflow/specs/Join.py
+++ b/SpiffWorkflow/specs/Join.py
@@ -278,7 +278,7 @@ class Join(TaskSpec):
                 self.entered_event.emit(my_task.workflow, my_task)
                 task._ready()
             else:
-                task.state = Task.COMPLETED
+                task._set_state(Task.COMPLETED)
                 task._drop_children()
 
 

--- a/SpiffWorkflow/specs/ThreadMerge.py
+++ b/SpiffWorkflow/specs/ThreadMerge.py
@@ -126,7 +126,7 @@ class ThreadMerge(Join):
                 self.entered_event.emit(my_task.workflow, my_task)
                 task._ready()
             else:
-                task.state = Task.COMPLETED
+                task._set_state(Task.COMPLETED)
                 task._drop_children()
 
     def serialize(self, serializer):

--- a/tests/SpiffWorkflow/bpmn/TimerCycleStartTest.py
+++ b/tests/SpiffWorkflow/bpmn/TimerCycleStartTest.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import, division
+
+from __future__ import division, absolute_import
+import unittest
+import datetime
+import time
+
+from SpiffWorkflow.bpmn.BpmnScriptEngine import BpmnScriptEngine
+from SpiffWorkflow.task import Task
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+__author__ = 'kellym'
+
+counter = 0
+def my_custom_function():
+    global counter
+    counter = counter+1
+    return counter
+
+class CustomBpmnScriptEngine(BpmnScriptEngine):
+    """This is a custom script processor that can be easily injected into Spiff Workflow.
+    It will execute python code read in from the bpmn.  It will also make any scripts in the
+     scripts directory available for execution. """
+
+
+    def execute(self, task, script, data):
+        augmentMethods = {'custom_function': my_custom_function}
+        super().execute(task, script, data, externalMethods=augmentMethods)
+    def eval(self, exp, data):
+        return super()._eval(exp, {}, **data)
+
+
+class TimerCycleStartTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        self.spec = self.load_spec()
+
+    def load_spec(self):
+        return self.load_workflow_spec('timer-cycle-start.bpmn', 'timer')
+
+    def testRunThroughHappy(self):
+        self.actual_test(save_restore=False)
+
+    def testThroughSaveRestore(self):
+        self.actual_test(save_restore=True)
+
+
+    def actual_test(self,save_restore = False):
+        global counter
+        self.workflow = BpmnWorkflow(self.spec,script_engine=CustomBpmnScriptEngine())
+        ready_tasks = self.workflow.get_tasks(Task.READY)
+        self.assertEqual(1, len(ready_tasks)) # Start Event
+        self.workflow.complete_task_from_id(ready_tasks[0].id)
+        self.workflow.do_engine_steps()
+        #ready_tasks = self.workflow.get_tasks(Task.READY)
+        #self.assertEqual(1, len(ready_tasks)) # GetCoffee
+        # the data doesn't really propagate to the end as in a 'normal' workflow, so I call a
+        # custom function that records the number of times this got called so that
+        # we can keep track of how many times the triggered item gets called.
+
+        loopcount = 0
+        # test bpmn has a timeout of .25s
+        # we should terminate loop before that.
+        starttime = datetime.datetime.now()
+        counter = 0
+        while loopcount < 10:
+            if len(self.workflow.get_tasks(Task.READY)) >= 2:
+                break
+            if save_restore:
+                self.save_restore()
+                self.workflow.script_engine = CustomBpmnScriptEngine()
+            waiting_tasks = self.workflow.get_tasks(Task.WAITING)
+            #self.assertEqual(1, len(waiting_tasks))
+            time.sleep(0.1)
+            self.workflow.refresh_waiting_tasks()
+            loopcount = loopcount +1
+        endtime = datetime.datetime.now()
+        self.assertEqual(counter,2)
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(TimerCycleStartTest)
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/bpmn/TimerCycleTest.py
+++ b/tests/SpiffWorkflow/bpmn/TimerCycleTest.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import, division
+
+from __future__ import division, absolute_import
+import unittest
+import datetime
+import time
+
+from SpiffWorkflow.bpmn.BpmnScriptEngine import BpmnScriptEngine
+from SpiffWorkflow.task import Task
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+__author__ = 'kellym'
+
+counter = 0
+def my_custom_function():
+    global counter
+    counter = counter+1
+    return counter
+
+class CustomBpmnScriptEngine(BpmnScriptEngine):
+    """This is a custom script processor that can be easily injected into Spiff Workflow.
+    It will execute python code read in from the bpmn.  It will also make any scripts in the
+     scripts directory available for execution. """
+
+
+    def execute(self, task, script, data):
+        augmentMethods = {'custom_function': my_custom_function}
+        super().execute(task, script, data, externalMethods=augmentMethods)
+    def eval(self, exp, data):
+        return super()._eval(exp, {}, **data)
+
+
+class TimerDurationTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        self.spec = self.load_spec()
+
+    def load_spec(self):
+        return self.load_workflow_spec('timer-cycle.bpmn', 'timer')
+
+    def testRunThroughHappy(self):
+        self.actual_test(save_restore=False)
+
+    def testThroughSaveRestore(self):
+        self.actual_test(save_restore=True)
+
+
+    def actual_test(self,save_restore = False):
+        global counter
+        self.workflow = BpmnWorkflow(self.spec,script_engine=CustomBpmnScriptEngine())
+        ready_tasks = self.workflow.get_tasks(Task.READY)
+        self.assertEqual(1, len(ready_tasks)) # Start Event
+        self.workflow.complete_task_from_id(ready_tasks[0].id)
+        self.workflow.do_engine_steps()
+        ready_tasks = self.workflow.get_tasks(Task.READY)
+        self.assertEqual(1, len(ready_tasks)) # GetCoffee
+        # the data doesn't really propagate to the end as in a 'normal' workflow, so I call a
+        # custom function that records the number of times this got called so that
+        # we can keep track of how many times the triggered item gets called.
+
+        loopcount = 0
+        # test bpmn has a timeout of .25s
+        # we should terminate loop before that.
+        starttime = datetime.datetime.now()
+        counter = 0
+        while loopcount < 8:
+            if len(self.workflow.get_tasks(Task.READY)) >= 2:
+                break
+            if save_restore:
+                self.save_restore()
+                self.workflow.script_engine = CustomBpmnScriptEngine()
+
+            waiting_tasks = self.workflow.get_tasks(Task.WAITING)
+            #self.assertEqual(1, len(waiting_tasks))
+            time.sleep(0.1)
+            self.workflow.refresh_waiting_tasks()
+            loopcount = loopcount +1
+        endtime = datetime.datetime.now()
+        self.assertEqual(counter,2)
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(TimerDurationTest)
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/bpmn/data/timer-cycle-start.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer-cycle-start.bpmn
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ilr8m3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <bpmn:collaboration id="Collaboration_0bcl3k5">
+    <bpmn:participant id="Participant_10cebxh" processRef="timer" />
+  </bpmn:collaboration>
+  <bpmn:process id="timer" isExecutable="true">
+    <bpmn:laneSet id="LaneSet_19op0am">
+      <bpmn:lane id="Lane_13pry5y">
+        <bpmn:flowNodeRef>StartEvent</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>wait_timer</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>EndItAll</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_1qb9sc3">
+        <bpmn:flowNodeRef>CycleStart</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Refill_Coffee</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>CycleEnd</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:startEvent id="StartEvent">
+      <bpmn:outgoing>Flow_1pahvlr</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="CycleStart">
+      <bpmn:outgoing>Flow_0jtfzsk</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0za5f2h">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">(2,timedelta(seconds=.25))</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:scriptTask id="Refill_Coffee" name="Refill Coffee">
+      <bpmn:incoming>Flow_0jtfzsk</bpmn:incoming>
+      <bpmn:outgoing>Flow_07sglzn</bpmn:outgoing>
+      <bpmn:script>print('refill count = %d'%custom_function())</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="CycleEnd">
+      <bpmn:incoming>Flow_07sglzn</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:intermediateCatchEvent id="wait_timer">
+      <bpmn:incoming>Flow_1pahvlr</bpmn:incoming>
+      <bpmn:outgoing>Flow_05ejbm4</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0o35ug0">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=1)</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="EndItAll">
+      <bpmn:incoming>Flow_05ejbm4</bpmn:incoming>
+      <bpmn:terminateEventDefinition id="TerminateEventDefinition_02us6b3" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1pahvlr" sourceRef="StartEvent" targetRef="wait_timer" />
+    <bpmn:sequenceFlow id="Flow_07sglzn" sourceRef="Refill_Coffee" targetRef="CycleEnd" />
+    <bpmn:sequenceFlow id="Flow_0jtfzsk" sourceRef="CycleStart" targetRef="Refill_Coffee" />
+    <bpmn:sequenceFlow id="Flow_05ejbm4" sourceRef="wait_timer" targetRef="EndItAll" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0bcl3k5">
+      <bpmndi:BPMNShape id="Participant_10cebxh_di" bpmnElement="Participant_10cebxh" isHorizontal="true">
+        <dc:Bounds x="158" y="84" width="600" height="380" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent">
+        <dc:Bounds x="222" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xk1ts7_di" bpmnElement="Refill_Coffee">
+        <dc:Bounds x="300" y="110" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1pahvlr_di" bpmnElement="Flow_1pahvlr">
+        <di:waypoint x="258" y="267" />
+        <di:waypoint x="352" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Lane_13pry5y_di" bpmnElement="Lane_13pry5y" isHorizontal="true">
+        <dc:Bounds x="188" y="204" width="570" height="260" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1qb9sc3_di" bpmnElement="Lane_1qb9sc3" isHorizontal="true">
+        <dc:Bounds x="188" y="84" width="570" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_051yw6f_di" bpmnElement="CycleStart">
+        <dc:Bounds x="212" y="132" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_19emh1x_di" bpmnElement="CycleEnd">
+        <dc:Bounds x="452" y="132" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_07sglzn_di" bpmnElement="Flow_07sglzn">
+        <di:waypoint x="400" y="150" />
+        <di:waypoint x="452" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jtfzsk_di" bpmnElement="Flow_0jtfzsk">
+        <di:waypoint x="248" y="150" />
+        <di:waypoint x="300" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05ejbm4_di" bpmnElement="Flow_05ejbm4">
+        <di:waypoint x="388" y="267" />
+        <di:waypoint x="492" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_19crrpp_di" bpmnElement="wait_timer">
+        <dc:Bounds x="352" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10njezb_di" bpmnElement="EndItAll">
+        <dc:Bounds x="492" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/timer-cycle.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer-cycle.bpmn
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ilr8m3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+  <bpmn:process id="timer" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1pahvlr</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:manualTask id="Get_Coffee" name="Get coffee">
+      <bpmn:incoming>Flow_09d7dp2</bpmn:incoming>
+      <bpmn:outgoing>Flow_1pvkgnu</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:manualTask id="Back_To_Work" name="Get Back To Work">
+      <bpmn:incoming>Flow_1pvkgnu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ekgt3x</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:endEvent id="Event_03w65sk">
+      <bpmn:incoming>Flow_1ekgt3x</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1ekgt3x" sourceRef="Back_To_Work" targetRef="Event_03w65sk" />
+    <bpmn:sequenceFlow id="Flow_1pvkgnu" sourceRef="Get_Coffee" targetRef="Back_To_Work" />
+    <bpmn:sequenceFlow id="Flow_1pahvlr" sourceRef="StartEvent_1" targetRef="Activity_1swqq74" />
+    <bpmn:sequenceFlow id="Flow_1pzc4jz" sourceRef="CatchMessage" targetRef="Refill_Coffee" />
+    <bpmn:scriptTask id="Refill_Coffee" name="Refill Coffee">
+      <bpmn:incoming>Flow_1pzc4jz</bpmn:incoming>
+      <bpmn:script>print('refill count = %d'%custom_function())</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_09d7dp2" sourceRef="Activity_1swqq74" targetRef="Get_Coffee" />
+    <bpmn:scriptTask id="Activity_1swqq74" name="Set Refill Count">
+      <bpmn:incoming>Flow_1pahvlr</bpmn:incoming>
+      <bpmn:outgoing>Flow_09d7dp2</bpmn:outgoing>
+      <bpmn:script>refill_count = 0</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:boundaryEvent id="CatchMessage" cancelActivity="false" attachedToRef="Get_Coffee">
+      <bpmn:outgoing>Flow_1pzc4jz</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_180fybf">
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">(2,timedelta(seconds=.25))</bpmn:timeCycle>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="timer">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tjl9dd_di" bpmnElement="Get_Coffee">
+        <dc:Bounds x="370" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15zi5m4_di" bpmnElement="Back_To_Work">
+        <dc:Bounds x="500" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03w65sk_di" bpmnElement="Event_03w65sk">
+        <dc:Bounds x="632" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1ekgt3x_di" bpmnElement="Flow_1ekgt3x">
+        <di:waypoint x="600" y="117" />
+        <di:waypoint x="632" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pvkgnu_di" bpmnElement="Flow_1pvkgnu">
+        <di:waypoint x="470" y="117" />
+        <di:waypoint x="500" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pahvlr_di" bpmnElement="Flow_1pahvlr">
+        <di:waypoint x="188" y="117" />
+        <di:waypoint x="220" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pzc4jz_di" bpmnElement="Flow_1pzc4jz">
+        <di:waypoint x="440" y="175" />
+        <di:waypoint x="440" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0xk1ts7_di" bpmnElement="Refill_Coffee">
+        <dc:Bounds x="390" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_09d7dp2_di" bpmnElement="Flow_09d7dp2">
+        <di:waypoint x="320" y="117" />
+        <di:waypoint x="370" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1tk82xi_di" bpmnElement="Activity_1swqq74">
+        <dc:Bounds x="220" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ttaw63_di" bpmnElement="CatchMessage">
+        <dc:Bounds x="422" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Add Cycle timer event - use cases covered are:

1) boundary event (non-interrupting - interrupting would only ever fire once)
2) start event (repeat task in one swimlane while the other is doing something)

Fixes #345