### PR TITLE
Fix #425

### DIFF
--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -6,6 +6,7 @@ from builtins import object
 import ast
 import datetime
 from datetime import timedelta
+import dateparser
 
 from SpiffWorkflow.exceptions import WorkflowTaskExecException
 from SpiffWorkflow.workflow import WorkflowException
@@ -104,7 +105,8 @@ class PythonScriptEngine(object):
             scriptingAdditions = {}
         self.globals = {'timedelta':timedelta,
                          'datetime':datetime,
-                        'Box':Box,
+                         'dateparser':dateparser,
+                         'Box':Box,
                         }
         self.globals.update(scriptingAdditions)
 

--- a/SpiffWorkflow/bpmn/specs/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/event_definitions.py
@@ -260,6 +260,7 @@ class TimerEventDefinition(CatchingEventDefinition):
             else:
                 now = datetime.datetime.now()
         else:
+            # assume type is a date, not datetime
             now = datetime.date.today()
         return now > dt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 celery
 coverage
 lxml
+dateparser
 .

--- a/tests/SpiffWorkflow/bpmn/CallActiivtyEndEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActiivtyEndEventTest.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import, division
+
+from __future__ import division, absolute_import
+import sys
+import os
+import unittest
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+__author__ = 'kellym'
+
+
+class CallActivityTest(BpmnWorkflowTestCase):
+    """The example bpmn diagram has a single task with a loop cardinality of 5.
+    It should repeat 5 times before termination."""
+
+    def setUp(self):
+        self.spec = self.load_workflow1_spec()
+
+    def load_workflow1_spec(self):
+        return self.load_workflow_spec('call_activity_*.bpmn','Process_8200379')
+
+    def testRunThroughHappy(self):
+
+        self.workflow = BpmnWorkflow(self.spec)
+        self.workflow.do_engine_steps()
+        print('-----------')
+        print(self.workflow.last_task.task_spec.name)
+        #self.assertIn('Workflow',self.workflow.last_task.task_spec.documentation)
+
+
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(CallActivityTest)
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/bpmn/TimerDateTest.py
+++ b/tests/SpiffWorkflow/bpmn/TimerDateTest.py
@@ -5,6 +5,7 @@ from __future__ import division, absolute_import
 import unittest
 import datetime
 import time
+import pytz
 
 from SpiffWorkflow.bpmn.BpmnScriptEngine import BpmnScriptEngine
 from SpiffWorkflow.task import Task
@@ -50,13 +51,15 @@ class TimerDateTest(BpmnWorkflowTestCase):
 
 
             waiting_tasks = self.workflow.get_tasks(Task.WAITING)
-            #self.assertEqual(1, len(waiting_tasks))
+            #self.assertEqual(1, len(waiting_tasks))z
             time.sleep(0.1)
             self.workflow.refresh_waiting_tasks()
             loopcount = loopcount +1
         endtime = datetime.datetime.now()
         self.workflow.do_engine_steps()
-        print(self.workflow.last_task.data)
+        tz = pytz.timezone('US/Eastern')
+        testdate = tz.localize(datetime.datetime.strptime('2021-09-01 10:00','%Y-%m-%d %H:%M'))
+        self.assertEqual(self.workflow.last_task.data['futuredate2'],testdate)
         self.assertTrue('completed' in self.workflow.last_task.data)
         self.assertTrue(self.workflow.last_task.data['completed'])
         self.assertTrue((endtime-starttime) > datetime.timedelta(seconds=.25))

--- a/tests/SpiffWorkflow/bpmn/data/call_activity_call_activity.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/call_activity_call_activity.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_34b94b6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Call_Activity_Get_Data" name="Call Activity Get Data" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_07uhaa7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_07uhaa7" sourceRef="StartEvent_1" targetRef="Activity_1mb2mnf" />
+    <bpmn:endEvent id="Event_1rokcus">
+      <bpmn:documentation># Call Event
+&lt;div&gt;&lt;span&gt;Hello {{my_var}}&lt;/span&gt;&lt;/div&gt;</bpmn:documentation>
+      <bpmn:incoming>Flow_0apfnjq</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0apfnjq" sourceRef="Activity_1mb2mnf" targetRef="Event_1rokcus" />
+    <bpmn:scriptTask id="Activity_1mb2mnf" name="Create Data">
+      <bpmn:incoming>Flow_07uhaa7</bpmn:incoming>
+      <bpmn:outgoing>Flow_0apfnjq</bpmn:outgoing>
+      <bpmn:script>my_var = 'World'
+my_other_var = 'Mike'</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Call_Activity_Get_Data">
+      <bpmndi:BPMNEdge id="Flow_07uhaa7_di" bpmnElement="Flow_07uhaa7">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0apfnjq_di" bpmnElement="Flow_0apfnjq">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="432" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1rokcus_di" bpmnElement="Event_1rokcus">
+        <dc:Bounds x="432" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0esr09m_di" bpmnElement="Activity_1mb2mnf">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/call_activity_end_event.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/call_activity_end_event.bpmn
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_f07329e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Process_8200379" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1g3dpd7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1g3dpd7" sourceRef="StartEvent_1" targetRef="Activity_0wppf2v" />
+    <bpmn:sequenceFlow id="Flow_0ovgj6c" sourceRef="Activity_0wppf2v" targetRef="Activity_12zat0d" />
+    <bpmn:callActivity id="Activity_12zat0d" name="Get Data Call Activity" calledElement="Call_Activity_Get_Data">
+      <bpmn:incoming>Flow_0ovgj6c</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qdgvah</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0qdgvah" sourceRef="Activity_12zat0d" targetRef="Activity_1ta6769" />
+    <bpmn:endEvent id="Event_18dla68">
+      <bpmn:documentation># Main Workflow
+Hello {{my_other_var}}
+
+</bpmn:documentation>
+      <bpmn:incoming>Flow_0izaz4f</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0izaz4f" sourceRef="Activity_1ta6769" targetRef="Event_18dla68" />
+    <bpmn:scriptTask id="Activity_1ta6769" name="Print Data">
+      <bpmn:incoming>Flow_0qdgvah</bpmn:incoming>
+      <bpmn:outgoing>Flow_0izaz4f</bpmn:outgoing>
+      <bpmn:script>print(pre_var)
+print(my_var)
+print(my_other_var)</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_0wppf2v" name="Pre Data">
+      <bpmn:incoming>Flow_1g3dpd7</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ovgj6c</bpmn:outgoing>
+      <bpmn:script>pre_var = 'some string'</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_8200379">
+      <bpmndi:BPMNEdge id="Flow_0izaz4f_di" bpmnElement="Flow_0izaz4f">
+        <di:waypoint x="690" y="177" />
+        <di:waypoint x="752" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qdgvah_di" bpmnElement="Flow_0qdgvah">
+        <di:waypoint x="530" y="177" />
+        <di:waypoint x="590" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ovgj6c_di" bpmnElement="Flow_0ovgj6c">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="430" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g3dpd7_di" bpmnElement="Flow_1g3dpd7">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mcej1g_di" bpmnElement="Activity_12zat0d">
+        <dc:Bounds x="430" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18dla68_di" bpmnElement="Event_18dla68">
+        <dc:Bounds x="752" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1v8hse1_di" bpmnElement="Activity_1ta6769">
+        <dc:Bounds x="590" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mhwjko_di" bpmnElement="Activity_0wppf2v">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/timer-date-start.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer-date-start.bpmn
@@ -7,7 +7,8 @@
     <bpmn:scriptTask id="Activity_1q1wged" name="Set Future Date">
       <bpmn:incoming>Flow_1i73q45</bpmn:incoming>
       <bpmn:outgoing>Flow_00e79cz</bpmn:outgoing>
-      <bpmn:script>futuredate = datetime.datetime.now() + timedelta(seconds=.25)</bpmn:script>
+      <bpmn:script>futuredate = dateparser.parse('in 1 second') - timedelta(seconds=.75) 
+futuredate2 = dateparser.parse('September 1 2021 at 10am EDT')</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_1i73q45" sourceRef="Event_0u1rmur" targetRef="Activity_1q1wged" />
     <bpmn:sequenceFlow id="Flow_00e79cz" sourceRef="Activity_1q1wged" targetRef="Event_0eb0w95" />


### PR DESCRIPTION
Gives a method for correcting for timezone on a timer event, but it is not automatic.

Adds a test for some of the call activity items.

You can now:

parse a date and include timezone and it should do the right thing on the server with utc timezone

dateparser.parse('2021-09-01 10:00 EDT')

and it also fixes another problem we've had with using

now() + timedelta(minutes=10)

instead you can use dateparser.parse('in 10 minutes') - and it should do the right thing.

I have not added a test for this because it doesn't parse fractions of seconds correctly, instead just yielding seconds.