### PR TITLE
Replace absolute import self-references with relative imports

### DIFF
--- a/SpiffWorkflow/__init__.py
+++ b/SpiffWorkflow/__init__.py
@@ -13,5 +13,6 @@ from .bpmn.specs.CallActivity import CallActivity
 from .bpmn.specs.BoundaryEvent import _BoundaryEventParent
 
 import inspect
+
 __all__ = [name for name, obj in list(locals().items())
            if not (name.startswith('_') or inspect.ismodule(obj))]

--- a/SpiffWorkflow/bpmn/FeelLikeScriptEngine.py
+++ b/SpiffWorkflow/bpmn/FeelLikeScriptEngine.py
@@ -6,7 +6,7 @@ import datetime
 import operator
 from datetime import timedelta
 from decimal import Decimal
-from SpiffWorkflow.workflow import WorkflowException
+from ..workflow import WorkflowException
 from .PythonScriptEngine import PythonScriptEngine
 
 # Copyright (C) 2020 Kelly McDonald

--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -11,9 +11,9 @@ from decimal import Decimal
 import dateparser
 import pytz
 
-from SpiffWorkflow.exceptions import WorkflowTaskExecException
-from SpiffWorkflow.operators import Operator
-from SpiffWorkflow.workflow import WorkflowException
+from ..exceptions import WorkflowTaskExecException
+from ..operators import Operator
+from ..workflow import WorkflowException
 
 
 # Copyright (C) 2020 Kelly McDonald

--- a/SpiffWorkflow/bpmn/parser/task_parsers.py
+++ b/SpiffWorkflow/bpmn/parser/task_parsers.py
@@ -28,8 +28,8 @@ from ..specs.event_definitions import (TimerEventDefinition,
                                        CancelEventDefinition, CycleTimerEventDefinition)
 from lxml import etree
 import copy
-from SpiffWorkflow.exceptions import WorkflowException
-from SpiffWorkflow.bpmn.specs.IntermediateCatchEvent import IntermediateCatchEvent
+from ...exceptions import WorkflowException
+from ...bpmn.specs.IntermediateCatchEvent import IntermediateCatchEvent
 CAMUNDA_MODEL_NS = 'http://camunda.org/schema/1.0/bpmn'
 
 class StartEventParser(TaskParser):

--- a/SpiffWorkflow/bpmn/serializer/BpmnSerializer.py
+++ b/SpiffWorkflow/bpmn/serializer/BpmnSerializer.py
@@ -24,9 +24,9 @@ import zipfile
 import os
 from json import loads
 
-from SpiffWorkflow.bpmn.specs.CallActivity import CallActivity
-from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
-from SpiffWorkflow.serializer import json as spiff_json
+from ...bpmn.specs.CallActivity import CallActivity
+from ...bpmn.workflow import BpmnWorkflow
+from ...serializer import json as spiff_json
 from ..parser.BpmnParser import BpmnParser
 from .Packager import Packager
 

--- a/SpiffWorkflow/bpmn/specs/CallActivity.py
+++ b/SpiffWorkflow/bpmn/specs/CallActivity.py
@@ -16,7 +16,7 @@ from __future__ import division
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
-from SpiffWorkflow import Task
+from ... import Task
 
 from .BpmnSpecMixin import BpmnSpecMixin
 from ...specs.SubWorkflow import SubWorkflow

--- a/SpiffWorkflow/bpmn/specs/IntermediateCatchEvent.py
+++ b/SpiffWorkflow/bpmn/specs/IntermediateCatchEvent.py
@@ -20,8 +20,8 @@ from __future__ import division
 from ...task import Task
 from .BpmnSpecMixin import BpmnSpecMixin
 from ...specs.Simple import Simple
-from SpiffWorkflow.bpmn.specs.StartEvent import StartEvent
-from SpiffWorkflow.specs.StartTask import StartTask
+from ...bpmn.specs.StartEvent import StartEvent
+from ...specs.StartTask import StartTask
 
 class IntermediateCatchEvent(Simple, BpmnSpecMixin):
 

--- a/SpiffWorkflow/bpmn/specs/ManualTask.py
+++ b/SpiffWorkflow/bpmn/specs/ManualTask.py
@@ -16,9 +16,9 @@ from __future__ import division
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
-from SpiffWorkflow.bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
+from ...bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
 
-from SpiffWorkflow.specs import Simple
+from ...specs import Simple
 
 from .UserTask import UserTask
 

--- a/SpiffWorkflow/bpmn/specs/NoneTask.py
+++ b/SpiffWorkflow/bpmn/specs/NoneTask.py
@@ -16,9 +16,9 @@ from __future__ import division
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
-from SpiffWorkflow.specs import Simple
+from ...specs import Simple
 
-from SpiffWorkflow.bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
+from ...bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
 
 from .UserTask import UserTask
 

--- a/SpiffWorkflow/bpmn/specs/ScriptTask.py
+++ b/SpiffWorkflow/bpmn/specs/ScriptTask.py
@@ -18,7 +18,7 @@ from __future__ import division
 # 02110-1301  USA
 import logging
 
-from SpiffWorkflow import WorkflowException
+from ... import WorkflowException
 
 from .BpmnSpecMixin import BpmnSpecMixin
 from ...task import Task

--- a/SpiffWorkflow/bpmn/specs/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/event_definitions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
-from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from ...bpmn.PythonScriptEngine import PythonScriptEngine
 from builtins import object
 import datetime
 # Copyright (C) 2012 Matthew Hampton

--- a/SpiffWorkflow/camunda/parser/CamundaParser.py
+++ b/SpiffWorkflow/camunda/parser/CamundaParser.py
@@ -1,6 +1,6 @@
-from SpiffWorkflow.camunda.specs.UserTask import UserTask
-from SpiffWorkflow.camunda.parser.UserTaskParser import UserTaskParser
-from SpiffWorkflow.bpmn.parser.BpmnParser import BpmnParser, full_tag
+from ..specs.UserTask import UserTask
+from ..parser.UserTaskParser import UserTaskParser
+from ...bpmn.parser.BpmnParser import BpmnParser, full_tag
 
 
 class CamundaParser(BpmnParser):

--- a/SpiffWorkflow/camunda/parser/UserTaskParser.py
+++ b/SpiffWorkflow/camunda/parser/UserTaskParser.py
@@ -1,5 +1,5 @@
-from SpiffWorkflow.bpmn.parser.TaskParser import TaskParser, xpath_eval
-from SpiffWorkflow.camunda.specs.UserTask import Form, FormField, EnumFormField
+from ...bpmn.parser.TaskParser import TaskParser, xpath_eval
+from ...camunda.specs.UserTask import Form, FormField, EnumFormField
 
 CAMUNDA_MODEL_NS = 'http://camunda.org/schema/1.0/bpmn'
 

--- a/SpiffWorkflow/camunda/specs/UserTask.py
+++ b/SpiffWorkflow/camunda/specs/UserTask.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
 
-from SpiffWorkflow.bpmn.specs.UserTask import UserTask
-from SpiffWorkflow.bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
-from SpiffWorkflow.specs import Simple
+from ...bpmn.specs.UserTask import UserTask
+from ...bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
+from ...specs import Simple
 
 
 class UserTask(UserTask, BpmnSpecMixin):

--- a/SpiffWorkflow/dmn/engine/DMNEngine.py
+++ b/SpiffWorkflow/dmn/engine/DMNEngine.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from SpiffWorkflow.util import levenshtein
+from ...util import levenshtein
 
 
 class DMNEngine:

--- a/SpiffWorkflow/dmn/parser/BpmnDmnParser.py
+++ b/SpiffWorkflow/dmn/parser/BpmnDmnParser.py
@@ -1,11 +1,11 @@
 import glob
 
-from SpiffWorkflow.bpmn.parser.util import xpath_eval
+from ...bpmn.parser.util import xpath_eval
 
-from SpiffWorkflow.bpmn.parser.BpmnParser import BpmnParser, full_tag
-from SpiffWorkflow.dmn.parser.BusinessRuleTaskParser import BusinessRuleTaskParser
-from SpiffWorkflow.dmn.parser.DMNParser import DMNParser
-from SpiffWorkflow.dmn.specs.BusinessRuleTask import BusinessRuleTask
+from ...bpmn.parser.BpmnParser import BpmnParser, full_tag
+from ...dmn.parser.BusinessRuleTaskParser import BusinessRuleTaskParser
+from ...dmn.parser.DMNParser import DMNParser
+from ...dmn.specs.BusinessRuleTask import BusinessRuleTask
 from lxml import etree
 
 class BpmnDmnParser(BpmnParser):

--- a/SpiffWorkflow/dmn/parser/BusinessRuleTaskParser.py
+++ b/SpiffWorkflow/dmn/parser/BusinessRuleTaskParser.py
@@ -1,12 +1,12 @@
-from SpiffWorkflow.bpmn.parser.ValidationException import ValidationException
+from ...bpmn.parser.ValidationException import ValidationException
 
-from SpiffWorkflow.bpmn.parser.util import xpath_eval
+from ...bpmn.parser.util import xpath_eval
 
-from SpiffWorkflow.bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
+from ...bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
 
-from SpiffWorkflow.bpmn.parser.TaskParser import TaskParser
-from SpiffWorkflow.dmn.engine.DMNEngine import DMNEngine
-from SpiffWorkflow.dmn.specs.BusinessRuleTask import BusinessRuleTask
+from ...bpmn.parser.TaskParser import TaskParser
+from ...dmn.engine.DMNEngine import DMNEngine
+from ...dmn.specs.BusinessRuleTask import BusinessRuleTask
 
 CAMUNDA_MODEL_NS = 'http://camunda.org/schema/1.0/bpmn'
 

--- a/SpiffWorkflow/dmn/parser/DMNParser.py
+++ b/SpiffWorkflow/dmn/parser/DMNParser.py
@@ -4,9 +4,9 @@ from decimal import Decimal
 from ast import literal_eval
 from datetime import datetime
 
-from SpiffWorkflow.bpmn.parser.util import xpath_eval
+from ...bpmn.parser.util import xpath_eval
 
-from SpiffWorkflow.dmn.specs.model import Decision, DecisionTable, InputEntry, \
+from ...dmn.specs.model import Decision, DecisionTable, InputEntry, \
     OutputEntry, Input, Output, Rule
 
 def get_dmn_ns(node):

--- a/SpiffWorkflow/dmn/specs/BusinessRuleTask.py
+++ b/SpiffWorkflow/dmn/specs/BusinessRuleTask.py
@@ -1,8 +1,8 @@
-from SpiffWorkflow.exceptions import WorkflowTaskExecException
+from ...exceptions import WorkflowTaskExecException
 
-from SpiffWorkflow.specs import Simple
+from ...specs import Simple
 
-from SpiffWorkflow.bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
+from ...bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
 from ...util.deep_merge import DeepMerge
 from ...util.metrics import timeit
 

--- a/SpiffWorkflow/dmn/specs/model.py
+++ b/SpiffWorkflow/dmn/specs/model.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from SpiffWorkflow.util.deep_merge import DeepMerge
+from ...util.deep_merge import DeepMerge
 
 
 class Decision:

--- a/SpiffWorkflow/exceptions.py
+++ b/SpiffWorkflow/exceptions.py
@@ -20,7 +20,7 @@ from __future__ import division
 # 02110-1301  USA
 import re
 
-from SpiffWorkflow.util import levenshtein
+from .util import levenshtein
 
 
 class WorkflowException(Exception):

--- a/SpiffWorkflow/serializer/json.py
+++ b/SpiffWorkflow/serializer/json.py
@@ -18,7 +18,7 @@ import json
 import uuid
 from .dict import DictionarySerializer
 from ..operators import Attrib
-from SpiffWorkflow.camunda.specs.UserTask import Form
+from ..camunda.specs.UserTask import Form
 from ..util.impl import get_class
 
 def object_hook(dct):

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -20,7 +20,7 @@ from builtins import object
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
-from SpiffWorkflow.exceptions import WorkflowException
+from .exceptions import WorkflowException
 import logging
 import time
 from uuid import uuid4

--- a/tests/SpiffWorkflow/bpmn/ExculsiveGatewayNonDefaultPathIntoMultiTest.py
+++ b/tests/SpiffWorkflow/bpmn/ExculsiveGatewayNonDefaultPathIntoMultiTest.py
@@ -52,7 +52,7 @@ class ExclusiveGatewayNonDefaultPathIntoMultiTest(BpmnWorkflowTestCase):
 
 
 def suite():
-    return unittest.TestLoader().loadTestsFromTestCase(ExclusiveGatewayIntoMultiInstanceTest)
+    return unittest.TestLoader().loadTestsFromTestCase(ExclusiveGatewayNonDefaultPathIntoMultiTest)
 
 if __name__ == '__main__':
     unittest.TextTestRunner(verbosity=2).run(suite())


### PR DESCRIPTION
SpiffWorkflow contained some absolute imports within its modules, this was inconsistent with it's relative import references in the same files and blocked the ability to develop SpiffWorkflow within the context of another Python project.

This PR replaces all absolute references within the module to be relative.

This PR also fixes a minor issue where `ExclusiveGatewayNonDefaultPathIntoMultiTest` attempted to include `ExclusiveGatewayIntoMultiInstanceTest` 

- [x] References in project
- [x] Pass tests