### PR TITLE
looping back to an earlier point in the workflow is grossly inefficient 

### DIFF
--- a/SpiffWorkflow/serializer/dict.py
+++ b/SpiffWorkflow/serializer/dict.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, absolute_import
 
-import codecs
 from builtins import str
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,6 +20,7 @@ import pickle
 from base64 import b64encode, b64decode
 from .. import Workflow
 from ..bpmn.specs.BpmnSpecMixin import SequenceFlow
+from SpiffWorkflow.specs.LoopResetTask import LoopResetTask
 from ..dmn.engine.DMNEngine import DMNEngine
 from ..dmn.specs.BusinessRuleTask import BusinessRuleTask
 from ..dmn.specs.model import DecisionTable
@@ -41,8 +41,6 @@ from ..bpmn.specs.ExclusiveGateway import ExclusiveGateway
 from ..bpmn.specs.ScriptTask import ScriptTask
 from .exceptions import TaskNotSupportedError, MissingSpecError
 import warnings
-import copy
-
 
 
 class DictionarySerializer(Serializer):
@@ -333,6 +331,17 @@ class DictionarySerializer(Serializer):
         self.deserialize_task_spec(wf_spec, s_state, spec=spec)
         return spec
 
+    def serialize_loop_reset_task(self, spec):
+        s_state = self.serialize_task_spec(spec)
+        s_state['destination_id'] = spec.destination_id
+        s_state['destination_spec_name'] = spec.destination_spec_name
+        return s_state
+
+    def deserialize_loop_reset_task(self, wf_spec, s_state):
+        spec = LoopResetTask(wf_spec, s_state['name'], s_state['destination_id'],
+                             s_state['destination_spec_name'])
+        self.deserialize_task_spec(wf_spec, s_state, spec=spec)
+        return spec
 
     def serialize_call_activity(self, spec):
         s_state = self.serialize_task_spec(spec)

--- a/SpiffWorkflow/serializer/xml.py
+++ b/SpiffWorkflow/serializer/xml.py
@@ -27,7 +27,7 @@ from ..specs import (Cancel, AcquireMutex, CancelTask, Celery, Choose,
                      ExclusiveChoice, Execute, Gate, Join, MultiChoice,
                      MultiInstance, ReleaseMutex, Simple, WorkflowSpec,
                      SubWorkflow, StartTask, ThreadMerge,
-                     ThreadSplit, ThreadStart, Merge, Trigger)
+                     ThreadSplit, ThreadStart, Merge, Trigger, LoopResetTask)
 from .base import Serializer
 from .exceptions import TaskNotSupportedError
 
@@ -728,6 +728,21 @@ class XmlSerializer(Serializer):
             workflow.last_task = workflow.get_task(last_task)
 
         return workflow
+
+    def serialize_loop_reset_task(self, spec):
+        elem = etree.Element('loop-reset-task')
+        SubElement(elem, 'destination_id').text = str(spec.destination_id)
+        SubElement(elem, 'destination_spec_name').text = str(spec.destination_spec_name)
+        return self.serialize_task_spec(spec, elem)
+
+    def deserialize_loop_reset_task(self, wf_spec, elem, cls=LoopResetTask, **kwargs):
+        destination_id = elem.findtext('destination_id')
+        destination_spec_name = elem.findtext('destination_spec_name')
+
+        task = self.deserialize_task_spec(wf_spec, elem, cls,
+                                          destination_id=destination_id,
+                                          destination_spec_name=destination_spec_name)
+        return task
 
     def serialize_task(self, task, skip_children=False):
         assert isinstance(task, Task)

--- a/SpiffWorkflow/specs/LoopResetTask.py
+++ b/SpiffWorkflow/specs/LoopResetTask.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, absolute_import
+# Copyright (C) 2021 Sartography
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301  USA
+
+
+from .base import TaskSpec
+from ..task import Task
+from ..exceptions import WorkflowTaskExecException
+
+
+class LoopResetTask(TaskSpec):
+
+    """
+    This task is used as a placeholder when we are going to loopback
+    to a previous point in the workflow.  When this task is completed,
+    it will reset the workflow back to a previous point.
+    """
+
+    def __init__(self, wf_spec, name, destination_id, destination_spec_name, **kwargs):
+        """
+        Constructor.
+
+        :param script: the script that must be executed by the script engine.
+        """
+        super(LoopResetTask, self).__init__(wf_spec, name, **kwargs)
+        self.destination_id = destination_id
+        self.destination_spec_name = destination_spec_name
+
+    def _on_complete_hook(self, task):
+        try:
+            # Prefer the exact task id, but if not available, use the
+            # last instance of the task_spec.
+            destination = task.workflow.get_task(self.destination_id)
+            if not destination:
+                destination = task.workflow.get_tasks_from_spec_name(
+                    self.destination_spec_name)[-1]
+
+            destination.reset_token(reset_data=False)
+        except Exception as e:
+            LOG.error('Error Looping back to previous task; task=%r',
+                      self.destination_id, exc_info=True)
+            # set state to WAITING (because it is definitely not COMPLETED)
+            # and raise WorkflowException pointing to this task because
+            # maybe upstream someone will be able to handle this situation
+            task._setstate(Task.WAITING, force=True)
+            if isinstance(e, WorkflowTaskExecException):
+                raise e
+            else:
+                raise WorkflowTaskExecException(
+                    task, 'Error during loop back:' + str(e), e)
+        super(LoopResetTask, self)._on_complete_hook(task)
+
+    def serialize(self, serializer):
+        return serializer.serialize_loop_reset_task(self)
+
+    @classmethod
+    def deserialize(cls, serializer, wf_spec, s_state):
+        return serializer.deserialize_loop_reset_task(wf_spec, s_state)
+

--- a/SpiffWorkflow/specs/__init__.py
+++ b/SpiffWorkflow/specs/__init__.py
@@ -24,6 +24,7 @@ from .ThreadSplit import ThreadSplit
 from .Transform import Transform
 from .Trigger import Trigger
 from .WorkflowSpec import WorkflowSpec
+from .LoopResetTask import LoopResetTask
 
 import inspect
 __all__ = [name for name, obj in list(locals().items())

--- a/SpiffWorkflow/workflow.py
+++ b/SpiffWorkflow/workflow.py
@@ -2,7 +2,6 @@
 from __future__ import division, absolute_import
 from __future__ import print_function
 
-import copy
 from builtins import next
 from builtins import object
 # Copyright (C) 2007 Samuel Abels
@@ -23,6 +22,7 @@ from builtins import object
 # 02110-1301  USA
 import logging
 from . import specs
+from SpiffWorkflow.specs.LoopResetTask import LoopResetTask
 from .task import Task
 from .util.compat import mutex
 from .util.event import Event
@@ -324,6 +324,20 @@ class Workflow(object):
                 return task.reset_token()
         msg = 'A task with the given task_id (%s) was not found' % task_id
         raise WorkflowException(self.spec, msg)
+
+    def get_reset_task_spec(self, destination):
+        """
+        Returns a task, that once complete, will reset the workflow back
+        to a previously completed task.
+        :param destination: Task to reset to, on complete.
+        :return: TaskSpec
+        """
+        name = "return_to_" + destination.task_spec.name
+        spec = self.get_task_spec_from_name(name)
+        if not spec:
+            spec = LoopResetTask(self.spec, name, destination.id,
+                                 destination.task_spec.name)
+        return spec
 
     def get_tasks_iterator(self, state=Task.ANY_MASK):
         """

--- a/tests/SpiffWorkflow/bpmn/LoopBackNavTest.py
+++ b/tests/SpiffWorkflow/bpmn/LoopBackNavTest.py
@@ -44,6 +44,7 @@ class LoopBackNavTest(BpmnWorkflowTestCase):
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual("Why?", task.task_spec.description)
         self.workflow.complete_task_from_id(task.id)
+        self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual("Loop Again?", task.task_spec.description)
 

--- a/tests/SpiffWorkflow/bpmn/data/too_many_loops.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/too_many_loops.bpmn
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_d4f3442" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
+  <bpmn:process id="loops" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0q7fkb7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0q7fkb7" sourceRef="StartEvent_1" targetRef="initialize" />
+    <bpmn:scriptTask id="increment_counter" name="increment counter">
+      <bpmn:incoming>Flow_1gb8wca</bpmn:incoming>
+      <bpmn:outgoing>Flow_1d2usdq</bpmn:outgoing>
+      <bpmn:script>counter = counter + 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1d2usdq" sourceRef="increment_counter" targetRef="Gateway_over_100" />
+    <bpmn:endEvent id="end_event5">
+      <bpmn:documentation>### Results
+Submission for Pre-Review was sent to the HSR-IRB on {{ sent_local_date_str }} at {{ sent_local_time_str }}.
+
+The HSR-IRB started the Pre-Review process on {{ end_local_date_str }} at {{ end_local_time_str }} and assigned {{ irb_info.IRB_ADMINISTRATIVE_REVIEWER }} as the reviewer.
+
+### Metrics
+
+
+Days elapsed: {{days_delta }}</bpmn:documentation>
+      <bpmn:incoming>Flow_1tj9oz1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1gb8wca" sourceRef="TIMER_EVENT" targetRef="increment_counter" />
+    <bpmn:intermediateCatchEvent id="TIMER_EVENT" name="Wait">
+      <bpmn:incoming>Flow_15jw6a4</bpmn:incoming>
+      <bpmn:incoming>Flow_0op1a19</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gb8wca</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0x6divu">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(milliseconds=100)</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:exclusiveGateway id="Gateway_over_100" name="is &#62; 100">
+      <bpmn:incoming>Flow_1d2usdq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1tj9oz1</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0op1a19</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1tj9oz1" name="Yes" sourceRef="Gateway_over_100" targetRef="end_event5">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">counter &gt;= 100</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0op1a19" name="No" sourceRef="Gateway_over_100" targetRef="TIMER_EVENT">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">counter &lt; 100</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_15jw6a4" sourceRef="initialize" targetRef="TIMER_EVENT" />
+    <bpmn:scriptTask id="initialize" name="initialize">
+      <bpmn:incoming>Flow_0q7fkb7</bpmn:incoming>
+      <bpmn:outgoing>Flow_15jw6a4</bpmn:outgoing>
+      <bpmn:script>counter = 0</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="loops">
+      <bpmndi:BPMNEdge id="Flow_15jw6a4_di" bpmnElement="Flow_15jw6a4">
+        <di:waypoint x="350" y="177" />
+        <di:waypoint x="412" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0op1a19_di" bpmnElement="Flow_0op1a19">
+        <di:waypoint x="780" y="152" />
+        <di:waypoint x="780" y="80" />
+        <di:waypoint x="430" y="80" />
+        <di:waypoint x="430" y="159" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="598" y="62" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tj9oz1_di" bpmnElement="Flow_1tj9oz1">
+        <di:waypoint x="805" y="177" />
+        <di:waypoint x="932" y="177" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="818" y="159" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gb8wca_di" bpmnElement="Flow_1gb8wca">
+        <di:waypoint x="448" y="177" />
+        <di:waypoint x="560" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1d2usdq_di" bpmnElement="Flow_1d2usdq">
+        <di:waypoint x="660" y="177" />
+        <di:waypoint x="755" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0q7fkb7_di" bpmnElement="Flow_0q7fkb7">
+        <di:waypoint x="188" y="177" />
+        <di:waypoint x="250" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fgfg5d_di" bpmnElement="increment_counter">
+        <dc:Bounds x="560" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tseamj_di" bpmnElement="end_event5">
+        <dc:Bounds x="932" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0whindt_di" bpmnElement="TIMER_EVENT">
+        <dc:Bounds x="412" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="419" y="202" width="22" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0gr4bqq_di" bpmnElement="Gateway_over_100" isMarkerVisible="true">
+        <dc:Bounds x="755" y="152" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="765" y="209" width="39" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0whalo9_di" bpmnElement="initialize">
+        <dc:Bounds x="250" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/data/spiff/control-flow/arbitrary_cycles.path
+++ b/tests/SpiffWorkflow/data/spiff/control-flow/arbitrary_cycles.path
@@ -2,8 +2,9 @@ Start
   first
     excl_choice_1
       go_to_repetition
-        first
-          excl_choice_1
-            task_c1
-              last
-                End
+        return_to_first
+  first
+    excl_choice_1
+      task_c1
+        last
+          End

--- a/tests/SpiffWorkflow/data/spiff/control-flow/blocking_discriminator.path
+++ b/tests/SpiffWorkflow/data/spiff/control-flow/blocking_discriminator.path
@@ -3,13 +3,12 @@ Start
     task_f1
       struct_discriminator_1
         excl_choice_1
-          first
-            task_f1
-              struct_discriminator_1
-                excl_choice_1
-                  last
-                    End
-            task_f2
-            task_f3
+          return_to_first
+  first
+    task_f1
+      struct_discriminator_1
+        excl_choice_1
+          last
+            End
     task_f2
     task_f3

--- a/tests/SpiffWorkflow/data/spiff/control-flow/blocking_partial_join.path
+++ b/tests/SpiffWorkflow/data/spiff/control-flow/blocking_partial_join.path
@@ -4,12 +4,12 @@ Start
     task_e3
       struct_synch_merge_1
         excl_choice_1
-          multi_choice_1
-            task_e1
-            task_e3
-              struct_synch_merge_1
-                excl_choice_1
-                  last
-                    End
-            task_e4
+          return_to_multi_choice_1
+  multi_choice_1
+    task_e1
+    task_e3
+      struct_synch_merge_1
+        excl_choice_1
+          last
+            End
     task_e4

--- a/tests/SpiffWorkflow/data/spiff/control-flow/cancelling_discriminator.path
+++ b/tests/SpiffWorkflow/data/spiff/control-flow/cancelling_discriminator.path
@@ -3,9 +3,10 @@ Start
     task_f1
       struct_discriminator_1
         excl_choice_1
-          first
-            task_f1
-              struct_discriminator_1
-                excl_choice_1
-                  last
-                    End
+          return_to_first
+  first
+    task_f1
+      struct_discriminator_1
+        excl_choice_1
+          last
+            End

--- a/tests/SpiffWorkflow/data/spiff/control-flow/cancelling_partial_join.path
+++ b/tests/SpiffWorkflow/data/spiff/control-flow/cancelling_partial_join.path
@@ -4,10 +4,10 @@ Start
     task_e3
       struct_synch_merge_1
         excl_choice_1
-          multi_choice_1
-            task_e1
-            task_e3
-              struct_synch_merge_1
-                excl_choice_1
-                  last
-                    End
+          return_to_multi_choice_1
+  multi_choice_1
+    task_e1
+      struct_synch_merge_1
+        excl_choice_1
+          last
+            End

--- a/tests/SpiffWorkflow/data/spiff/control-flow/general_synchronizing_merge.path
+++ b/tests/SpiffWorkflow/data/spiff/control-flow/general_synchronizing_merge.path
@@ -4,16 +4,18 @@ Start
     task_b1
     task_c1
       loop_back_to_c1_once
-        task_c1
-          loop_back_to_c1_once
-            task_c2
-              go_to_stub
-                stub_1
-                  loop_back_to_stub_1_once
-                    stub_1
-                      loop_back_to_stub_1_once
       join
         End
-                        go_to_stub_3
-                          stub_3
-                            foo
+        return_to_task_c1
+    task_c1
+      loop_back_to_c1_once
+        task_c2
+          go_to_stub
+            stub_1
+              loop_back_to_stub_1_once
+                return_to_stub_1
+            stub_1
+              loop_back_to_stub_1_once
+                go_to_stub_3
+                  stub_3
+                    foo

--- a/tests/SpiffWorkflow/data/spiff/control-flow/generalized_and_join.path
+++ b/tests/SpiffWorkflow/data/spiff/control-flow/generalized_and_join.path
@@ -8,14 +8,15 @@ Start
       task_f3
         struct_synch_merge_1
           excl_choice_1
-            first
-              task_e1
-                task_f1
-              task_e2
-                task_f2
-              task_e3
-                task_f3
-                  struct_synch_merge_1
-                    excl_choice_1
-                      last
-                        End
+            return_to_first
+  first
+    task_e1
+      task_f1
+    task_e2
+      task_f2
+    task_e3
+      task_f3
+        struct_synch_merge_1
+          excl_choice_1
+            last
+              End

--- a/tests/SpiffWorkflow/data/spiff/workflow1.path
+++ b/tests/SpiffWorkflow/data/spiff/workflow1.path
@@ -15,28 +15,27 @@ Start
                       task_f1
                         struct_discriminator_1
                           excl_choice_3
-                            excl_choice_1
-                              task_c1
-                                excl_choice_2
-                                  task_d3
-                                    multi_choice_1
-                                      task_e1
-                                      task_e3
-                                        struct_synch_merge_1
-                                          task_f1
-                                            struct_discriminator_1
-                                              excl_choice_3
-                                                multi_instance_1
-                                                  task_g1
-                                                  task_g2
-                                                  task_g1
-                                                  task_g2
-                                                  task_g1
-                                                  task_g2
-                                                    struct_synch_merge_2
-                                                      last
-                                                        End
-                                          task_f2
-                                          task_f3
+                            return_to_excl_choice_1
+        excl_choice_1
+          task_c1
+            excl_choice_2
+              task_d3
+                multi_choice_1
+                  task_e1
+                  task_e3
+                    struct_synch_merge_1
+                      task_f1
+                        struct_discriminator_1
+                          excl_choice_3
+                            multi_instance_1
+                              task_g1
+                              task_g2
+                              task_g1
+                              task_g2
+                              task_g1
+                              task_g2
+                                struct_synch_merge_2
+                                  last
+                                    End
                       task_f2
                       task_f3

--- a/tests/SpiffWorkflow/serializer/baseTest.py
+++ b/tests/SpiffWorkflow/serializer/baseTest.py
@@ -34,7 +34,7 @@ class SerializerTest(PatternTest):
                          exclude_items=None):
         #with open('1.xml', 'w') as fp: fp.write(item1)
         #with open('2.xml', 'w') as fp: fp.write(item2)
-        self.assertEqual(item1, item2)
+        self.assertEqual(item1.decode('utf8'), item2.decode('utf8'))
 
     def _test_roundtrip_serialization(self, obj):
         # Test round trip serialization.


### PR DESCRIPTION
Looping back to a previous point can cause the tree of tasks in a running workflow to grow enormously.

This adds a "Loop Reset Task" which is placed into the task tree where ever we would return to a previous task in the workflow,
when executed it resets the token back to that task, and the tree is pruned back to that point.