### PR TITLE
Fix bug where deserialization failed when a sub-workflow had tasks with the same id as the parent workflow

### DIFF
--- a/SpiffWorkflow/bpmn/serializer/BpmnSerializer.py
+++ b/SpiffWorkflow/bpmn/serializer/BpmnSerializer.py
@@ -72,11 +72,13 @@ class BpmnSerializer(spiff_json.JSONSerializer):
         if not isinstance(task.task_spec, SubWorkflowTask):
             return super()._deserialize_task_children(task, s_state)
         else:
-
             sub_workflow = task.task_spec.create_sub_workflow(task)
             children = []
             for c in s_state['children']:
-                if sub_workflow.get_tasks_from_spec_name(c['task_spec']):
+                # One child belongs to the parent workflow (The path back
+                # out of the subworkflow) the other children belong to the
+                # sub-workflow.
+                if c['workflow_name'] == sub_workflow.name:
                     start_task = self.deserialize_task(sub_workflow, c)
                     children.append(start_task)
                     start_task.parent = task.id

--- a/SpiffWorkflow/workflow.py
+++ b/SpiffWorkflow/workflow.py
@@ -51,6 +51,7 @@ class Workflow(object):
           generating tasks twice (and associated problems with multiple
           hierarchies of tasks)
         """
+        self.name = None
         assert workflow_spec is not None
         LOG.debug("__init__ Workflow instance: %s" % self.__str__())
         self.spec = workflow_spec

--- a/tests/SpiffWorkflow/bpmn/SameNameBugTest.py
+++ b/tests/SpiffWorkflow/bpmn/SameNameBugTest.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function, absolute_import, division
+
+from __future__ import division, absolute_import
+import unittest
+
+from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+__author__ = 'sartography'
+
+
+class SameNameBugTest(BpmnWorkflowTestCase):
+
+    """Should we bail out with a good error message, when two BPMN diagrams
+    that work with each other, have tasks with the same id?!?"""
+
+    def setUp(self):
+        self.spec = self.load_spec()
+
+    def load_spec(self):
+        return self.load_workflow_spec('same_id*.bpmn', 'same_id')
+
+    def testRunThroughHappy(self):
+        self.actual_test(save_restore=False)
+
+    def testThroughSaveRestore(self):
+        self.actual_test(save_restore=True)
+
+    def actual_test(self,save_restore = False):
+        self.workflow = BpmnWorkflow(self.spec,script_engine=PythonScriptEngine())
+        if save_restore:
+            self.save_restore()
+        self.workflow.do_engine_steps()
+        if save_restore:
+            self.save_restore()
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(SameNameBugTest)
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/bpmn/data/same_id.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/same_id.bpmn
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1reb12g" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="same_id" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1fij5ow</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="I_AM_TASK_1" name="Task 1">
+      <bpmn:incoming>Flow_1fij5ow</bpmn:incoming>
+      <bpmn:outgoing>Flow_0gdswwp</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1fij5ow" sourceRef="StartEvent_1" targetRef="I_AM_TASK_1" />
+    <bpmn:sequenceFlow id="Flow_0gdswwp" sourceRef="I_AM_TASK_1" targetRef="CALL_ACTIVITY" />
+    <bpmn:endEvent id="Event_0fd3fmj">
+      <bpmn:incoming>Flow_0z5aj2a</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0z5aj2a" sourceRef="CALL_ACTIVITY" targetRef="Event_0fd3fmj" />
+    <bpmn:callActivity id="CALL_ACTIVITY" name="Task 2" calledElement="same_id_sub">
+      <bpmn:incoming>Flow_0gdswwp</bpmn:incoming>
+      <bpmn:outgoing>Flow_0z5aj2a</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:textAnnotation id="TextAnnotation_09fr7kt">
+      <bpmn:text>This Task's id is "I_AM_TASK_1"  which is the same id of a task in workflow referenced in Task 2</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0wxf3v4" sourceRef="I_AM_TASK_1" targetRef="TextAnnotation_09fr7kt" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="same_id">
+      <bpmndi:BPMNEdge id="Flow_0z5aj2a_di" bpmnElement="Flow_0z5aj2a">
+        <di:waypoint x="530" y="177" />
+        <di:waypoint x="592" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gdswwp_di" bpmnElement="Flow_0gdswwp">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="430" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fij5ow_di" bpmnElement="Flow_1fij5ow">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0n4aa2o_di" bpmnElement="I_AM_TASK_1">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0fd3fmj_di" bpmnElement="Event_0fd3fmj">
+        <dc:Bounds x="592" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1xjmm82_di" bpmnElement="CALL_ACTIVITY">
+        <dc:Bounds x="430" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_09fr7kt_di" bpmnElement="TextAnnotation_09fr7kt">
+        <dc:Bounds x="370" y="50" width="240" height="60" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0wxf3v4_di" bpmnElement="Association_0wxf3v4">
+        <di:waypoint x="356" y="137" />
+        <di:waypoint x="380" y="110" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/same_id_sub.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/same_id_sub.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1reb12g" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="same_id_sub" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1fij5ow</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="I_AM_TASK_1" name="Task 1">
+      <bpmn:incoming>Flow_1fij5ow</bpmn:incoming>
+      <bpmn:outgoing>Flow_0gdswwp</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1fij5ow" sourceRef="StartEvent_1" targetRef="I_AM_TASK_1" />
+    <bpmn:sequenceFlow id="Flow_0gdswwp" sourceRef="I_AM_TASK_1" targetRef="Event_0fd3fmj" />
+    <bpmn:endEvent id="Event_0fd3fmj">
+      <bpmn:incoming>Flow_0gdswwp</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:textAnnotation id="TextAnnotation_09fr7kt">
+      <bpmn:text>This Task's id is "I_AM_TASK_1"  which is the same id of a task in workflow referenced in Task 2</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0wxf3v4" sourceRef="I_AM_TASK_1" targetRef="TextAnnotation_09fr7kt" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="same_id_sub">
+      <bpmndi:BPMNShape id="TextAnnotation_09fr7kt_di" bpmnElement="TextAnnotation_09fr7kt">
+        <dc:Bounds x="370" y="50" width="240" height="60" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1fij5ow_di" bpmnElement="Flow_1fij5ow">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gdswwp_di" bpmnElement="Flow_0gdswwp">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="432" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0n4aa2o_di" bpmnElement="I_AM_TASK_1">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0fd3fmj_di" bpmnElement="Event_0fd3fmj">
+        <dc:Bounds x="432" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0wxf3v4_di" bpmnElement="Association_0wxf3v4">
+        <di:waypoint x="356" y="137" />
+        <di:waypoint x="380" y="110" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Found a bug where deserialization would fail if a sub-workflow contained tasks that had the same id as the parent workflow.`