### PR TITLE
miscellaneous updates to events

### DIFF
--- a/SpiffWorkflow/bpmn/parser/event_parsers.py
+++ b/SpiffWorkflow/bpmn/parser/event_parsers.py
@@ -185,18 +185,21 @@ class IntermediateThrowEventParser(EventDefinitionParser):
 
     def create_task(self):
 
+        escalationEvent = first(self.xpath('.//bpmn:escalationEventDefinition'))
         messageEvent = first(self.xpath('.//bpmn:messageEventDefinition'))
         signalEvent = first(self.xpath('.//bpmn:signalEventDefinition'))
         timerEvent = first(self.xpath('.//bpmn:timerEventDefinition'))
 
-        if messageEvent is not None:
+        if escalationEvent is not None:
+            event_definition = self.parse_escalation_event(escalationEvent)
+        elif messageEvent is not None:
             event_definition = self.parse_message_event(messageEvent)
         elif signalEvent is not None:
             event_definition = self.parse_signal_event(signalEvent)
         elif timerEvent is not None:
             event_definition = self.parse_timer_event(timerEvent)
         else:
-            raise NotImplementedError('Unsupported Throw Catch Event: %r', etree.tostring(self.node))
+            raise NotImplementedError('Unsupported Throw Event: %r', etree.tostring(self.node))
 
         kwargs = {
             'lane': self.get_lane(),

--- a/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
@@ -100,14 +100,12 @@ class BoundaryEvent(CatchingEvent):
         super(BoundaryEvent, self).__init__(wf_spec, name, event_definition, **kwargs)
         self.cancel_activity = cancel_activity
 
-    def will_catch(self, my_task, event_definition):
-        return my_task.state == Task.WAITING
+    def catches(self, my_task, event_definition):
+        # Boundary events should only be caught while waiting
+        return super(BoundaryEvent, self).catches(my_task, event_definition) and my_task.state == Task.WAITING
 
     def catch(self, my_task, event_definition):
         super(BoundaryEvent, self).catch(my_task, event_definition)
-        # Boundary events can be completed as soon as they're received, as they are
-        # activated by the boundary event parent when it is reached and cancelled
-        # after the main task (or another cancelling event) occurs.
         my_task.complete()
 
     def _on_complete_hook(self, my_task):

--- a/SpiffWorkflow/bpmn/specs/events/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_definitions.py
@@ -22,8 +22,6 @@ import datetime
 import logging
 import datetime
 
-from ....bpmn.PythonScriptEngine import PythonScriptEngine
-
 from builtins import object
 
 LOG = logging.getLogger(__name__)

--- a/SpiffWorkflow/bpmn/specs/events/event_types.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_types.py
@@ -35,8 +35,8 @@ class CatchingEvent(Simple, BpmnSpecMixin):
         super(CatchingEvent, self).__init__(wf_spec, name, **kwargs)
         self.event_definition = event_definition
 
-    def will_catch(self, my_task, event_definition):
-        return True  # some tasks may only catch if they are in a certain state.
+    def catches(self, my_task, event_definition):
+        return self.event_definition == event_definition
 
     def catch(self, my_task, event_definition):
         """

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -34,7 +34,6 @@ LOG = logging.getLogger(__name__)
 
 def updateDotDict(dict,id,value):
     x = id.split('.')
-    print(x)
     if len(x) == 1:
         dict[x[0]]=value
     elif dict.get(x[0]):


### PR DESCRIPTION
I've added Intermediate escalation events (we apparently had only included end and boundary events) and fixed an error message.

I think we have to have two functions (one for detecting the event and one for executing the code after all).  I changed the name of that method, which I admit was unnecessary but I like the shorter name.  The bigger improvement is just moving the event definition check out of the workflow to that method, so that all the conditions are checked in the same place.