### PR TITLE
Better Errors for Call Activities

### DIFF
--- a/SpiffWorkflow/exceptions.py
+++ b/SpiffWorkflow/exceptions.py
@@ -70,19 +70,7 @@ class WorkflowTaskExecException(WorkflowException):
         # so we can tell how we got to this paticular task, no matter how
         # deeply nested in sub-workflows it is.  Takes the form of:
         # task-description (file-name)
-        self.task_trace = []
-
-        back_task = task
-        last_workflow = None
-        while True:
-            if back_task.workflow != last_workflow:
-                self.task_trace.append(f"{back_task.task_spec.description} "
-                                       f"({back_task.workflow.spec.file})")
-                last_workflow = back_task.workflow
-            if back_task.parent and back_task != back_task.parent:
-                back_task = back_task.parent
-            else:
-                break
+        self.task_trace = self.get_task_trace(task)
 
         if isinstance(exception, SyntaxError):
             # Prefer line number from syntax error if available.
@@ -97,6 +85,22 @@ class WorkflowTaskExecException(WorkflowException):
             error_msg += f' Did you mean \'{most_similar}\'?'
 
         WorkflowException.__init__(self, task.task_spec, error_msg)
+
+    @staticmethod
+    def get_task_trace(task):
+        task_trace = []
+        back_task = task
+        last_workflow = None
+        while True:
+            if back_task.workflow != last_workflow:
+                task_trace.append(f"{back_task.task_spec.description} "
+                                  f"({back_task.workflow.spec.file})")
+                last_workflow = back_task.workflow
+            if back_task.parent and back_task != back_task.parent:
+                back_task = back_task.parent
+            else:
+                break
+        return task_trace
 
 
 class StorageException(Exception):

--- a/SpiffWorkflow/exceptions.py
+++ b/SpiffWorkflow/exceptions.py
@@ -66,6 +66,23 @@ class WorkflowTaskExecException(WorkflowException):
         self.task = task
         self.exception = exception
         self.error_line = error_line
+        # If encountered in a sub-workflow, this traces back up the stack
+        # so we can tell how we got to this paticular task, no matter how
+        # deeply nested in sub-workflows it is.  Takes the form of:
+        # task-description (file-name)
+        self.task_trace = []
+
+        back_task = task
+        last_workflow = None
+        while True:
+            if back_task.workflow != last_workflow:
+                self.task_trace.append(f"{back_task.task_spec.description} "
+                                       f"({back_task.workflow.spec.file})")
+                last_workflow = back_task.workflow
+            if back_task.parent and back_task != back_task.parent:
+                back_task = back_task.parent
+            else:
+                break
 
         if isinstance(exception, SyntaxError):
             # Prefer line number from syntax error if available.

--- a/tests/SpiffWorkflow/bpmn/CallActivityEndEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivityEndEventTest.py
@@ -7,6 +7,7 @@ import os
 import unittest
 
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.exceptions import WorkflowTaskExecException
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
@@ -64,6 +65,14 @@ class CallActivityTest(BpmnWorkflowTestCase):
         self.assertTrue(self.workflow.is_completed())
         self.assertNotIn('remove_this_var', self.workflow.last_task.data.keys())
 
+    def test_call_acitivity_errors_include_task_trace(self):
+        error_spec = self.load_workflow_spec('call_activity_*.bpmn','ErroringBPMN')
+        with self.assertRaises(WorkflowTaskExecException) as context:
+            self.workflow = BpmnWorkflow(error_spec)
+            self.workflow.do_engine_steps()
+        self.assertEquals(2, len(context.exception.task_trace))
+        self.assertEqual('Create Data (None:Call_Activity_Get_Data.bpmn)', context.exception.task_trace[0])
+        self.assertEqual('Get Data Call Activity (None:ErroringBPMN.bpmn)', context.exception.task_trace[1])
 
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(CallActivityTest)

--- a/tests/SpiffWorkflow/bpmn/data/call_activity_with_error.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/call_activity_with_error.bpmn
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_f07329e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
+  <bpmn:process id="ErroringBPMN" name="Primary  BPMN" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1g3dpd7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1g3dpd7" sourceRef="StartEvent_1" targetRef="Activity_0wppf2v" />
+    <bpmn:sequenceFlow id="Flow_0ovgj6c" sourceRef="Activity_0wppf2v" targetRef="Activity_12zat0d" />
+    <bpmn:callActivity id="Activity_12zat0d" name="Get Data Call Activity" calledElement="Call_Activity_Get_Data">
+      <bpmn:incoming>Flow_0ovgj6c</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qdgvah</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0qdgvah" sourceRef="Activity_12zat0d" targetRef="Activity_1ta6769" />
+    <bpmn:endEvent id="Event_18dla68">
+      <bpmn:documentation># Main Workflow
+Hello {{my_other_var}}
+
+</bpmn:documentation>
+      <bpmn:incoming>Flow_0izaz4f</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0izaz4f" sourceRef="Activity_1ta6769" targetRef="Event_18dla68" />
+    <bpmn:scriptTask id="Activity_1ta6769" name="Print Data">
+      <bpmn:incoming>Flow_0qdgvah</bpmn:incoming>
+      <bpmn:outgoing>Flow_0izaz4f</bpmn:outgoing>
+      <bpmn:script>print(pre_var)
+print(my_var)
+print(my_other_var)</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_0wppf2v" name="Pre Data">
+      <bpmn:incoming>Flow_1g3dpd7</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ovgj6c</bpmn:outgoing>
+      <bpmn:script>pre_var = 'some string'
+# There is no variable remove
+# remove_this_var = 'something else'</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ErroringBPMN">
+      <bpmndi:BPMNEdge id="Flow_0izaz4f_di" bpmnElement="Flow_0izaz4f">
+        <di:waypoint x="690" y="117" />
+        <di:waypoint x="752" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qdgvah_di" bpmnElement="Flow_0qdgvah">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="590" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ovgj6c_di" bpmnElement="Flow_0ovgj6c">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g3dpd7_di" bpmnElement="Flow_1g3dpd7">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mcej1g_di" bpmnElement="Activity_12zat0d">
+        <dc:Bounds x="430" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18dla68_di" bpmnElement="Event_18dla68">
+        <dc:Bounds x="752" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1v8hse1_di" bpmnElement="Activity_1ta6769">
+        <dc:Bounds x="590" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mhwjko_di" bpmnElement="Activity_0wppf2v">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
If you have a sub-workflow in a separate file, or worse, workflows within workflows within workflows, all in different files, it can be difficult to tell what series of events got you to where the error happened.  This adds a little context to the WorkflowTaskExecException, an array that contains the Task Spec Description, and the Workflow filename for every file involved in reaching the error state.