### PR TITLE
Bug/serializer call activity issue

### DIFF
--- a/SpiffWorkflow/bpmn/serializer/task_spec_converters.py
+++ b/SpiffWorkflow/bpmn/serializer/task_spec_converters.py
@@ -100,7 +100,7 @@ class UserTaskConverter(BpmnTaskSpecConverter):
 
     def __init__(self, data_converter=None, typename=None):
         super().__init__(UserTask, data_converter, typename)
- 
+
     def to_dict(self, spec):
         dct = self.get_default_attributes(spec)
         dct.update(self.get_bpmn_attributes(spec))

--- a/SpiffWorkflow/bpmn/serializer/workflow_spec_converter.py
+++ b/SpiffWorkflow/bpmn/serializer/workflow_spec_converter.py
@@ -114,10 +114,12 @@ class BpmnProcessSpecConverter(BpmnWorkflowSpecConverter):
                 task_dict = self.convert(task_spec)
             if isinstance(task_spec, SubWorkflowTask):
                 task_dict['spec'] = self.convert(task_spec.spec)
-#                task_dict['sub_workflow'] = None
-#                if isinstance(task_spec.sub_workflow, BpmnWorkflow):
-#                    task_dict['sub_workflow'] = task_spec.sub_workflow.name
-                task_dict['sub_workflow'] = task_spec.sub_workflow.name if task_spec.sub_workflow is not None else None
+                task_dict['sub_workflow'] = None
+                if isinstance(task_spec.sub_workflow, BpmnWorkflow):
+                    task_dict['sub_workflow'] = task_spec.sub_workflow.name
+                elif isinstance(task_spec.sub_workflow, str):
+                    task_dict['sub_workflow'] = task_spec.sub_workflow
+#                task_dict['sub_workflow'] = task_spec.sub_workflow.name if task_spec.sub_workflow is not None else None
             self.convert_task_spec_extensions(task_spec, task_dict)
             dct['task_specs'][name] = task_dict
 

--- a/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
+++ b/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
@@ -448,7 +448,7 @@ class MultiInstanceTask(TaskSpec):
             runtimesvar = runtimes
 
         if self.elementVar in my_task.data and isinstance(my_task.data[self.elementVar], dict):
-            collect[runtimesvar] = DeepMerge.merge(collect.get(runtimesvar, {}),
+            collect[str(runtimesvar)] = DeepMerge.merge(collect.get(runtimesvar, {}),
                                                    copy.copy(my_task.data[self.elementVar]))
 
         LOG.debug(my_task.task_spec.name + 'complete hook')

--- a/SpiffWorkflow/bpmn/specs/events/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_definitions.py
@@ -200,7 +200,10 @@ class MessageEventDefinition(NamedEventDefinition):
             result_var = f'{my_task.task_spec.name}_Response'
         else:
             result_var = event_definition.result_var
-        my_task.internal_data[event_definition.name] = result_var, event_definition.payload
+        my_task.internal_data[event_definition.name] = {
+            "result_var": result_var,
+            "payload": event_definition.payload
+        }
         super(MessageEventDefinition, self).catch(my_task, event_definition)
 
     def throw(self, my_task):

--- a/SpiffWorkflow/bpmn/specs/events/event_types.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_types.py
@@ -68,8 +68,8 @@ class CatchingEvent(Simple, BpmnSpecMixin):
         if isinstance(self.event_definition, MessageEventDefinition):
             # If we are a message event, then we need to copy the event data out of
             # our internal data and into the task data
-            result_var, result = my_task.internal_data[self.event_definition.name]
-            my_task.data[result_var] = result
+            event_data = my_task.internal_data[self.event_definition.name]
+            my_task.data[event_data['result_var']] = event_data['payload']
         self.event_definition.reset(my_task)
         super(CatchingEvent, self)._on_complete_hook(my_task)
 

--- a/SpiffWorkflow/bpmn/workflow.py
+++ b/SpiffWorkflow/bpmn/workflow.py
@@ -168,7 +168,6 @@ class BpmnWorkflow(Workflow):
 
     def _task_completed_notify(self, task):
         assert (not self.read_only) or self._is_busy_with_restore()
-        self.last_task = task
         super(BpmnWorkflow, self)._task_completed_notify(task)
 
     def _task_cancelled_notify(self, task):

--- a/SpiffWorkflow/dmn/parser/DMNParser.py
+++ b/SpiffWorkflow/dmn/parser/DMNParser.py
@@ -190,7 +190,6 @@ class DMNParser(object):
             if entry.text and entry.text != '':
                 try:
                     ast.parse(entry.text)
-                    entry.parsedRef = entry.text
                 except:
                     raise Exception("Malformed Output Expression '%s' " % entry.text)
         return entry

--- a/SpiffWorkflow/dmn/specs/model.py
+++ b/SpiffWorkflow/dmn/specs/model.py
@@ -116,16 +116,12 @@ class OutputEntry:
         out['output'] = self.output.serialize()
         out['description'] = self.description
         out['text'] = self.text
-        if hasattr(self,'parsedRef'):
-            out['parsedRef'] = self.parsedRef
         return out
 
     def deserialize(self, indict):
         self.id = indict['id']
         self.description = indict['description']
         self.text = indict['text']
-        if 'parsedRef' in indict:
-            self.parsedRef = indict['parsedRef']
         self.output = Output(**indict['output'])
 
 
@@ -160,8 +156,8 @@ class Rule:
         for outputEntry in self.outputEntries:
             # try to use the id, but fall back to label if no name is provided.
             key = outputEntry.output.name or outputEntry.output.label
-            if hasattr(outputEntry, "parsedRef"):
-                outvalue = script_engine.evaluate(task, outputEntry.parsedRef)
+            if hasattr(outputEntry, "text") and outputEntry.text:
+                outvalue = script_engine.evaluate(task, outputEntry.text)
             else:
                 outvalue = ""
             if '.' in key:         # we need to allow for dot notation in the DMN -

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -400,9 +400,10 @@ class TaskSpec(object):
                 my_task.task_spec.__class__.__name__,
                 my_task.get_name(), my_task.get_description()))
 
+        # We have to set the last task here, because the on_complete_hook
+        # of a loopback task may overwrite what the last_task will be.
+        my_task.workflow.last_task = my_task
         self._on_complete_hook(my_task)
-
-        # Notify the Workflow.
         my_task.workflow._task_completed_notify(my_task)
 
         if my_task.workflow.debug:

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -298,6 +298,7 @@ class Task(object):
             return
 
         if isinstance(self.task_spec,SubWorkflowTask):
+            self.task_spec.sub_workflow = None
             self.children = [] # if we have a call activity,
                                # force reset of children.
 

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
@@ -98,8 +98,8 @@ class BpmnWorkflowTestCase(unittest.TestCase):
         before_state = self._get_workflow_state(do_steps=False)
         before_dump = self.workflow.get_dump()
         # Check that we can actully convert this to JSON
-        json.dumps(before_state)
-        self.restore(before_state)
+        json_str = json.dumps(before_state)
+        self.restore(json.loads(json_str))
         # Check that serializing and deserializing results in the same workflow
         after_state = self._get_workflow_state(do_steps=False)
         after_dump = self.workflow.get_dump()

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
@@ -99,13 +99,15 @@ class BpmnWorkflowTestCase(unittest.TestCase):
         before_dump = self.workflow.get_dump()
         # Check that we can actully convert this to JSON
         json_str = json.dumps(before_state)
-        self.restore(json.loads(json_str))
+        workflow2 = self.serializer.workflow_from_dict(json.loads(json_str), read_only=False)
+#       self.restore(json.loads(json_str))
         # Check that serializing and deserializing results in the same workflow
-        after_state = self._get_workflow_state(do_steps=False)
-        after_dump = self.workflow.get_dump()
+        after_state = self.serializer.workflow_to_dict(workflow2)
+        after_dump = workflow2.get_dump()
         self.maxDiff = None
         self.assertEqual(before_dump, after_dump)
         self.assertEqual(before_state, after_state)
+        self.workflow = workflow2
 
     def restore(self, state):
         self.workflow = self.serializer.workflow_from_dict(state, read_only=False)

--- a/tests/SpiffWorkflow/bpmn/TooManyLoopsTest.py
+++ b/tests/SpiffWorkflow/bpmn/TooManyLoopsTest.py
@@ -21,7 +21,7 @@ class TooManyLoopsTest(BpmnWorkflowTestCase):
         self.spec = self.load_spec()
 
     def load_spec(self):
-        return self.load_workflow_spec('too_many_loops.bpmn', 'loops')
+        return self.load_workflow_spec('too_many_loops*.bpmn', 'loops')
 
     def testRunThroughHappy(self):
         self.actual_test(save_restore=False)
@@ -48,7 +48,7 @@ class TooManyLoopsTest(BpmnWorkflowTestCase):
         # Found an issue where looping back would fail when it happens
         # right after a sub-process.  So assuring this is fixed.
         counter = 0
-        spec = self.load_workflow_spec('too_many_loops_sub_process.bpmn', 'loops')
+        spec = self.load_workflow_spec('too_many_loops_sub_process.bpmn', 'loops_sub')
         self.workflow = BpmnWorkflow(spec,script_engine=PythonScriptEngine())
         data = {}
         while not self.workflow.is_completed():

--- a/tests/SpiffWorkflow/bpmn/data/message_test.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/message_test.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0ktat0o" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0ktat0o" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
   <bpmn:collaboration id="Collaboration_0n93bdm">
     <bpmn:participant id="Participant_1s3h4jc" processRef="ThrowCatch" />
   </bpmn:collaboration>
@@ -13,12 +13,12 @@
       </bpmn:lane>
       <bpmn:lane id="Lane_0m6phgl" name="process_b">
         <bpmn:flowNodeRef>Event_NormalStart</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Gateway_Approved</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Activity_EnterPlan</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Event_SendRequest</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Event_GetRequest</bpmn:flowNodeRef>
-        <bpmn:flowNodeRef>Event_EndEvent1</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Gateway_Approved</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Activity_EnterPlan</bpmn:flowNodeRef>
         <bpmn:flowNodeRef>Activity_EnablePlan</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_EndEvent1</bpmn:flowNodeRef>
       </bpmn:lane>
     </bpmn:laneSet>
     <bpmn:startEvent id="Event_NormalStart">
@@ -82,10 +82,6 @@
       <bpmn:outgoing>Flow_1ym5g7r</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_0q86vff" messageRef="Message_1rkbi27" />
     </bpmn:startEvent>
-    <bpmn:endEvent id="Event_EndEvent1">
-      <bpmn:incoming>Flow_1ync7ek</bpmn:incoming>
-      <bpmn:terminateEventDefinition id="TerminateEventDefinition_1xkk9g2" />
-    </bpmn:endEvent>
     <bpmn:userTask id="Activity_EnablePlan" name="Enable Plan" camunda:formKey="Final Form">
       <bpmn:extensionElements>
         <camunda:formData>
@@ -95,20 +91,72 @@
       <bpmn:incoming>Flow_0jqxt85</bpmn:incoming>
       <bpmn:outgoing>Flow_1ync7ek</bpmn:outgoing>
     </bpmn:userTask>
+    <bpmn:endEvent id="Event_EndEvent1">
+      <bpmn:incoming>Flow_1ync7ek</bpmn:incoming>
+      <bpmn:terminateEventDefinition id="TerminateEventDefinition_1xkk9g2" />
+    </bpmn:endEvent>
   </bpmn:process>
   <bpmn:message id="Message_0sqqwvq" name="Approval" />
   <bpmn:message id="Message_1rkbi27" name="ApprovalRequest" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0n93bdm">
       <bpmndi:BPMNShape id="Participant_1s3h4jc_di" bpmnElement="Participant_1s3h4jc" isHorizontal="true">
-        <dc:Bounds x="129" y="79" width="991" height="401" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Lane_0stxlz6_di" bpmnElement="Lane_0stxlz6" isHorizontal="true">
-        <dc:Bounds x="159" y="79" width="961" height="125" />
+        <dc:Bounds x="129" y="79" width="761" height="401" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Lane_0m6phgl_di" bpmnElement="Lane_0m6phgl" isHorizontal="true">
-        <dc:Bounds x="159" y="204" width="961" height="276" />
+        <dc:Bounds x="159" y="204" width="731" height="276" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0stxlz6_di" bpmnElement="Lane_0stxlz6" isHorizontal="true">
+        <dc:Bounds x="159" y="79" width="731" height="125" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0abuvsx_di" bpmnElement="Flow_0abuvsx">
+        <di:waypoint x="528" y="150" />
+        <di:waypoint x="572" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_060cfic_di" bpmnElement="Flow_060cfic">
+        <di:waypoint x="258" y="330" />
+        <di:waypoint x="280" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tfirpy_di" bpmnElement="Flow_1tfirpy">
+        <di:waypoint x="620" y="355" />
+        <di:waypoint x="620" y="450" />
+        <di:waypoint x="330" y="450" />
+        <di:waypoint x="330" y="370" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="455" y="432" width="42" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ym5g7r_di" bpmnElement="Flow_1ym5g7r">
+        <di:waypoint x="278" y="150" />
+        <di:waypoint x="340" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m1dzpq_di" bpmnElement="Flow_0m1dzpq">
+        <di:waypoint x="440" y="150" />
+        <di:waypoint x="492" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jqxt85_di" bpmnElement="Flow_0jqxt85">
+        <di:waypoint x="645" y="330" />
+        <di:waypoint x="690" y="330" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="656" y="312" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nsjil4_di" bpmnElement="Flow_1nsjil4">
+        <di:waypoint x="380" y="330" />
+        <di:waypoint x="422" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1t3bhky_di" bpmnElement="Flow_1t3bhky">
+        <di:waypoint x="458" y="330" />
+        <di:waypoint x="512" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ync7ek_di" bpmnElement="Flow_1ync7ek">
+        <di:waypoint x="790" y="330" />
+        <di:waypoint x="832" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jdfc06_di" bpmnElement="Flow_1jdfc06">
+        <di:waypoint x="548" y="330" />
+        <di:waypoint x="595" y="330" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1kih4yf_di" bpmnElement="Event_NormalStart">
         <dc:Bounds x="222" y="312" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -121,89 +169,41 @@
       <bpmndi:BPMNShape id="Event_1cb7mmu_di" bpmnElement="Event_GetRequest">
         <dc:Bounds x="512" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="487" y="376" width="65" height="27" />
+          <dc:Bounds x="497" y="356" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1jdfc06_di" bpmnElement="Flow_1jdfc06">
-        <di:waypoint x="548" y="330" />
-        <di:waypoint x="595" y="330" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ync7ek_di" bpmnElement="Flow_1ync7ek">
-        <di:waypoint x="790" y="330" />
-        <di:waypoint x="862" y="330" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1t3bhky_di" bpmnElement="Flow_1t3bhky">
-        <di:waypoint x="458" y="330" />
-        <di:waypoint x="512" y="330" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1nsjil4_di" bpmnElement="Flow_1nsjil4">
-        <di:waypoint x="380" y="330" />
-        <di:waypoint x="422" y="330" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Gateway_0hlo27j_di" bpmnElement="Gateway_Approved" isMarkerVisible="true">
         <dc:Bounds x="595" y="305" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="595" y="275" width="50" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0jqxt85_di" bpmnElement="Flow_0jqxt85">
-        <di:waypoint x="645" y="330" />
-        <di:waypoint x="690" y="330" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="656" y="312" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0m1dzpq_di" bpmnElement="Flow_0m1dzpq">
-        <di:waypoint x="440" y="150" />
-        <di:waypoint x="492" y="150" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0bbi5vw_di" bpmnElement="Activity_ApproveOrDeny">
+        <dc:Bounds x="340" y="110" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kg6an6_di" bpmnElement="Activity_EnterPlan">
+        <dc:Bounds x="280" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jotxd7_di" bpmnElement="Event_SendRequestResponse">
         <dc:Bounds x="492" y="132" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="472" y="175" width="76" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1ym5g7r_di" bpmnElement="Flow_1ym5g7r">
-        <di:waypoint x="278" y="150" />
-        <di:waypoint x="340" y="150" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tfirpy_di" bpmnElement="Flow_1tfirpy">
-        <di:waypoint x="620" y="355" />
-        <di:waypoint x="620" y="450" />
-        <di:waypoint x="330" y="450" />
-        <di:waypoint x="330" y="370" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="455" y="432" width="42" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_16fdfur_di" bpmnElement="Event_EndEvent2">
         <dc:Bounds x="572" y="132" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0bbi5vw_di" bpmnElement="Activity_ApproveOrDeny">
-        <dc:Bounds x="340" y="110" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_060cfic_di" bpmnElement="Flow_060cfic">
-        <di:waypoint x="258" y="330" />
-        <di:waypoint x="280" y="330" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1kg6an6_di" bpmnElement="Activity_EnterPlan">
-        <dc:Bounds x="280" y="290" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_13sr7ty_di" bpmnElement="Activity_EnablePlan">
-        <dc:Bounds x="690" y="290" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0abuvsx_di" bpmnElement="Flow_0abuvsx">
-        <di:waypoint x="528" y="150" />
-        <di:waypoint x="572" y="150" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_11yv3q9_di" bpmnElement="Event_GotRequest">
         <dc:Bounds x="242" y="132" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="217" y="175" width="88" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13sr7ty_di" bpmnElement="Activity_EnablePlan">
+        <dc:Bounds x="690" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0sezh04_di" bpmnElement="Event_EndEvent1">
-        <dc:Bounds x="862" y="312" width="36" height="36" />
+        <dc:Bounds x="832" y="312" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/tests/SpiffWorkflow/bpmn/data/too_many_loops.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/too_many_loops.bpmn
@@ -1,16 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_d4f3442" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
   <bpmn:process id="loops" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1">
-      <bpmn:outgoing>Flow_0q7fkb7</bpmn:outgoing>
-    </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0q7fkb7" sourceRef="StartEvent_1" targetRef="initialize" />
     <bpmn:scriptTask id="increment_counter" name="increment counter">
       <bpmn:incoming>Flow_1gb8wca</bpmn:incoming>
       <bpmn:outgoing>Flow_1d2usdq</bpmn:outgoing>
       <bpmn:script>counter = counter + 1</bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:sequenceFlow id="Flow_1d2usdq" sourceRef="increment_counter" targetRef="Gateway_over_20" />
+    <bpmn:sequenceFlow id="Flow_1d2usdq" sourceRef="increment_counter" targetRef="Activity_0w5u4k4" />
     <bpmn:endEvent id="end_event5">
       <bpmn:documentation>### Results
 Submission for Pre-Review was sent to the HSR-IRB on {{ sent_local_date_str }} at {{ sent_local_time_str }}.
@@ -33,7 +29,7 @@ Days elapsed: {{days_delta }}</bpmn:documentation>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
     <bpmn:exclusiveGateway id="Gateway_over_20" name="is &#62; 20">
-      <bpmn:incoming>Flow_1d2usdq</bpmn:incoming>
+      <bpmn:incoming>Flow_0mxlkif</bpmn:incoming>
       <bpmn:outgoing>Flow_1tj9oz1</bpmn:outgoing>
       <bpmn:outgoing>Flow_0op1a19</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -49,6 +45,15 @@ Days elapsed: {{days_delta }}</bpmn:documentation>
       <bpmn:outgoing>Flow_15jw6a4</bpmn:outgoing>
       <bpmn:script>counter = 0</bpmn:script>
     </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_0mxlkif" sourceRef="Activity_0w5u4k4" targetRef="Gateway_over_20" />
+    <bpmn:callActivity id="Activity_0w5u4k4" name="call something" calledElement="loops_ca">
+      <bpmn:incoming>Flow_1d2usdq</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mxlkif</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0q7fkb7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0q7fkb7" sourceRef="StartEvent_1" targetRef="initialize" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="loops">
@@ -74,21 +79,22 @@ Days elapsed: {{days_delta }}</bpmn:documentation>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gb8wca_di" bpmnElement="Flow_1gb8wca">
         <di:waypoint x="448" y="177" />
-        <di:waypoint x="560" y="177" />
+        <di:waypoint x="480" y="177" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1d2usdq_di" bpmnElement="Flow_1d2usdq">
-        <di:waypoint x="660" y="177" />
-        <di:waypoint x="755" y="177" />
+        <di:waypoint x="580" y="177" />
+        <di:waypoint x="620" y="177" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0q7fkb7_di" bpmnElement="Flow_0q7fkb7">
         <di:waypoint x="188" y="177" />
         <di:waypoint x="250" y="177" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mxlkif_di" bpmnElement="Flow_0mxlkif">
+        <di:waypoint x="720" y="177" />
+        <di:waypoint x="755" y="177" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="152" y="159" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1fgfg5d_di" bpmnElement="increment_counter">
-        <dc:Bounds x="560" y="137" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1tseamj_di" bpmnElement="end_event5">
         <dc:Bounds x="932" y="159" width="36" height="36" />
@@ -107,6 +113,12 @@ Days elapsed: {{days_delta }}</bpmn:documentation>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0whalo9_di" bpmnElement="initialize">
         <dc:Bounds x="250" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fgfg5d_di" bpmnElement="increment_counter">
+        <dc:Bounds x="480" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mmgsiw_di" bpmnElement="Activity_0w5u4k4">
+        <dc:Bounds x="620" y="137" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/tests/SpiffWorkflow/bpmn/data/too_many_loops_call_activity.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/too_many_loops_call_activity.bpmn
@@ -26,22 +26,22 @@ Days elapsed: {{days_delta }}</bpmn:documentation>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="loops_ca">
-      <bpmndi:BPMNEdge id="Flow_1d2usdq_di" bpmnElement="Flow_1d2usdq">
-        <di:waypoint x="725" y="127" />
-        <di:waypoint x="1072" y="127" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_175n91v_di" bpmnElement="Flow_175n91v">
         <di:waypoint x="188" y="127" />
-        <di:waypoint x="625" y="127" />
+        <di:waypoint x="220" y="127" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1d2usdq_di" bpmnElement="Flow_1d2usdq">
+        <di:waypoint x="320" y="127" />
+        <di:waypoint x="362" y="127" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="152" y="109" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1fgfg5d_di" bpmnElement="increment_counter">
-        <dc:Bounds x="625" y="87" width="100" height="80" />
+        <dc:Bounds x="220" y="87" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1tseamj_di" bpmnElement="end_event5">
-        <dc:Bounds x="1072" y="109" width="36" height="36" />
+        <dc:Bounds x="362" y="109" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/tests/SpiffWorkflow/bpmn/data/too_many_loops_call_activity.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/too_many_loops_call_activity.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_d4f3442" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
+  <bpmn:process id="loops_ca" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_175n91v</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:scriptTask id="increment_counter" name="increment counter">
+      <bpmn:incoming>Flow_175n91v</bpmn:incoming>
+      <bpmn:outgoing>Flow_1d2usdq</bpmn:outgoing>
+      <bpmn:script>counter2 = 1000</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1d2usdq" sourceRef="increment_counter" targetRef="end_event5" />
+    <bpmn:endEvent id="end_event5">
+      <bpmn:documentation>### Results
+Submission for Pre-Review was sent to the HSR-IRB on {{ sent_local_date_str }} at {{ sent_local_time_str }}.
+
+The HSR-IRB started the Pre-Review process on {{ end_local_date_str }} at {{ end_local_time_str }} and assigned {{ irb_info.IRB_ADMINISTRATIVE_REVIEWER }} as the reviewer.
+
+### Metrics
+
+
+Days elapsed: {{days_delta }}</bpmn:documentation>
+      <bpmn:incoming>Flow_1d2usdq</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_175n91v" sourceRef="StartEvent_1" targetRef="increment_counter" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="loops_ca">
+      <bpmndi:BPMNEdge id="Flow_1d2usdq_di" bpmnElement="Flow_1d2usdq">
+        <di:waypoint x="725" y="127" />
+        <di:waypoint x="1072" y="127" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_175n91v_di" bpmnElement="Flow_175n91v">
+        <di:waypoint x="188" y="127" />
+        <di:waypoint x="625" y="127" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="109" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fgfg5d_di" bpmnElement="increment_counter">
+        <dc:Bounds x="625" y="87" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tseamj_di" bpmnElement="end_event5">
+        <dc:Bounds x="1072" y="109" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/too_many_loops_sub_process.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/too_many_loops_sub_process.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_d4f3442" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
-  <bpmn:process id="loops" isExecutable="true">
+  <bpmn:process id="loops_sub" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0q7fkb7</bpmn:outgoing>
     </bpmn:startEvent>
@@ -71,7 +71,7 @@ counter3 = 0</bpmn:script>
     </bpmn:subProcess>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="loops">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="loops_sub">
       <bpmndi:BPMNEdge id="Flow_1ivr6d7_di" bpmnElement="Flow_1ivr6d7">
         <di:waypoint x="490" y="310" />
         <di:waypoint x="430" y="310" />
@@ -89,6 +89,13 @@ counter3 = 0</bpmn:script>
           <dc:Bounds x="863" y="292" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tj9oz1_di" bpmnElement="Flow_1tj9oz1">
+        <di:waypoint x="945" y="127" />
+        <di:waypoint x="1072" y="127" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="958" y="109" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gb8wca_di" bpmnElement="Flow_1gb8wca">
         <di:waypoint x="448" y="127" />
         <di:waypoint x="625" y="127" />
@@ -101,15 +108,14 @@ counter3 = 0</bpmn:script>
         <di:waypoint x="188" y="127" />
         <di:waypoint x="250" y="127" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tj9oz1_di" bpmnElement="Flow_1tj9oz1">
-        <di:waypoint x="945" y="127" />
-        <di:waypoint x="1072" y="127" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="958" y="109" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="152" y="109" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fgfg5d_di" bpmnElement="increment_counter">
+        <dc:Bounds x="625" y="87" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1tseamj_di" bpmnElement="end_event5">
+        <dc:Bounds x="1072" y="109" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0whindt_di" bpmnElement="TIMER_EVENT">
         <dc:Bounds x="412" y="109" width="36" height="36" />
@@ -117,20 +123,14 @@ counter3 = 0</bpmn:script>
           <dc:Bounds x="419" y="85" width="22" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0whalo9_di" bpmnElement="initialize">
-        <dc:Bounds x="250" y="87" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1tseamj_di" bpmnElement="end_event5">
-        <dc:Bounds x="1072" y="109" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0gr4bqq_di" bpmnElement="Gateway_over_20" isMarkerVisible="true">
         <dc:Bounds x="895" y="102" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="908" y="159" width="33" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1fgfg5d_di" bpmnElement="increment_counter">
-        <dc:Bounds x="625" y="87" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0whalo9_di" bpmnElement="initialize">
+        <dc:Bounds x="250" y="87" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0v3bik3_di" bpmnElement="my_sub_process" isExpanded="true">
         <dc:Bounds x="490" y="210" width="350" height="200" />

--- a/tests/SpiffWorkflow/camunda/MultiInstanceArrayTest.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceArrayTest.py
@@ -84,9 +84,9 @@ class MultiInstanceArrayTest(BaseTestCase):
             if save_restore: self.save_restore()
             self.workflow.do_engine_steps()
 
-        self.assertEqual({1: {'FirstName': 'The Funk #0'},
-                          2: {'FirstName': 'The Funk #1'},
-                          3: {'FirstName': 'The Funk #2'}},
+        self.assertEqual({'1': {'FirstName': 'The Funk #0'},
+                          '2': {'FirstName': 'The Funk #1'},
+                          '3': {'FirstName': 'The Funk #2'}},
                          task.data["Family"]["Members"])
         #### NB - start here
         ###  Data is not correctly getting to the next task upon complete of the last task
@@ -111,9 +111,9 @@ class MultiInstanceArrayTest(BaseTestCase):
         if save_restore: self.save_restore()
         self.assertTrue(self.workflow.is_completed())
 
-        self.assertEqual({1: {'FirstName': 'The Funk #0', "Birthdate": "10/00/1985"},
-                          2: {'FirstName': 'The Funk #1', "Birthdate": "10/01/1985"},
-                          3: {'FirstName': 'The Funk #2', "Birthdate": "10/02/1985"}},
+        self.assertEqual({'1': {'FirstName': 'The Funk #0', "Birthdate": "10/00/1985"},
+                          '2': {'FirstName': 'The Funk #1', "Birthdate": "10/01/1985"},
+                          '3': {'FirstName': 'The Funk #2', "Birthdate": "10/02/1985"}},
                          self.workflow.last_task.data["Family"]["Members"])
 
 
@@ -142,9 +142,9 @@ class MultiInstanceArrayTest(BaseTestCase):
             self.workflow.complete_task_from_id(task.id)
             if save_restore: self.save_restore()
 
-        self.assertEqual({1: {'FirstName': 'The Funk #0'},
-                          2: {'FirstName': 'The Funk #1'},
-                          3: {'FirstName': 'The Funk #2'}},
+        self.assertEqual({'1': {'FirstName': 'The Funk #0'},
+                          '2': {'FirstName': 'The Funk #1'},
+                          '3': {'FirstName': 'The Funk #2'}},
                          task.data["Family"]["Members"])
 
 
@@ -183,9 +183,9 @@ class MultiInstanceArrayTest(BaseTestCase):
             self.workflow.complete_task_from_id(task.id)
             if save_restore: self.save_restore()
 
-        self.assertEqual({1: {'FirstName': 'The Funk #0'},
-                          2: {'FirstName': 'The Funk #1'},
-                          3: {'FirstName': 'The Funk #2'}},
+        self.assertEqual({'1': {'FirstName': 'The Funk #0'},
+                          '2': {'FirstName': 'The Funk #1'},
+                          '3': {'FirstName': 'The Funk #2'}},
                          task.data["Family"]["Members"])
 
 

--- a/tests/SpiffWorkflow/camunda/ResetTokenMIParallelTest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenMIParallelTest.py
@@ -57,7 +57,7 @@ class ResetTokenTestMIParallel(BaseTestCase):
 
         self.assertEqual({'current': {'A': 'y'},
                           'do_step': 'Yes',
-                          'output': {1: {'A': 'x'}, 2: {'A': 'y'}, 3: {'A': 'z'}}},
+                          'output': {'1': {'A': 'x'}, '2': {'A': 'y'}, '3': {'A': 'z'}}},
                          self.workflow.last_task.data)
 
         self.workflow.reset_task_from_id(firsttaskid)
@@ -80,9 +80,9 @@ class ResetTokenTestMIParallel(BaseTestCase):
         self.assertEqual({'current': {'A': 'x'},
                           'do_step': 'Yes',
                           'C': 'c',
-                          'output': {1: {'A': 'a1'},
-                                     2: {'A': 'y'},
-                                     3: {'A': 'z'}}},
+                          'output': {'1': {'A': 'a1'},
+                                     '2': {'A': 'y'},
+                                     '3': {'A': 'z'}}},
                          self.workflow.last_task.data)
 
 

--- a/tests/SpiffWorkflow/camunda/ResetTokenMITest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenMITest.py
@@ -77,9 +77,9 @@ class ResetTokenTestMI(BaseTestCase):
 
         self.assertTrue(self.workflow.is_completed())
         self.assertEqual({'do_step': 'Yes',
-                          'output': {1: {'A': 'a1'},
-                                     2: {'A': 'a2'},
-                                     3: {'A': 'a3'}},
+                          'output': {'1': {'A': 'a1'},
+                                     '2': {'A': 'a2'},
+                                     '3': {'A': 'a3'}},
                           'C': 'c'},
                          self.workflow.last_task.data)
 


### PR DESCRIPTION
Serialization Fixes
---------------------
* For event_definitions.py, event_types.py we were storing internal data as a tuple (see line 203) - which is not json serializable.  this turns it into a dict.
* For multi-instance the runtimesvar is an integer, but that can't be a key in a json file, all keys in json must be strings, so we now make sure it is always a string.
* Removed the self.last_task setter in _task_completed_notify in the specs/workflow.py, because we need to set this manually (as is the case in a loopback). We now set this in specs/base TaskSpec > _on_complete(), just BEFORE we call the _on_complete_hook which can set the last_task to something else when needed.  Almost feels like we need another hook.
* task, set_children_future - the subworkflow is set to none at the same time the children are wiped out.

Optimizations:
--------------
The DMNParser was using this thing called a "parsedRef" that seemed completely pointless and replicated all the content in a DMN file. dropping it.
The DMN was repeating the serialization of every input and output for every record, adding a lot of pointless content into the serizialized output.   Now we reference it by id.