### PR TITLE
parses out spiffworklow:property tags in bpmn extensions and makes th…

### DIFF
--- a/SpiffWorkflow/spiff/parser/task_spec.py
+++ b/SpiffWorkflow/spiff/parser/task_spec.py
@@ -26,11 +26,11 @@ class SpiffTaskParser(TaskParser):
 
     def _parse_properties(self, node):
         extra_ns = {'spiffworkflow': SPIFFWORKFLOW_MODEL_NS}
-        xpath = xpath_eval(self.node, extra_ns)
+        xpath = xpath_eval(node, extra_ns)
         property_nodes = xpath('.//spiffworkflow:property')
         properties = {}
-        for node in property_nodes:
-            properties[node.attrib['name']] = node.attrib['value']
+        for prop_node in property_nodes:
+            properties[prop_node.attrib['name']] = prop_node.attrib['value']
         return properties
 
     def create_task(self):

--- a/SpiffWorkflow/spiff/parser/task_spec.py
+++ b/SpiffWorkflow/spiff/parser/task_spec.py
@@ -10,15 +10,28 @@ SPIFFWORKFLOW_MODEL_NS = 'http://spiffworkflow.org/bpmn/schema/1.0/core'
 class SpiffTaskParser(TaskParser):
 
     def parse_extensions(self):
-        # Too bad doing this works in such a stupid way.  We should set a namespace and automatically do this.
+        # Too bad doing this works in such a stupid way.
+        # We should set a namespace and automatically do this.
         extensions = {}
         extra_ns = {'spiffworkflow': SPIFFWORKFLOW_MODEL_NS}
         xpath = xpath_eval(self.node, extra_ns)
         extension_nodes = xpath('.//bpmn:extensionElements/spiffworkflow:*')
         for node in extension_nodes:
             name = etree.QName(node).localname
-            extensions[name] = node.text
+            if name in ['preScript', 'postScript']:
+                extensions[name] = node.text
+            if name == 'properties':
+                extensions['properties'] = self._parse_properties(node)
         return extensions
+
+    def _parse_properties(self, node):
+        extra_ns = {'spiffworkflow': SPIFFWORKFLOW_MODEL_NS}
+        xpath = xpath_eval(self.node, extra_ns)
+        property_nodes = xpath('.//spiffworkflow:property')
+        properties = {}
+        for node in property_nodes:
+            properties[node.attrib['name']] = node.attrib['value']
+        return properties
 
     def create_task(self):
         # The main task parser already calls this, and even sets an attribute, but

--- a/tests/SpiffWorkflow/spiff/SpiffPropertiesTest.py
+++ b/tests/SpiffWorkflow/spiff/SpiffPropertiesTest.py
@@ -1,0 +1,29 @@
+from SpiffWorkflow.task import TaskState
+from .BaseTestCase import BaseTestCase
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+
+# Assure we correctly parse and pass on the Spiffworkflow properties in
+# an extension.
+class SpiffWorkflowProperties(BaseTestCase):
+
+    def testTask(self):
+        self.task_test()
+
+    def testTaskSaveRestore(self):
+        self.task_test(True)
+
+    def task_test(self, save_restore=False):
+
+        spec, subprocesses = self.load_workflow_spec('spiff_properties.bpmn', 'Process_1')
+        self.workflow = BpmnWorkflow(spec, subprocesses)
+        self.workflow.do_engine_steps()
+        if save_restore:
+            self.save_restore()
+        ready_tasks = self.workflow.get_tasks(TaskState.READY)
+        # The ready task's spec should contain extension properties
+        # with name/value pairs.
+        task = ready_tasks[0]
+        self.assertDictEqual({'formJsonSchemaFilename': 'my_json_jschema.json',
+                              'formUiSchemaFilename': 'my_ui_jschema.json'},
+        task.task_spec.extensions['properties'])
+

--- a/tests/SpiffWorkflow/spiff/data/spiff_properties.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/spiff_properties.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19o7vxg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:ioSpecification />
+    <bpmn:startEvent id="Event_1ftsuzw">
+      <bpmn:outgoing>Flow_1hjrex4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="F2low_1hjrex4" sourceRef="Event_1ftsuzw" targetRef="Activity_04b30i8" />
+    <bpmn:endEvent id="Event_0c80924">
+      <bpmn:incoming>Flow_1vlqqxh</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1vlqqxh" sourceRef="Activity_04b30i8" targetRef="Event_0c80924" />
+    <bpmn:userTask id="Activity_04b30i8" name="Complete Form">
+      <bpmn:extensionElements>
+        <spiffworkflow:properties>
+          <spiffworkflow:property name="formJsonSchemaFilename" value="my_json_jschema.json" />
+          <spiffworkflow:property name="formUiSchemaFilename" value="my_ui_jschema.json" />
+        </spiffworkflow:properties>
+      </bpmn:extensionElements>3
+      <bpmn:incoming>Flow_1hjrex4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vlqqxh</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_1hjrex4_di" bpmnElement="Flow_1hjrex4">
+        <di:waypoint x="228" y="220" />
+        <di:waypoint x="260" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vlqqxh_di" bpmnElement="Flow_1vlqqxh">
+        <di:waypoint x="360" y="220" />
+        <di:waypoint x="432" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1ftsuzw_di" bpmnElement="Event_1ftsuzw">
+        <dc:Bounds x="192" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c80924_di" bpmnElement="Event_0c80924">
+        <dc:Bounds x="432" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xv4p5e_di" bpmnElement="Activity_04b30i8">
+        <dc:Bounds x="260" y="180" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
…em available as a dictionary on the task spec.

if the xml looks like this:
```xml
      <bpmn:extensionElements>
        <spiffworkflow:properties>
          <spiffworkflow:property name="formJsonSchemaFilename" value="my_json_jschema.json" />
          <spiffworkflow:property name="formUiSchemaFilename" value="my_ui_jschema.json" />
        </spiffworkflow:properties>
      </bpmn:extensionElements>
 ```

 Then the task properties will be accessible here:
 ```python
 task.task_spec.extensions['properties']
 ```