### PR TITLE
docs: Fix a few typos

### DIFF
--- a/SpiffWorkflow/bpmn/FeelLikeScriptEngine.py
+++ b/SpiffWorkflow/bpmn/FeelLikeScriptEngine.py
@@ -134,7 +134,7 @@ def feelFilter(var,a,b,op,column=None):
     # then we convert it to a list of dictionaries with the elements
     # all having {'key':key,<rest of dict>}
     # if it is a dictionary and the key refers to a non-dict, then
-    # we conver to a dict having {'key':key,'value':value}
+    # we convert to a dict having {'key':key,'value':value}
     if (isinstance(var,dict)):
         newvar = []
         for key in var.keys():

--- a/SpiffWorkflow/bpmn/specs/ExclusiveGateway.py
+++ b/SpiffWorkflow/bpmn/specs/ExclusiveGateway.py
@@ -34,7 +34,7 @@ class ExclusiveGateway(ExclusiveChoice, BpmnSpecMixin):
         Checks whether all required attributes are set. Throws an exception
         if an error was detected.
         """
-        # This has been overidden to allow a single default flow out (without a
+        # This has been overridden to allow a single default flow out (without a
         # condition) - useful for the converging type
         TaskSpec.test(self)
 #        if len(self.cond_task_specs) < 1:

--- a/SpiffWorkflow/bpmn/specs/events/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_definitions.py
@@ -175,7 +175,7 @@ class MessageEventDefinition(NamedEventDefinition):
 
     # It is not entirely clear how the payload is supposed to be handled, so I have
     # deviated from what the earlier code did as little as possible, but I believe
-    # this should be revisited: for one thing, we're relying on some Camunda-sepcific
+    # this should be revisited: for one thing, we're relying on some Camunda-specific
     # properties.
 
     def __init__(self, name, payload=None, result_var=None):

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -97,7 +97,7 @@ class TaskSpec(object):
         :param post_assign: a list of name/value pairs
         :type  position: dict((str, object))
         :param position: a dict containing an 'x' and 'y' with coordinates
-                            that describe where the element occured in the
+                            that describe where the element occurred in the
                             diagram.
         """
         assert wf_spec is not None

--- a/doc/bpmn/events.rst
+++ b/doc/bpmn/events.rst
@@ -185,7 +185,7 @@ Timer Events
 ^^^^^^^^^^^^
 
 In the previous section, we mentioned that that we would try again later if we were unable
-to ship the order.  We can use a Duration Timer Event to force our workflow to wait a cetain
+to ship the order.  We can use a Duration Timer Event to force our workflow to wait a certain
 amount of time before continuing.  We can use this as a regular Intermediate Event (in
 'Try Again Later') or a Boundary Event.  Timer Boundary Events can be Interrupting, but in
 this case, we simply want to notify the customer of the delay while continuing to process


### PR DESCRIPTION
There are small typos in:
- SpiffWorkflow/bpmn/FeelLikeScriptEngine.py
- SpiffWorkflow/bpmn/specs/ExclusiveGateway.py
- SpiffWorkflow/bpmn/specs/events/event_definitions.py
- SpiffWorkflow/specs/base.py
- doc/bpmn/events.rst

Fixes:
- Should read `specific` rather than `sepcific`.
- Should read `overridden` rather than `overidden`.
- Should read `occurred` rather than `occured`.
- Should read `convert` rather than `conver`.
- Should read `certain` rather than `cetain`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md