### PR TITLE
Bugfix/separate subprocess dict for serializer

### DIFF
--- a/tests/SpiffWorkflow/bpmn/BpmnSerializerTest.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnSerializerTest.py
@@ -15,7 +15,7 @@ class BpmnSerializerTest(unittest.TestCase):
         parser = TestBpmnParser()
         parser.add_bpmn_files_by_glob(f)
         top_level_spec = parser.get_spec(process_name)
-        subprocesses = parser.get_process_specs()
+        subprocesses = parser.get_subprocess_specs(process_name)
         return top_level_spec, subprocesses
 
     def setUp(self):

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowSerializerTest.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowSerializerTest.py
@@ -20,7 +20,7 @@ class BpmnWorkflowSerializerTest(unittest.TestCase):
         parser = BpmnParser()
         parser.add_bpmn_files_by_glob(f)
         top_level_spec = parser.get_spec(process_name)
-        subprocesses = parser.get_process_specs()
+        subprocesses = parser.get_subprocess_specs(process_name)
         return top_level_spec, subprocesses
 
     def setUp(self):

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
@@ -24,7 +24,7 @@ class BpmnWorkflowTestCase(unittest.TestCase):
         parser = TestBpmnParser()
         parser.add_bpmn_files_by_glob(f)
         top_level_spec = parser.get_spec(process_name)
-        subprocesses = parser.get_process_specs()
+        subprocesses = parser.get_subprocess_specs(process_name)
         return top_level_spec, subprocesses
 
     def do_next_exclusive_step(self, step_name, with_save_load=False, set_attribs=None, choice=None):

--- a/tests/SpiffWorkflow/bpmn/CallActivityEndEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivityEndEventTest.py
@@ -59,8 +59,9 @@ class CallActivityTest(BpmnWorkflowTestCase):
 
     def test_call_acitivity_errors_include_task_trace(self):
         error_spec = self.subprocesses.get('ErroringBPMN')
+        error_spec, subprocesses = self.load_workflow_spec('call_activity_*.bpmn', 'ErroringBPMN')
         with self.assertRaises(WorkflowTaskExecException) as context:
-            self.workflow = BpmnWorkflow(error_spec, self.subprocesses)
+            self.workflow = BpmnWorkflow(error_spec, subprocesses)
             self.workflow.do_engine_steps()
         self.assertEquals(2, len(context.exception.task_trace))
         self.assertRegexpMatches(context.exception.task_trace[0], 'Create Data \(.*?call_activity_call_activity.bpmn\)')

--- a/tests/SpiffWorkflow/bpmn/ParserTest.py
+++ b/tests/SpiffWorkflow/bpmn/ParserTest.py
@@ -1,52 +1,10 @@
 import unittest
 import os
 
-from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from SpiffWorkflow.bpmn.parser.BpmnParser import BpmnParser
 
 
 class ParserTest(unittest.TestCase):
-
-    def testTwoTopLevelProcessesParallel(self):
-
-        parser = BpmnParser()
-        bpmn_file = os.path.join(os.path.dirname(__file__), 'data', 'two_top_level_procs.bpmn')
-        parser.add_bpmn_file(bpmn_file)
-        procs = parser.get_process_specs()
-        spec = parser.get_top_level_spec('Combined', ['Proc_1', 'Proc_2'])
-        workflow = BpmnWorkflow(spec, procs)
-        workflow.do_engine_steps()
-        ready_tasks = workflow.get_ready_user_tasks()
-        self.assertEqual(len(ready_tasks), 2)
-        for task in ready_tasks:
-            task.complete()
-        workflow.do_engine_steps()
-        ready_tasks = workflow.get_ready_user_tasks()
-        self.assertEqual(len(ready_tasks), 0)
-        self.assertTrue(workflow.is_completed())
-
-    def testTwoTopLevelProcessesSequential(self):
-
-        parser = BpmnParser()
-        bpmn_file = os.path.join(os.path.dirname(__file__), 'data', 'two_top_level_procs.bpmn')
-        parser.add_bpmn_file(bpmn_file)
-        procs = parser.get_process_specs()
-        spec = parser.get_top_level_spec('Combined', ['Proc_1', 'Proc_2'], parallel=False)
-        workflow = BpmnWorkflow(spec, procs)
-        workflow.do_engine_steps()
-        ready_tasks = workflow.get_ready_user_tasks()
-        self.assertEqual(len(ready_tasks), 1)
-        self.assertEqual(ready_tasks[0].task_spec.description, 'Process 1 Task')
-        ready_tasks[0].complete()
-        workflow.do_engine_steps()
-        ready_tasks = workflow.get_ready_user_tasks()
-        self.assertEqual(len(ready_tasks), 1)
-        self.assertEqual(ready_tasks[0].task_spec.description, 'Process 2 Task')
-        ready_tasks[0].complete()
-        workflow.do_engine_steps()
-        ready_tasks = workflow.get_ready_user_tasks()
-        self.assertEqual(len(ready_tasks), 0)
-        self.assertTrue(workflow.is_completed())
 
     def testIOSpecification(self):
 

--- a/tests/SpiffWorkflow/camunda/BaseTestCase.py
+++ b/tests/SpiffWorkflow/camunda/BaseTestCase.py
@@ -21,7 +21,7 @@ class BaseTestCase(BpmnWorkflowTestCase):
         parser = CamundaParser()
         parser.add_bpmn_files_by_glob(f)
         top_level_spec = parser.get_spec(process_name)
-        subprocesses = parser.get_process_specs()
+        subprocesses = parser.get_subprocess_specs(process_name)
         return top_level_spec, subprocesses
 
     def reload_save_restore(self):

--- a/tests/SpiffWorkflow/spiff/BaseTestCase.py
+++ b/tests/SpiffWorkflow/spiff/BaseTestCase.py
@@ -23,6 +23,6 @@ class BaseTestCase(BpmnWorkflowTestCase):
         parser = SpiffBpmnParser()
         parser.add_bpmn_files_by_glob(f)
         top_level_spec = parser.get_spec(process_name)
-        subprocesses = parser.get_process_specs()
+        subprocesses = parser.get_subprocess_specs(process_name)
         return top_level_spec, subprocesses
 


### PR DESCRIPTION
Using get_subprocess_specs() allows us to filter out un-used files so we don't carry extra weight around in the serialization.
Avoid a race-condition in the workflow_spec_converter.
