### PR TITLE
Profile and improve run time of the test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,14 @@ tests-cov:
 	cd tests/$(NAME)
 	coverage run --source=$(NAME) -m unittest discover -v . "*Test.py"
 
+.PHONY : tests-ind
+tests-ind:
+	cd tests/$(NAME)
+	PYTHONPATH=../.. find . -name "*Test.py" -printf '%p' -exec python -m unittest {} \;
+
 .PHONY : tests-timing
 tests-timing:
-	# TODO generate this file
-	./scripts/test_times.py < /tmp/rawtimes.txt | xclip -sel clip
+	@make tests-ind 2>&1 | ./scripts/test_times.py
 
 ###################################################################
 # Package builders.

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ tests-cov:
 .PHONY : tests-timing
 tests-timing:
 	# TODO generate this file
-	./scripts/test_times.py < /tmp/rawtimes.txt
+	./scripts/test_times.py < /tmp/rawtimes.txt | xclip -sel clip
 
 ###################################################################
 # Package builders.

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,17 @@ uninstall:
 .PHONY : tests
 tests:
 	cd tests/$(NAME)
+	PYTHONPATH=../.. python -m unittest discover -v . "*Test.py"
+
+.PHONY : tests-cov
+tests-cov:
+	cd tests/$(NAME)
 	coverage run --source=$(NAME) -m unittest discover -v . "*Test.py"
+
+.PHONY : tests-timing
+tests-timing:
+	# TODO generate this file
+	./scripts/test_times.py < /tmp/rawtimes.txt
 
 ###################################################################
 # Package builders.

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ tests-cov:
 .PHONY : tests-ind
 tests-ind:
 	cd tests/$(NAME)
-	PYTHONPATH=../.. find . -name "*Test.py" -printf '%p' -exec python -m unittest {} \;
+	@PYTHONPATH=../.. find . -name "*Test.py" -printf '%p' -exec python -m unittest {} \;
 
 .PHONY : tests-timing
 tests-timing:

--- a/SpiffWorkflow/bpmn/serializer/workflow.py
+++ b/SpiffWorkflow/bpmn/serializer/workflow.py
@@ -214,7 +214,7 @@ class BpmnWorkflowSerializer:
 
         task = Task(workflow, task_spec, parent)
         task.id = UUID(dct['id'])
-        task.state = TaskState(dct['state'])
+        task.state = dct['state']
         task.last_state_change = dct['last_state_change']
         task.triggered = dct['triggered']
         task.internal_data = self.data_converter.restore(dct['internal_data'])

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -44,7 +44,7 @@ def updateDotDict(dct,dotted_path,value):
     return root
 
 
-class TaskState(IntFlag):
+class TaskState:
     """
 
     The following states may exist:

--- a/scripts/test_times.py
+++ b/scripts/test_times.py
@@ -42,8 +42,16 @@ def parse(lines):
     return test_file_timings
 
 def report(parsed_data):
-    for parsed in parsed_data:
-        print(f'{parsed[0]}: {parsed[1]}')
+    lines = [
+        '| Method | Time | Tests Ran |',
+        '|----|----|----|',
+    ]
+
+    sorted_data = sorted(parsed_data, key=lambda d: d[1][1], reverse=True)
+    for d in sorted_data:
+        lines.append(f'| {d[0]} | {d[1][1]} | {d[1][0]} |')
+
+    print('\n'.join(lines))
 
 if __name__ == '__main__':
     data = sys.stdin.readlines()

--- a/scripts/test_times.py
+++ b/scripts/test_times.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import re
+import sys
+
+def parse(lines):
+    test_file = None
+    timing = None
+
+    test_file_regex = re.compile('.*?Test.py')
+    timing_regex = re.compile('Ran .* tests in .*')
+
+    for line in lines:
+        # line.rstrip()
+        if test_file is None:
+            match = test_file_regex.match(line)
+            if match:
+                test_file = match.group(0).rstrip()
+        elif timing is None:
+            match = timing_regex.match(line)
+            if match:
+                timing = match.group(0).rstrip()
+
+        if test_file is not None and timing is not None:
+            print(f'{test_file}: {timing}')
+            test_file = None
+            timing = None
+
+if __name__ == '__main__':
+    data = sys.stdin.readlines()
+    parse(data)

--- a/scripts/test_times.py
+++ b/scripts/test_times.py
@@ -4,29 +4,48 @@
 import re
 import sys
 
+def regex_line_parser(pattern, handler):
+    regex = re.compile(pattern)
+    def parser(line):
+        match = regex.match(line)
+        if match:
+            return handler(match)
+        return None
+    return parser
+
+def rstripped(match):
+    return match.group(0).rstrip()
+
+def tupled(match):
+    return (match.group(1), match.group(2))
+
+
 def parse(lines):
     test_file = None
     timing = None
+    test_file_timings = []
 
-    test_file_regex = re.compile('.*?Test.py')
-    timing_regex = re.compile('Ran .* tests in .*')
+    test_file_line_parser = regex_line_parser('.*?Test.py', rstripped)
+    timing_line_parser = regex_line_parser('Ran (.*) tests in (.*)', tupled)
 
     for line in lines:
-        # line.rstrip()
         if test_file is None:
-            match = test_file_regex.match(line)
-            if match:
-                test_file = match.group(0).rstrip()
+            test_file = test_file_line_parser(line)
         elif timing is None:
-            match = timing_regex.match(line)
-            if match:
-                timing = match.group(0).rstrip()
+            timing = timing_line_parser(line)
 
         if test_file is not None and timing is not None:
-            print(f'{test_file}: {timing}')
+            test_file_timings.append((test_file, timing))
             test_file = None
             timing = None
 
+    return test_file_timings
+
+def report(parsed_data):
+    for parsed in parsed_data:
+        print(f'{parsed[0]}: {parsed[1]}')
+
 if __name__ == '__main__':
     data = sys.stdin.readlines()
-    parse(data)
+    parsed_data = parse(data)
+    report(parsed_data)

--- a/tests/SpiffWorkflow/bpmn/data/timer-cycle-start.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer-cycle-start.bpmn
@@ -22,7 +22,7 @@
     <bpmn:startEvent id="CycleStart">
       <bpmn:outgoing>Flow_0jtfzsk</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0za5f2h">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">(2,timedelta(seconds=.25))</bpmn:timeCycle>
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">(2,timedelta(seconds=0.01))</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
     <bpmn:scriptTask id="Refill_Coffee" name="Refill Coffee">
@@ -37,7 +37,7 @@
       <bpmn:incoming>Flow_1pahvlr</bpmn:incoming>
       <bpmn:outgoing>Flow_05ejbm4</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0o35ug0">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=1)</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=0.05)</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
     <bpmn:endEvent id="EndItAll">

--- a/tests/SpiffWorkflow/bpmn/data/timer-cycle.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer-cycle.bpmn
@@ -32,7 +32,7 @@
     <bpmn:boundaryEvent id="CatchMessage" cancelActivity="false" attachedToRef="Get_Coffee">
       <bpmn:outgoing>Flow_1pzc4jz</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_180fybf">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">(2,timedelta(seconds=.25))</bpmn:timeCycle>
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">(2,timedelta(seconds=0.01))</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
   </bpmn:process>

--- a/tests/SpiffWorkflow/bpmn/events/ActionManagementTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/ActionManagementTest.py
@@ -11,13 +11,18 @@ __author__ = 'matth'
 
 
 class ActionManagementTest(BpmnWorkflowTestCase):
+    START_TIME_DELTA=0.01
+    FINISH_TIME_DELTA=0.02
+
+    def now_plus_seconds(self, seconds):
+        return datetime.datetime.now() + datetime.timedelta(seconds=seconds)
 
     def setUp(self):
         self.spec, self.subprocesses = self.load_workflow_spec('Test-Workflows/Action-Management.bpmn20.xml', 'Action Management')
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses)
 
-        start_time = datetime.datetime.now() + datetime.timedelta(seconds=0.5)
-        finish_time = datetime.datetime.now() + datetime.timedelta(seconds=1.5)
+        start_time = self.now_plus_seconds(self.START_TIME_DELTA)
+        finish_time = self.now_plus_seconds(self.FINISH_TIME_DELTA)
 
         self.assertEqual(1, len(self.workflow.get_tasks(TaskState.READY)))
         self.workflow.get_tasks(TaskState.READY)[0].set_data(
@@ -34,7 +39,7 @@ class ActionManagementTest(BpmnWorkflowTestCase):
         self.assertEqual('Cancel Action (if necessary)',
                           self.workflow.get_tasks(TaskState.READY)[0].task_spec.description)
 
-        time.sleep(0.6)
+        time.sleep(self.START_TIME_DELTA)
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
         self.assertEqual(2, len(self.workflow.get_tasks(TaskState.WAITING)))
@@ -57,7 +62,7 @@ class ActionManagementTest(BpmnWorkflowTestCase):
         self.assertEqual('Cancel Action (if necessary)',
                           self.workflow.get_tasks(TaskState.READY)[0].task_spec.description)
 
-        time.sleep(0.6)
+        time.sleep(self.START_TIME_DELTA)
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
         self.assertEqual(2, len(self.workflow.get_tasks(TaskState.WAITING)))
@@ -69,7 +74,7 @@ class ActionManagementTest(BpmnWorkflowTestCase):
         self.assertEqual(2, len(self.workflow.get_tasks(TaskState.WAITING)))
         self.assertEqual('Finish Time', self.workflow.get_tasks(
             TaskState.WAITING)[1].task_spec.description)
-        time.sleep(1.1)
+        time.sleep(self.FINISH_TIME_DELTA)
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
         self.assertEqual(2, len(self.workflow.get_tasks(TaskState.WAITING)))
@@ -113,7 +118,7 @@ class ActionManagementTest(BpmnWorkflowTestCase):
 
         self.assertEqual(1, len(self.workflow.get_tasks(TaskState.WAITING)))
         self.assertEqual(1, len(self.workflow.get_tasks(TaskState.READY)))
-        time.sleep(0.6)
+        time.sleep(self.START_TIME_DELTA)
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
         self.assertEqual(2, len(self.workflow.get_tasks(TaskState.WAITING)))

--- a/tests/SpiffWorkflow/bpmn/events/TimerCycleStartTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerCycleStartTest.py
@@ -54,11 +54,11 @@ class TimerCycleStartTest(BpmnWorkflowTestCase):
         # timers expire.  The test workflow has a wait timer that pauses long enough to
         # allow the cycle to complete twice -- otherwise the first iteration through the
         # cycle process causes the remaining tasks to be cancelled.
-        for loopcount in range(10):
+        for loopcount in range(5):
             if save_restore:
                 self.save_restore()
                 self.workflow.script_engine = CustomScriptEngine()
-            time.sleep(0.1)
+            time.sleep(0.01)
             self.workflow.refresh_waiting_tasks()
             self.workflow.do_engine_steps()
         self.assertEqual(counter, 2)

--- a/tests/SpiffWorkflow/bpmn/events/TimerCycleTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerCycleTest.py
@@ -50,11 +50,11 @@ class TimerDurationTest(BpmnWorkflowTestCase):
 
         # See comments in timer cycle test for more context
         counter = 0
-        for loopcount in range(10):
+        for loopcount in range(5):
             if save_restore:
                 self.save_restore()
                 self.workflow.script_engine = CustomScriptEngine()
-            time.sleep(0.1)
+            time.sleep(0.01)
             self.workflow.refresh_waiting_tasks()
             self.workflow.do_engine_steps()
 


### PR DESCRIPTION
The test suite used to take ~38s to `make test` on my machine. These changes reduce that time to ~16s and provides some basic tooling to help understand the time slice per test file. The main changes are:

1. `make tests` no longer runs coverage which saved ~11s per run. If you want coverage the old make tests is now `make tests-cov`.
2. `make tests-ind` will run each test file individually to expose the time per file.
3. `make tests-timing` will run make tests-ind and generate a simple markdown report suitable for pasting into a [wiki page for instance](https://github.com/jbirddog/SpiffWorkflow/wiki/Unit-test-timings#timing-per-test-file)
4. Reduced sleep times in `ActionManagementTest.py`, `TimerCycleStartTest.py` and `TimerCycleTest.py`. This saved ~7s per run. If the new sleep times are too tight and cause issues we can open them up some, but I'd like to try them as tight as possible.
5. `TaskState` is no longer an enum, its members are just ints. This was a reoccurring item near the top of several `cProfile` runs for various test files. This is the only change so far that is a general performance improvement for the library and reduced the time of the test suite by ~4s.

[wiki page](https://github.com/jbirddog/SpiffWorkflow/wiki/Unit-test-timings)