### PR TITLE
Improve test suite run time, part 2

### DIFF
--- a/scripts/test_times.py
+++ b/scripts/test_times.py
@@ -26,7 +26,7 @@ def parse(lines):
     test_file_timings = []
 
     test_file_line_parser = regex_line_parser('.*?Test.py', rstripped)
-    timing_line_parser = regex_line_parser('Ran (.*) tests in (.*)', tupled)
+    timing_line_parser = regex_line_parser('Ran (.*) tests? in (.*)', tupled)
 
     for line in lines:
         if test_file is None:

--- a/tests/SpiffWorkflow/bpmn/data/MessageBoundary.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/MessageBoundary.bpmn
@@ -78,7 +78,7 @@
         <bpmn:incoming>Flow_11u0pgk</bpmn:incoming>
         <bpmn:outgoing>Flow_1rqk2v9</bpmn:outgoing>
         <bpmn:timerEventDefinition id="TimerEventDefinition_0bct7zl">
-          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=.1)</bpmn:timeDuration>
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=.01)</bpmn:timeDuration>
         </bpmn:timerEventDefinition>
       </bpmn:intermediateCatchEvent>
       <bpmn:sequenceFlow id="Flow_1gs89vo" sourceRef="Event_0akpdke" targetRef="Activity_106f08z" />

--- a/tests/SpiffWorkflow/bpmn/data/boundary.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/boundary.bpmn
@@ -65,7 +65,7 @@
     <bpmn:boundaryEvent id="Event_0iiih8g" name="FedUp" attachedToRef="Subworkflow">
       <bpmn:outgoing>Flow_0yzqey7</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0irxg9m">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT0.3S</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT0.03S</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
   </bpmn:process>

--- a/tests/SpiffWorkflow/bpmn/data/timer-date-start.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer-date-start.bpmn
@@ -7,7 +7,7 @@
     <bpmn:scriptTask id="Activity_1q1wged" name="Set Future Date">
       <bpmn:incoming>Flow_1i73q45</bpmn:incoming>
       <bpmn:outgoing>Flow_00e79cz</bpmn:outgoing>
-      <bpmn:script>futuredate = dateparser.parse('in 1 second') - timedelta(seconds=.75) 
+      <bpmn:script>futuredate = dateparser.parse('in 1 second') - timedelta(seconds=.95) 
 futuredate2 = dateparser.parse('September 1 2021 at 10am EDT')</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_1i73q45" sourceRef="Event_0u1rmur" targetRef="Activity_1q1wged" />

--- a/tests/SpiffWorkflow/bpmn/data/timer.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer.bpmn
@@ -12,7 +12,7 @@
       <bpmn:incoming>Flow_1pvkgnu</bpmn:incoming>
       <bpmn:outgoing>Flow_1elbn9u</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_1jrn73k">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=.25)</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=.025)</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
     <bpmn:manualTask id="Activity_1rbj8j1" name="Get Back To Work">

--- a/tests/SpiffWorkflow/bpmn/events/MessageBoundaryEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageBoundaryEventTest.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 
 
+import os
+import sys
 import unittest
 import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
+
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
@@ -39,11 +44,11 @@ class MessageBoundaryTest(BpmnWorkflowTestCase):
 
                 self.workflow.complete_task_from_id(task.id)
                 self.workflow.do_engine_steps()
-                time.sleep(.1)
+                time.sleep(.01)
                 self.workflow.refresh_waiting_tasks()
                 if save_restore: self.save_restore()
             ready_tasks = self.workflow.get_tasks(TaskState.READY)
-        time.sleep(.1)
+        time.sleep(.01)
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
         self.assertEqual(self.workflow.is_completed(),True,'Expected the workflow to be complete at this point')

--- a/tests/SpiffWorkflow/bpmn/events/MessageBoundaryEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageBoundaryEventTest.py
@@ -1,13 +1,8 @@
 # -*- coding: utf-8 -*-
 
 
-import os
-import sys
 import unittest
 import time
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..', '..'))
-
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase

--- a/tests/SpiffWorkflow/bpmn/events/TimerDateTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDateTest.py
@@ -33,7 +33,7 @@ class TimerDateTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
 
         loopcount = 0
-        # test bpmn has a timeout of .25s
+        # test bpmn has a timeout of .05s
         # we should terminate loop before that.
         starttime = datetime.datetime.now()
         counter = 0
@@ -45,7 +45,7 @@ class TimerDateTest(BpmnWorkflowTestCase):
 
 
             waiting_tasks = self.workflow.get_tasks(TaskState.WAITING)
-            time.sleep(0.1)
+            time.sleep(0.01)
             self.workflow.refresh_waiting_tasks()
             loopcount = loopcount +1
         endtime = datetime.datetime.now()
@@ -55,7 +55,7 @@ class TimerDateTest(BpmnWorkflowTestCase):
         self.assertEqual(self.workflow.last_task.data['futuredate2'],testdate)
         self.assertTrue('completed' in self.workflow.last_task.data)
         self.assertTrue(self.workflow.last_task.data['completed'])
-        self.assertTrue((endtime-starttime) > datetime.timedelta(seconds=.25))
+        self.assertTrue((endtime-starttime) > datetime.timedelta(seconds=.04))
 
 
 

--- a/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryOnTaskTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryOnTaskTest.py
@@ -46,7 +46,7 @@ class TimerDurationTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
         if save_restore:
             self.save_restore()
-        time.sleep(0.5)
+        time.sleep(0.1)
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]

--- a/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryTest.py
@@ -35,7 +35,7 @@ class TimerDurationTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
 
         loopcount = 0
-        # test bpmn has a timeout of .25s
+        # test bpmn has a timeout of .03s
         # we should terminate loop before that.
 
         while loopcount < 11:
@@ -46,7 +46,7 @@ class TimerDurationTest(BpmnWorkflowTestCase):
                 self.save_restore()
                 self.workflow.script_engine = FeelLikeScriptEngine()
             #self.assertEqual(1, len(self.workflow.get_tasks(Task.WAITING)))
-            time.sleep(0.1)
+            time.sleep(0.01)
             self.workflow.complete_task_from_id(ready_tasks[0].id)
             self.workflow.refresh_waiting_tasks()
             self.workflow.do_engine_steps()

--- a/tests/SpiffWorkflow/bpmn/events/TimerDurationTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDurationTest.py
@@ -34,7 +34,7 @@ class TimerDurationTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
 
         loopcount = 0
-        # test bpmn has a timeout of .25s
+        # test bpmn has a timeout of .025s
         # we should terminate loop before that.
         starttime = datetime.datetime.now()
         while loopcount < 10:
@@ -42,13 +42,13 @@ class TimerDurationTest(BpmnWorkflowTestCase):
                 break
             if save_restore: self.save_restore()
             self.assertEqual(1, len(self.workflow.get_tasks(TaskState.WAITING)))
-            time.sleep(0.1)
+            time.sleep(0.01)
             self.workflow.refresh_waiting_tasks()
             loopcount = loopcount +1
         endtime = datetime.datetime.now()
         duration = endtime-starttime
-        self.assertEqual(duration<datetime.timedelta(seconds=.5),True)
-        self.assertEqual(duration>datetime.timedelta(seconds=.25),True)
+        self.assertEqual(duration<datetime.timedelta(seconds=.05),True)
+        self.assertEqual(duration>datetime.timedelta(seconds=.02),True)
 
 
 def suite():

--- a/tests/SpiffWorkflow/bpmn/events/TimerIntermediateTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerIntermediateTest.py
@@ -13,12 +13,12 @@ __author__ = 'matth'
 class TimerIntermediateTest(BpmnWorkflowTestCase):
 
     def setUp(self):
-        self.spec, self.subprocesss = self.load_workflow_spec('Test-Workflows/*.bpmn20.xml', 'Timer Intermediate')
+        self.spec, self.subprocesss = self.load_workflow_spec('Test-Workflows/Timer-Intermediate.bpmn20.xml', 'Timer Intermediate')
         self.workflow = BpmnWorkflow(self.spec, self.subprocesss)
 
     def testRunThroughHappy(self):
 
-        due_time = datetime.datetime.now() + datetime.timedelta(seconds=0.5)
+        due_time = datetime.datetime.now() + datetime.timedelta(seconds=0.01)
 
         self.assertEqual(1, len(self.workflow.get_tasks(TaskState.READY)))
         self.workflow.get_tasks(TaskState.READY)[0].set_data(due_time=due_time)
@@ -27,7 +27,7 @@ class TimerIntermediateTest(BpmnWorkflowTestCase):
 
         self.assertEqual(1, len(self.workflow.get_tasks(TaskState.WAITING)))
 
-        time.sleep(0.6)
+        time.sleep(0.02)
 
         self.assertEqual(1, len(self.workflow.get_tasks(TaskState.WAITING)))
         self.workflow.refresh_waiting_tasks()


### PR DESCRIPTION
Tightens up more sleep times in the tests, which brings the test suite time down to ~11s locally. Also fixed a silly bug in the report script - files with 1 test were not being reported properly due to the regex used in the line parser.