### PR TITLE
Remove unused imports

### DIFF
--- a/SpiffWorkflow/bpmn/parser/BpmnParser.py
+++ b/SpiffWorkflow/bpmn/parser/BpmnParser.py
@@ -21,7 +21,6 @@ import glob
 
 from lxml import etree
 
-from SpiffWorkflow.bpmn.specs.BpmnProcessSpec import BpmnProcessSpec
 from .ValidationException import ValidationException
 from ..specs.events import StartEvent, EndEvent, BoundaryEvent, IntermediateCatchEvent, IntermediateThrowEvent
 from ..specs.SubWorkflowTask import CallActivity, SubWorkflowTask, TransactionSubprocess

--- a/SpiffWorkflow/bpmn/parser/ProcessParser.py
+++ b/SpiffWorkflow/bpmn/parser/ProcessParser.py
@@ -20,7 +20,7 @@
 from .ValidationException import ValidationException
 from ..specs.BpmnProcessSpec import BpmnProcessSpec, BpmnDataSpecification
 from .node_parser import NodeParser
-from .util import first, xpath_eval
+from .util import first
 
 
 class ProcessParser(NodeParser):

--- a/SpiffWorkflow/bpmn/parser/event_parsers.py
+++ b/SpiffWorkflow/bpmn/parser/event_parsers.py
@@ -6,8 +6,7 @@ from .util import first, one
 from ..specs.events import (TimerEventDefinition, MessageEventDefinition,
                             ErrorEventDefinition, EscalationEventDefinition,SignalEventDefinition,
                             CancelEventDefinition, CycleTimerEventDefinition,
-                            TerminateEventDefinition, NoneEventDefinition,
-                            StartEvent, EndEvent, BoundaryEvent, IntermediateCatchEvent, IntermediateThrowEvent)
+                            TerminateEventDefinition, NoneEventDefinition)
 
 
 CAMUNDA_MODEL_NS = 'http://camunda.org/schema/1.0/bpmn'

--- a/SpiffWorkflow/bpmn/serializer/BpmnSerializer.py
+++ b/SpiffWorkflow/bpmn/serializer/BpmnSerializer.py
@@ -23,7 +23,6 @@ from warnings import warn
 from lxml import etree
 import zipfile
 import os
-from json import loads
 
 from SpiffWorkflow import TaskState
 from ...bpmn.specs.SubWorkflowTask import SubWorkflowTask

--- a/SpiffWorkflow/bpmn/serializer/task_spec_converters.py
+++ b/SpiffWorkflow/bpmn/serializer/task_spec_converters.py
@@ -1,19 +1,18 @@
 from uuid import UUID
 
-from .bpmn_converters import BpmnDataConverter, BpmnTaskSpecConverter
+from .bpmn_converters import BpmnTaskSpecConverter
 
 from ...specs import StartTask
 from ...specs.Simple import Simple
 from ...specs.LoopResetTask import LoopResetTask
 
 from ..specs.BpmnProcessSpec import _EndJoin
-from ..specs.BpmnSpecMixin import BpmnSpecMixin, SequenceFlow, _BpmnCondition
+from ..specs.BpmnSpecMixin import _BpmnCondition
 
 from ..specs.NoneTask import NoneTask
 from ..specs.UserTask import UserTask
 from ..specs.ManualTask import ManualTask
 from ..specs.ScriptTask import ScriptTask
-from ..specs.MultiInstanceTask import MultiInstanceTask
 from ..specs.SubWorkflowTask import CallActivity, TransactionSubprocess
 
 from ..specs.ExclusiveGateway import ExclusiveGateway

--- a/SpiffWorkflow/bpmn/serializer/workflow.py
+++ b/SpiffWorkflow/bpmn/serializer/workflow.py
@@ -9,7 +9,7 @@ from .bpmn_converters import BpmnDataConverter
 
 from ..workflow import BpmnWorkflow
 from ..specs.SubWorkflowTask import SubWorkflowTask
-from ...task import Task, TaskState
+from ...task import Task
 
 from .workflow_spec_converter import BpmnProcessSpecConverter
 

--- a/SpiffWorkflow/bpmn/specs/ManualTask.py
+++ b/SpiffWorkflow/bpmn/specs/ManualTask.py
@@ -20,8 +20,6 @@ from ...bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
 
 from ...specs import Simple
 
-from .UserTask import UserTask
-
 
 class ManualTask(Simple, BpmnSpecMixin):
 

--- a/SpiffWorkflow/bpmn/specs/NoneTask.py
+++ b/SpiffWorkflow/bpmn/specs/NoneTask.py
@@ -20,8 +20,6 @@ from ...specs import Simple
 
 from ...bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
 
-from .UserTask import UserTask
-
 
 class NoneTask(Simple, BpmnSpecMixin):
 

--- a/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
@@ -20,7 +20,6 @@
 from .event_types import ThrowingEvent, CatchingEvent
 from .event_definitions import CycleTimerEventDefinition
 from ..BpmnSpecMixin import BpmnSpecMixin
-from ..SubWorkflowTask import SubWorkflowTask
 from ....specs.Simple import Simple
 from ....task import TaskState
 

--- a/SpiffWorkflow/bpmn/specs/events/StartEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/StartEvent.py
@@ -18,7 +18,6 @@
 # 02110-1301  USA
 
 from .event_types import CatchingEvent
-from .event_definitions import CycleTimerEventDefinition
 from ....task import TaskState
 
 

--- a/SpiffWorkflow/bpmn/specs/events/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_definitions.py
@@ -17,7 +17,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
 
-import sys
 import datetime
 import logging
 import datetime

--- a/SpiffWorkflow/camunda/serializer/task_spec_converters.py
+++ b/SpiffWorkflow/camunda/serializer/task_spec_converters.py
@@ -1,7 +1,6 @@
-from ...bpmn.serializer.bpmn_converters import BpmnDataConverter, BpmnTaskSpecConverter
+from ...bpmn.serializer.bpmn_converters import BpmnTaskSpecConverter
 
 from ..specs.UserTask import UserTask, Form
-from ..specs.UserTask import FormField
 
 class UserTaskConverter(BpmnTaskSpecConverter):
 

--- a/SpiffWorkflow/camunda/specs/UserTask.py
+++ b/SpiffWorkflow/camunda/specs/UserTask.py
@@ -3,7 +3,6 @@
 
 from ...bpmn.specs.UserTask import UserTask
 from ...bpmn.specs.BpmnSpecMixin import BpmnSpecMixin
-from ...specs import Simple
 
 
 class UserTask(UserTask, BpmnSpecMixin):

--- a/SpiffWorkflow/dmn/parser/DMNParser.py
+++ b/SpiffWorkflow/dmn/parser/DMNParser.py
@@ -1,8 +1,4 @@
 import ast
-import re
-from decimal import Decimal
-from ast import literal_eval
-from datetime import datetime
 
 from ...bpmn.parser.util import xpath_eval
 

--- a/SpiffWorkflow/dmn/serializer/task_spec_converters.py
+++ b/SpiffWorkflow/dmn/serializer/task_spec_converters.py
@@ -1,7 +1,7 @@
-from ...bpmn.serializer.bpmn_converters import BpmnDataConverter, BpmnTaskSpecConverter
+from ...bpmn.serializer.bpmn_converters import BpmnTaskSpecConverter
 
 from ..specs.BusinessRuleTask import BusinessRuleTask
-from ..specs.model import Decision, DecisionTable, Rule
+from ..specs.model import DecisionTable, Rule
 from ..specs.model import Input, InputEntry, Output, OutputEntry
 from ..engine.DMNEngine import DMNEngine
 

--- a/SpiffWorkflow/serializer/json.py
+++ b/SpiffWorkflow/serializer/json.py
@@ -19,7 +19,6 @@ import uuid
 from .dict import DictionarySerializer
 from ..operators import Attrib
 from ..camunda.specs.UserTask import Form
-from ..util.impl import get_class
 
 def object_hook(dct):
     if '__uuid__' in dct:

--- a/SpiffWorkflow/specs/Trigger.py
+++ b/SpiffWorkflow/specs/Trigger.py
@@ -17,7 +17,7 @@ from builtins import range
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
-from ..task import Task, TaskState
+from ..task import TaskState
 from .base import TaskSpec
 from ..operators import valueof
 

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -23,7 +23,7 @@ import logging
 from abc import abstractmethod
 
 from ..util.event import Event
-from ..task import Task, TaskState
+from ..task import TaskState
 from ..exceptions import WorkflowException
 
 

--- a/SpiffWorkflow/spiff/specs/subworkflow_task.py
+++ b/SpiffWorkflow/spiff/specs/subworkflow_task.py
@@ -1,4 +1,3 @@
-from ast import Pass
 from SpiffWorkflow.bpmn.specs.SubWorkflowTask import SubWorkflowTask, TransactionSubprocess, CallActivity
 from SpiffWorkflow.spiff.specs.spiff_task import SpiffBpmnTask
 

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -24,7 +24,6 @@ from .exceptions import WorkflowException
 import logging
 import time
 from uuid import uuid4
-from enum import IntFlag
 
 from .util.deep_merge import DeepMerge
 

--- a/SpiffWorkflow/workflow.py
+++ b/SpiffWorkflow/workflow.py
@@ -24,7 +24,6 @@ from .task import Task, TaskState
 from .util.compat import mutex
 from .util.event import Event
 from .exceptions import WorkflowException
-from .bpmn.specs.events import _BoundaryEventParent
 LOG = logging.getLogger(__name__)
 
 

--- a/tests/SpiffWorkflow/PatternTest.py
+++ b/tests/SpiffWorkflow/PatternTest.py
@@ -3,9 +3,7 @@
 from builtins import object
 import sys
 import unittest
-import re
 import os
-import glob
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from SpiffWorkflow.specs import *

--- a/tests/SpiffWorkflow/TaskTest.py
+++ b/tests/SpiffWorkflow/TaskTest.py
@@ -12,7 +12,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from SpiffWorkflow import Task, TaskState
 from SpiffWorkflow.task import updateDotDict
 from SpiffWorkflow.specs import WorkflowSpec, Simple
-from SpiffWorkflow.exceptions import WorkflowException
 
 
 class MockWorkflow(object):

--- a/tests/SpiffWorkflow/WorkflowTest.py
+++ b/tests/SpiffWorkflow/WorkflowTest.py
@@ -2,7 +2,6 @@
 
 import sys
 import unittest
-import re
 import os
 data_dir = os.path.join(os.path.dirname(__file__), 'data')
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))

--- a/tests/SpiffWorkflow/bpmn/InvalidWorkflowsTest.py
+++ b/tests/SpiffWorkflow/bpmn/InvalidWorkflowsTest.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from fileinput import filename
 import unittest
 
 import os

--- a/tests/SpiffWorkflow/bpmn/MultiInstanceTest.py
+++ b/tests/SpiffWorkflow/bpmn/MultiInstanceTest.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from asyncio import subprocess
 import sys
 import os
 import unittest

--- a/tests/SpiffWorkflow/bpmn/events/CallActivityMessageTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/CallActivityMessageTest.py
@@ -1,6 +1,4 @@
 import unittest
-import datetime
-import time
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase

--- a/tests/SpiffWorkflow/bpmn/events/MessageInterruptsSpTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageInterruptsSpTest.py
@@ -3,8 +3,6 @@
 
 
 import unittest
-import datetime
-import time
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase

--- a/tests/SpiffWorkflow/bpmn/events/MessageInterruptsTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageInterruptsTest.py
@@ -3,8 +3,6 @@
 
 
 import unittest
-import datetime
-import time
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase

--- a/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptTest.py
@@ -3,8 +3,6 @@
 
 
 import unittest
-import datetime
-import time
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase

--- a/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptsSpTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptsSpTest.py
@@ -3,8 +3,6 @@
 
 
 import unittest
-import datetime
-import time
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase

--- a/tests/SpiffWorkflow/camunda/MultiInstanceDeepDictEdit.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceDeepDictEdit.py
@@ -9,8 +9,6 @@ import os
 import unittest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
-from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
-from SpiffWorkflow.exceptions import WorkflowException
 __author__ = 'matth'
 
 from tests.SpiffWorkflow.camunda.BaseTestCase import BaseTestCase

--- a/tests/SpiffWorkflow/data/spiff/workflow1.py
+++ b/tests/SpiffWorkflow/data/spiff/workflow1.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from builtins import str
 from SpiffWorkflow.specs import *
 from SpiffWorkflow.operators import *
 

--- a/tests/SpiffWorkflow/dmn/BoxDeepCopyTest.py
+++ b/tests/SpiffWorkflow/dmn/BoxDeepCopyTest.py
@@ -1,6 +1,5 @@
 import unittest
 
-from tests.SpiffWorkflow.dmn.DecisionRunner import DecisionRunner
 from SpiffWorkflow.bpmn.PythonScriptEngine import Box
 
 

--- a/tests/SpiffWorkflow/dmn/BusinessRuleTaskParserTest.py
+++ b/tests/SpiffWorkflow/dmn/BusinessRuleTaskParserTest.py
@@ -3,7 +3,6 @@ import unittest
 from unittest.mock import patch
 
 from SpiffWorkflow import TaskState
-from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
 
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 

--- a/tests/SpiffWorkflow/dmn/Dmn20151101VersionTest.py
+++ b/tests/SpiffWorkflow/dmn/Dmn20151101VersionTest.py
@@ -1,8 +1,6 @@
 import os
 import unittest
 
-from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
-
 from SpiffWorkflow.dmn.parser.BpmnDmnParser import BpmnDmnParser
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 

--- a/tests/SpiffWorkflow/dmn/Dmn20191111VersionTest.py
+++ b/tests/SpiffWorkflow/dmn/Dmn20191111VersionTest.py
@@ -1,8 +1,6 @@
 import os
 import unittest
 
-from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
-
 from SpiffWorkflow.dmn.parser.BpmnDmnParser import BpmnDmnParser
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 

--- a/tests/SpiffWorkflow/docTest.py
+++ b/tests/SpiffWorkflow/docTest.py
@@ -2,7 +2,6 @@
 
 import sys
 import unittest
-import re
 import os
 dirname = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(dirname, '..', '..'))

--- a/tests/SpiffWorkflow/serializer/baseTest.py
+++ b/tests/SpiffWorkflow/serializer/baseTest.py
@@ -3,21 +3,17 @@
 from builtins import str
 import sys
 import unittest
-import re
 import os
 import warnings
 dirname = os.path.dirname(__file__)
 data_dir = os.path.join(dirname, '..', 'data')
 sys.path.insert(0, os.path.join(dirname, '..'))
 
-from uuid import UUID
 from PatternTest import run_workflow, PatternTest
 from SpiffWorkflow.serializer.base import Serializer
 from SpiffWorkflow.specs import WorkflowSpec
 from SpiffWorkflow import Workflow
-from SpiffWorkflow.serializer.exceptions import TaskSpecNotSupportedError, \
-    TaskNotSupportedError
-from data.spiff.workflow1 import TestWorkflowSpec
+from SpiffWorkflow.serializer.exceptions import TaskNotSupportedError
 
 
 class SerializerTest(PatternTest):

--- a/tests/SpiffWorkflow/serializer/dictTest.py
+++ b/tests/SpiffWorkflow/serializer/dictTest.py
@@ -3,7 +3,6 @@
 from builtins import str
 import sys
 import unittest
-import re
 import os
 dirname = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(dirname, '..', '..', '..'))

--- a/tests/SpiffWorkflow/serializer/jsonTest.py
+++ b/tests/SpiffWorkflow/serializer/jsonTest.py
@@ -2,14 +2,12 @@
 
 import sys
 import unittest
-import re
 import os
 dirname = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(dirname, '..', '..', '..'))
 
 import json
 from SpiffWorkflow.serializer.json import JSONSerializer
-from .baseTest import SerializerTest
 from .dictTest import DictionarySerializerTest
 
 

--- a/tests/SpiffWorkflow/serializer/prettyxmlTest.py
+++ b/tests/SpiffWorkflow/serializer/prettyxmlTest.py
@@ -2,7 +2,6 @@
 
 import sys
 import unittest
-import re
 import os
 dirname = os.path.dirname(__file__)
 data_dir = os.path.join(dirname, '..', 'data')

--- a/tests/SpiffWorkflow/serializer/xmlTest.py
+++ b/tests/SpiffWorkflow/serializer/xmlTest.py
@@ -2,7 +2,6 @@
 
 import sys
 import unittest
-import re
 import os
 dirname = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(dirname, '..'))

--- a/tests/SpiffWorkflow/specs/DeepMergeTest.py
+++ b/tests/SpiffWorkflow/specs/DeepMergeTest.py
@@ -10,9 +10,7 @@ from SpiffWorkflow.util.deep_merge import DeepMerge
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
-from tests.SpiffWorkflow.util import run_workflow
 from .TaskSpecTest import TaskSpecTest
-from SpiffWorkflow.specs import Transform, Simple
 
 
 class DeepMergeTest(TaskSpecTest):

--- a/tests/SpiffWorkflow/specs/JoinTest.py
+++ b/tests/SpiffWorkflow/specs/JoinTest.py
@@ -9,7 +9,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
 from .TaskSpecTest import TaskSpecTest
 from SpiffWorkflow.specs import Join
-from SpiffWorkflow import Workflow
 
 
 class JoinTest(TaskSpecTest):

--- a/tests/SpiffWorkflow/specs/SubWorkflowTest.py
+++ b/tests/SpiffWorkflow/specs/SubWorkflowTest.py
@@ -2,12 +2,11 @@
 
 import sys
 import unittest
-import re
 import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
-from SpiffWorkflow.specs import WorkflowSpec, Simple, Join
+from SpiffWorkflow.specs import WorkflowSpec
 from SpiffWorkflow.specs.SubWorkflow import SubWorkflow
 from SpiffWorkflow.serializer.prettyxml import XmlSerializer
 from SpiffWorkflow.task import TaskState

--- a/tests/SpiffWorkflow/specs/TaskSpecTest.py
+++ b/tests/SpiffWorkflow/specs/TaskSpecTest.py
@@ -2,7 +2,6 @@
 
 import sys
 import unittest
-import re
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 


### PR DESCRIPTION
I realized I forgot to remove the import for `IntFlag` during a previous pr. Figured there were probably more cases like that so I ran `pylint` to find some unused imports and removed those also.