### PR TITLE
Don't leave function definitions in the Context - avoids pointless serialization errors 

### DIFF
--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -266,6 +266,14 @@ class PythonScriptEngine(object):
         my_globals.update(context)
         my_globals.update(external_methods or {})
         exec(script, my_globals, context)
+        self.remove_functions_from_context(context)
+
+    def remove_functions_from_context(self, context):
+        """When executing a script, don't leave function definitions around
+         in the context"""
+        for k in list(context):
+            if hasattr(context[k], '__call__'):
+                context.pop(k)
 
     def _is_complete(self, task):
         # The default is just to run exec in this process, so we'll never need this

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowSerializerTest.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowSerializerTest.py
@@ -58,7 +58,7 @@ class BpmnWorkflowSerializerTest(unittest.TestCase):
     def testSerializeWorkflow(self):
         serialized = self.serializer.serialize_json(self.workflow)
         json.loads(serialized)
-    
+
     def testSerializeWorkflowCustomJSONEncoderDecoder(self):
         class MyCls:
             a = 1
@@ -170,6 +170,17 @@ class BpmnWorkflowSerializerTest(unittest.TestCase):
         ready_tasks[0].complete()
         wf.do_engine_steps()
         self.assertEqual(True, wf.is_completed())
+
+    def test_serialize_workflow_where_script_task_includes_function(self):
+        self.workflow.do_engine_steps()
+        ready_tasks = self.workflow.get_ready_user_tasks()
+        ready_tasks[0].complete()
+        self.workflow.do_engine_steps()
+        results = self.serializer.serialize_json(self.workflow)
+        assert self.workflow.is_completed()
+        assert 'y' in self.workflow.last_task.data
+        assert 'x' not in self.workflow.last_task.data
+        assert 'some_fun' not in self.workflow.last_task.data
 
     def _compare_with_deserialized_copy(self, wf):
         json = self.serializer.serialize_json(wf)

--- a/tests/SpiffWorkflow/bpmn/data/random_fact.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/random_fact.bpmn
@@ -1,10 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1gjhqt9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1gjhqt9" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
   <bpmn:process id="random_fact" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0ik56h0</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_0ik56h0" sourceRef="StartEvent_1" targetRef="Task_User_Select_Type" />
+    <bpmn:scriptTask id="Task_Get_Fact_From_API" name="Display Fact">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="Fact.type" />
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1291h6i</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0am07in</bpmn:outgoing>
+      <bpmn:script>#! scripts.FactService
+
+def some_fun():
+  x = "what fun!"
+  return x;
+
+y = some_fun() </bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="EndEvent_0u1cgrf">
+      <bpmn:incoming>SequenceFlow_0am07in</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0am07in" sourceRef="Task_Get_Fact_From_API" targetRef="EndEvent_0u1cgrf" />
     <bpmn:userTask id="Task_User_Select_Type" name="Set Type" camunda:formKey="Get A Random Fun Fact">
       <bpmn:documentation>Here's some documentation</bpmn:documentation>
       <bpmn:extensionElements>
@@ -58,69 +77,56 @@
       <bpmn:incoming>SequenceFlow_0ik56h0</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1291h6i</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:scriptTask id="Task_Get_Fact_From_API" name="Display Fact">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="Fact.type" />
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>SequenceFlow_1291h6i</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_0am07in</bpmn:outgoing>
-      <bpmn:script>#! scripts.FactService</bpmn:script>
-    </bpmn:scriptTask>
-    <bpmn:endEvent id="EndEvent_0u1cgrf">
-      <bpmn:incoming>SequenceFlow_0am07in</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_0am07in" sourceRef="Task_Get_Fact_From_API" targetRef="EndEvent_0u1cgrf" />
     <bpmn:sequenceFlow id="SequenceFlow_1291h6i" sourceRef="Task_User_Select_Type" targetRef="Task_Get_Fact_From_API" />
+    <bpmn:sequenceFlow id="SequenceFlow_0ik56h0" sourceRef="StartEvent_1" targetRef="Task_User_Select_Type" />
     <bpmn:textAnnotation id="TextAnnotation_09fq7kh">
       <bpmn:text>User sets the Fact.type to cat, norris, or buzzword</bpmn:text>
     </bpmn:textAnnotation>
-    <bpmn:association id="Association_1cfasjp" sourceRef="Task_User_Select_Type" targetRef="TextAnnotation_09fq7kh" />
     <bpmn:textAnnotation id="TextAnnotation_1234e5n">
       <bpmn:text>Makes an API  call to get a fact of the required type.</bpmn:text>
     </bpmn:textAnnotation>
     <bpmn:association id="Association_1qirnyy" sourceRef="Task_Get_Fact_From_API" targetRef="TextAnnotation_1234e5n" />
+    <bpmn:association id="Association_1cfasjp" sourceRef="Task_User_Select_Type" targetRef="TextAnnotation_09fq7kh" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="random_fact">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="152" y="232" width="36" height="36" />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1291h6i_di" bpmnElement="SequenceFlow_1291h6i">
+        <di:waypoint x="370" y="250" />
+        <di:waypoint x="470" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0am07in_di" bpmnElement="SequenceFlow_0am07in">
+        <di:waypoint x="570" y="250" />
+        <di:waypoint x="692" y="250" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0ik56h0_di" bpmnElement="SequenceFlow_0ik56h0">
         <di:waypoint x="188" y="250" />
         <di:waypoint x="270" y="250" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_186s7tw_di" bpmnElement="Task_User_Select_Type">
         <dc:Bounds x="270" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ScriptTask_10keafb_di" bpmnElement="Task_Get_Fact_From_API">
         <dc:Bounds x="470" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0u1cgrf_di" bpmnElement="EndEvent_0u1cgrf">
+        <dc:Bounds x="692" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_09fq7kh_di" bpmnElement="TextAnnotation_09fq7kh">
         <dc:Bounds x="330" y="116" width="99.99202297383536" height="68.28334396936822" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="TextAnnotation_1234e5n_di" bpmnElement="TextAnnotation_1234e5n">
+        <dc:Bounds x="570" y="120" width="100" height="68" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_1cfasjp_di" bpmnElement="Association_1cfasjp">
         <di:waypoint x="344" y="210" />
         <di:waypoint x="359" y="184" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="TextAnnotation_1234e5n_di" bpmnElement="TextAnnotation_1234e5n">
-        <dc:Bounds x="570" y="120" width="100" height="68" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Association_1qirnyy_di" bpmnElement="Association_1qirnyy">
         <di:waypoint x="561" y="210" />
         <di:waypoint x="584" y="188" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="EndEvent_0u1cgrf_di" bpmnElement="EndEvent_0u1cgrf">
-        <dc:Bounds x="692" y="232" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0am07in_di" bpmnElement="SequenceFlow_0am07in">
-        <di:waypoint x="570" y="250" />
-        <di:waypoint x="692" y="250" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1291h6i_di" bpmnElement="SequenceFlow_1291h6i">
-        <di:waypoint x="370" y="250" />
-        <di:waypoint x="470" y="250" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Just a quick fix to the base python script engine so we avoid leaving functions around in the context after executing a script.