### PR TITLE
Up some sleep times in tests for CI stability

### DIFF
--- a/tests/SpiffWorkflow/bpmn/data/timer-cycle-start.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer-cycle-start.bpmn
@@ -22,7 +22,7 @@
     <bpmn:startEvent id="CycleStart">
       <bpmn:outgoing>Flow_0jtfzsk</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0za5f2h">
-        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">(2,timedelta(seconds=0.01))</bpmn:timeCycle>
+        <bpmn:timeCycle xsi:type="bpmn:tFormalExpression">(2,timedelta(seconds=0.1))</bpmn:timeCycle>
       </bpmn:timerEventDefinition>
     </bpmn:startEvent>
     <bpmn:scriptTask id="Refill_Coffee" name="Refill Coffee">
@@ -37,7 +37,7 @@
       <bpmn:incoming>Flow_1pahvlr</bpmn:incoming>
       <bpmn:outgoing>Flow_05ejbm4</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0o35ug0">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=0.05)</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=0.5)</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
     <bpmn:endEvent id="EndItAll">

--- a/tests/SpiffWorkflow/bpmn/data/timer.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/timer.bpmn
@@ -12,7 +12,7 @@
       <bpmn:incoming>Flow_1pvkgnu</bpmn:incoming>
       <bpmn:outgoing>Flow_1elbn9u</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_1jrn73k">
-        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=.025)</bpmn:timeDuration>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=.25)</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
     <bpmn:manualTask id="Activity_1rbj8j1" name="Get Back To Work">

--- a/tests/SpiffWorkflow/bpmn/events/TimerCycleStartTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerCycleStartTest.py
@@ -58,7 +58,7 @@ class TimerCycleStartTest(BpmnWorkflowTestCase):
             if save_restore:
                 self.save_restore()
                 self.workflow.script_engine = CustomScriptEngine()
-            time.sleep(0.01)
+            time.sleep(0.1)
             self.workflow.refresh_waiting_tasks()
             self.workflow.do_engine_steps()
         self.assertEqual(counter, 2)

--- a/tests/SpiffWorkflow/bpmn/events/TimerDurationTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDurationTest.py
@@ -34,7 +34,7 @@ class TimerDurationTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
 
         loopcount = 0
-        # test bpmn has a timeout of .025s
+        # test bpmn has a timeout of .25s
         # we should terminate loop before that.
         starttime = datetime.datetime.now()
         while loopcount < 10:
@@ -42,13 +42,13 @@ class TimerDurationTest(BpmnWorkflowTestCase):
                 break
             if save_restore: self.save_restore()
             self.assertEqual(1, len(self.workflow.get_tasks(TaskState.WAITING)))
-            time.sleep(0.01)
+            time.sleep(0.1)
             self.workflow.refresh_waiting_tasks()
             loopcount = loopcount +1
         endtime = datetime.datetime.now()
         duration = endtime-starttime
-        self.assertEqual(duration<datetime.timedelta(seconds=.05),True)
-        self.assertEqual(duration>datetime.timedelta(seconds=.02),True)
+        self.assertEqual(duration<datetime.timedelta(seconds=.5),True)
+        self.assertEqual(duration>datetime.timedelta(seconds=.2),True)
 
 
 def suite():


### PR DESCRIPTION
Saw these were failing in the currently open prs. 10x'd the sleep times to start, hopefully these pass in CI consistently now.