### PR TITLE
Service task connector delegate

### DIFF
--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -150,25 +150,14 @@ class PythonScriptEngine(object):
         called from service tasks."""
         return None
 
-    def external_methods_for_operation_name(self, operation_name):
-        """Returns a subset of available_service_task_external_methods
-        that can be called from a service task with the given
-        operation_name."""
-
-        external_methods = self.available_service_task_external_methods()
-        if external_methods is None or operation_name not in external_methods:
-            return {}
-
-        return { operation_name: external_methods[operation_name] }
-
-    def execute_service_task_script(self, task, operation_name, script, data,
+    def execute_service_task_script(self, task, script, data,
             external_methods=None):
         """Execute the script, within the context of the specified task. Task
         is assumed to be a service task. service_task_external_methods are
         filtered by the given operation name and merged with the supplied
         external_methods before execution."""
 
-        additions = self.external_methods_for_operation_name(operation_name)
+        additions = self.available_service_task_external_methods()
 
         if external_methods is None:
             external_methods = {}

--- a/SpiffWorkflow/spiff/specs/service_task.py
+++ b/SpiffWorkflow/spiff/specs/service_task.py
@@ -14,7 +14,7 @@ class ServiceTask(SpiffBpmnTask, ServiceTask):
 
         operation_params_var_name = 'spiff__operation_params'
         evaluated_params = {k: evaluate(v) for k, v in self.operation_params.items()}
-        script = f'ServiceTaskDelegate.callConnector("{self.operation_name}", {operation_params_var_name})'
+        script = f'ServiceTaskDelegate.call_connector("{self.operation_name}", {operation_params_var_name})'
 
         task.workflow.script_engine.execute_service_task_script(task, script, task.data,
                 external_methods={ operation_params_var_name: evaluated_params })

--- a/SpiffWorkflow/spiff/specs/service_task.py
+++ b/SpiffWorkflow/spiff/specs/service_task.py
@@ -14,8 +14,7 @@ class ServiceTask(SpiffBpmnTask, ServiceTask):
 
         operation_params_var_name = 'spiff__operation_params'
         evaluated_params = {k: evaluate(v) for k, v in self.operation_params.items()}
-        script = f'{self.operation_name}(**{operation_params_var_name}).execute()'
+        script = f'ServiceTaskDelegate.callConnector("{self.operation_name}", {operation_params_var_name})'
 
-        task.workflow.script_engine.execute_service_task_script(task,
-                self.operation_name, script, task.data,
+        task.workflow.script_engine.execute_service_task_script(task, script, task.data,
                 external_methods={ operation_params_var_name: evaluated_params })

--- a/tests/SpiffWorkflow/spiff/ServiceTaskTest.py
+++ b/tests/SpiffWorkflow/spiff/ServiceTaskTest.py
@@ -15,23 +15,21 @@ from .BaseTestCase import BaseTestCase
 assertEqual = None
 operatorExecuted = False
 
-class SlackWebhookOperator(object):
-    def __init__(self, webhook_token="", message="", channel="", **kwargs):
-        self.channel = channel['value']
-        self.message = message['value']
-        self.webhook_token = webhook_token['value']
-
-    def execute(self):
-        assertEqual(self.channel, "#")
-        assertEqual(self.message, "ServiceTask testing")
-        assertEqual(self.webhook_token, "[FIXME]")
+class ServiceTaskDelegate:
+    @staticmethod
+    def callConnector(name, params):
+        assertEqual(name, 'bamboohr/GetPayRate')
+        assertEqual(len(params), 3)
+        assertEqual(params['api_key']['value'], 'secret:BAMBOOHR_API_KEY')
+        assertEqual(params['employee_id']['value'], '4')
+        assertEqual(params['subdomain']['value'], 'ServiceTask')
 
         global operatorExecuted
         operatorExecuted = True
 
 class ExampleCustomScriptEngine(PythonScriptEngine):
     def available_service_task_external_methods(self):
-        return { 'SlackWebhookOperator': SlackWebhookOperator }
+        return { 'ServiceTaskDelegate': ServiceTaskDelegate }
 
 class ServiceTaskTest(BaseTestCase):
 

--- a/tests/SpiffWorkflow/spiff/ServiceTaskTest.py
+++ b/tests/SpiffWorkflow/spiff/ServiceTaskTest.py
@@ -17,7 +17,7 @@ operatorExecuted = False
 
 class ServiceTaskDelegate:
     @staticmethod
-    def callConnector(name, params):
+    def call_connector(name, params):
         assertEqual(name, 'bamboohr/GetPayRate')
         assertEqual(len(params), 3)
         assertEqual(params['api_key']['value'], 'secret:BAMBOOHR_API_KEY')

--- a/tests/SpiffWorkflow/spiff/data/service_task.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/service_task.bpmn
@@ -7,11 +7,11 @@
     <bpmn:sequenceFlow id="Flow_0l9vzsi" sourceRef="StartEvent_1" targetRef="Activity_1inxqgx" />
     <bpmn:serviceTask id="Activity_1inxqgx" name="ServiceTask1">
       <bpmn:extensionElements>
-        <spiffworkflow:serviceTaskOperator id="SlackWebhookOperator">
+          <spiffworkflow:serviceTaskOperator id="bamboohr/GetPayRate">
           <spiffworkflow:parameters>
-            <spiffworkflow:parameter id="webhook_token" type="string" value="[FIXME]" />
-            <spiffworkflow:parameter id="message" type="string" value="ServiceTask testing" />
-            <spiffworkflow:parameter id="channel" type="string" value="#" />
+            <spiffworkflow:parameter id="api_key" type="string" value="secret:BAMBOOHR_API_KEY" />
+            <spiffworkflow:parameter id="employee_id" type="string" value="4" />
+            <spiffworkflow:parameter id="subdomain" type="string" value="ServiceTask" />
           </spiffworkflow:parameters>
         </spiffworkflow:serviceTaskOperator>
       </bpmn:extensionElements>


### PR DESCRIPTION
This is a change to give the consumer more control over how service task requests are executed. Previously service tasks could execute any class with an execute method - now the consumer of the library can provide a delegate to handle a given request. The backend currently routes requests through a local connector proxy, but a delegate could also communicate with a docker container, return dummy data, etc.

Wanted to go ahead and get this up since I have backend changes that depend on it.