### PR TITLE
Store service task response in task data

### DIFF
--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -150,12 +150,11 @@ class PythonScriptEngine(object):
         called from service tasks."""
         return None
 
-    def execute_service_task_script(self, task, script, data,
+    def evaluate_service_task_script(self, task, script, data,
             external_methods=None):
-        """Execute the script, within the context of the specified task. Task
+        """Evaluates the script, within the context of the specified task. Task
         is assumed to be a service task. service_task_external_methods are
-        filtered by the given operation name and merged with the supplied
-        external_methods before execution."""
+        merged with the supplied external_methods before execution."""
 
         additions = self.available_service_task_external_methods()
 
@@ -164,7 +163,7 @@ class PythonScriptEngine(object):
 
         external_methods.update(additions)
 
-        self.execute(task, script, external_methods=external_methods)
+        return self._evaluate(script, task.data, external_methods=external_methods)
 
     def is_complete(self, task):
 

--- a/SpiffWorkflow/spiff/parser/task_spec.py
+++ b/SpiffWorkflow/spiff/parser/task_spec.py
@@ -46,10 +46,11 @@ class SpiffTaskParser(TaskParser):
     @staticmethod
     def _parse_servicetask_operator(node):
         name = node.attrib['id']
+        result_variable = node.get('resultVariable', None)
         extra_ns = {'spiffworkflow': SPIFFWORKFLOW_MODEL_NS}
         xpath = xpath_eval(node, extra_ns)
         parameter_nodes = xpath('.//spiffworkflow:parameter')
-        operator = {'name': name}
+        operator = {'name': name, 'resultVariable': result_variable}
         parameters = {}
         for param_node in parameter_nodes:
             if 'value' in param_node.attrib:
@@ -112,6 +113,7 @@ class ServiceTaskParser(SpiffTaskParser):
         return self.spec_class(
                 self.spec, self.get_task_spec_name(),
                 operator['name'], operator['parameters'],
+                operator['resultVariable'],
                 lane=self.lane, position=self.position)
 
 class BusinessRuleTaskParser(SpiffTaskParser):

--- a/SpiffWorkflow/spiff/serializer/task_spec_converters.py
+++ b/SpiffWorkflow/spiff/serializer/task_spec_converters.py
@@ -43,6 +43,7 @@ class ServiceTaskConverter(SpiffBpmnTaskConverter):
         dct = super().to_dict(spec)
         dct['operation_name'] = spec.operation_name
         dct['operation_params'] = spec.operation_params
+        dct['result_variable'] = spec.result_variable
         return dct
 
     def from_dict(self, dct):

--- a/SpiffWorkflow/spiff/specs/service_task.py
+++ b/SpiffWorkflow/spiff/specs/service_task.py
@@ -4,16 +4,15 @@ from SpiffWorkflow.spiff.specs.spiff_task import SpiffBpmnTask
 
 class ServiceTask(SpiffBpmnTask, ServiceTask):
 
-    def __init__(self, wf_spec, name, operation_name, operation_params, **kwargs):
+    def __init__(self, wf_spec, name, operation_name, operation_params, result_variable, **kwargs):
         SpiffBpmnTask.__init__(self, wf_spec, name, **kwargs)
         self.operation_name = operation_name
         self.operation_params = operation_params
-        # TODO parse this from bpmn
-        self.result_variable = None
+        self.result_variable = result_variable
 
     def _result_variable(self, task):
-        if self.result_variable is not None:
-            return self.reslut_variable
+        if self.result_variable is not None and len(self.result_variable) > 0:
+            return self.result_variable
 
         return f'spiff__{task.task_spec.name}_result'
 

--- a/SpiffWorkflow/spiff/specs/service_task.py
+++ b/SpiffWorkflow/spiff/specs/service_task.py
@@ -14,7 +14,9 @@ class ServiceTask(SpiffBpmnTask, ServiceTask):
         if self.result_variable is not None and len(self.result_variable) > 0:
             return self.result_variable
 
-        return f'spiff__{task.task_spec.name}_result'
+        escaped_spec_name = task.task_spec.name.replace('-', '_')
+
+        return f'spiff__{escaped_spec_name}_result'
 
     def _execute(self, task):
         def evaluate(expression):

--- a/tests/SpiffWorkflow/spiff/ServiceTaskTest.py
+++ b/tests/SpiffWorkflow/spiff/ServiceTaskTest.py
@@ -22,6 +22,9 @@ class ServiceTaskDelegate:
             assertEqual(params['api_key']['value'], 'secret:BAMBOOHR_API_KEY')
             assertEqual(params['employee_id']['value'], '4')
             assertEqual(params['subdomain']['value'], 'ServiceTask')
+        elif name == 'weather/CurrentTemp':
+            assertEqual(len(params), 1)
+            assertEqual(params['zipcode']['value'], '22980')
         else:
             raise AssertionError('unexpected connector name')
 
@@ -31,6 +34,10 @@ class ServiceTaskDelegate:
                 "currency": "USD",
                 "id": "4",
                 "payRate": "65000.00 USD",
+            }
+        elif name == 'weather/CurrentTemp':
+            sample_response = {
+                "temp": "72F",
             }
 
         return json.dumps(sample_response)
@@ -66,11 +73,16 @@ class ServiceTaskTest(BaseTestCase):
         # service task without result variable name specified, mock
         # bamboohr/GetPayRate response
         result = self.workflow.data['spiff__Activity_1inxqgx_result']
-        assert len(result) == 4
-        assert result['amount'] == '65000.00'
-        assert result['currency'] == 'USD'
-        assert result['id'] == '4'
-        assert result['payRate'] == '65000.00 USD'
+        self.assertEqual(len(result), 4)
+        self.assertEqual(result['amount'], '65000.00')
+        self.assertEqual(result['currency'], 'USD')
+        self.assertEqual(result['id'], '4')
+        self.assertEqual(result['payRate'], '65000.00 USD')
+
+        # service task with result variable specified, mock weather response
+        result = self.workflow.data['waynesboroWeatherResult']
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result['temp'], '72F')
 
 
 def suite():

--- a/tests/SpiffWorkflow/spiff/ServiceTaskTest.py
+++ b/tests/SpiffWorkflow/spiff/ServiceTaskTest.py
@@ -12,7 +12,7 @@ from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from SpiffWorkflow.bpmn.exceptions import WorkflowTaskExecException
 from .BaseTestCase import BaseTestCase
 
-assertEqual = None
+#assertEqual = None
 
 class ServiceTaskDelegate:
     @staticmethod

--- a/tests/SpiffWorkflow/spiff/data/service_task.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/service_task.bpmn
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" id="Definitions_1rkzagd" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
-  <bpmn:process id="service_task_example1" name="ServiceTaskExample1" isExecutable="true">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" id="Definitions_1rkzagd" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.3.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.0.0">
+  <bpmn:process id="service_task_example1" name="ServiceTask" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0l9vzsi</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="Flow_0l9vzsi" sourceRef="StartEvent_1" targetRef="Activity_1inxqgx" />
     <bpmn:serviceTask id="Activity_1inxqgx" name="ServiceTask1">
       <bpmn:extensionElements>
-          <spiffworkflow:serviceTaskOperator id="bamboohr/GetPayRate">
+        <spiffworkflow:serviceTaskOperator id="bamboohr/GetPayRate">
           <spiffworkflow:parameters>
             <spiffworkflow:parameter id="api_key" type="string" value="secret:BAMBOOHR_API_KEY" />
             <spiffworkflow:parameter id="employee_id" type="string" value="4" />
@@ -19,30 +19,50 @@
       <bpmn:outgoing>Flow_16rdnn7</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:endEvent id="Event_0j8psiq">
-      <bpmn:incoming>Flow_16rdnn7</bpmn:incoming>
+      <bpmn:incoming>Flow_1fpsye7</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_16rdnn7" sourceRef="Activity_1inxqgx" targetRef="Event_0j8psiq" />
+    <bpmn:sequenceFlow id="Flow_16rdnn7" sourceRef="Activity_1inxqgx" targetRef="Activity_12erefa" />
+    <bpmn:sequenceFlow id="Flow_1fpsye7" sourceRef="Activity_12erefa" targetRef="Event_0j8psiq" />
+    <bpmn:serviceTask id="Activity_12erefa" name="ServiceTask2">
+      <bpmn:extensionElements>
+        <spiffworkflow:serviceTaskOperator id="weather/CurrentTemp" resultVariable="waynesboroWeatherResult">
+          <spiffworkflow:parameters>
+            <spiffworkflow:parameter id="zipcode" type="int" value="22980" />
+          </spiffworkflow:parameters>
+        </spiffworkflow:serviceTaskOperator>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_16rdnn7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fpsye7</bpmn:outgoing>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="service_task_example1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wwg8c1_di" bpmnElement="Activity_1inxqgx">
+        <dc:Bounds x="330" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0j8psiq_di" bpmnElement="Event_0j8psiq">
+        <dc:Bounds x="582" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ognsfj_di" bpmnElement="Activity_12erefa">
+        <dc:Bounds x="450" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0l9vzsi_di" bpmnElement="Flow_0l9vzsi">
         <di:waypoint x="215" y="117" />
         <di:waypoint x="330" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_16rdnn7_di" bpmnElement="Flow_16rdnn7">
         <di:waypoint x="430" y="117" />
+        <di:waypoint x="450" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fpsye7_di" bpmnElement="Flow_1fpsye7">
+        <di:waypoint x="550" y="117" />
         <di:waypoint x="582" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="99" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0j8psiq_di" bpmnElement="Event_0j8psiq">
-        <dc:Bounds x="582" y="99" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0wwg8c1_di" bpmnElement="Activity_1inxqgx">
-        <dc:Bounds x="330" y="77" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/tests/SpiffWorkflow/spiff/data/service_task.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/service_task.bpmn
@@ -4,8 +4,8 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0l9vzsi</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0l9vzsi" sourceRef="StartEvent_1" targetRef="Activity_1inxqgx" />
-    <bpmn:serviceTask id="Activity_1inxqgx" name="ServiceTask1">
+    <bpmn:sequenceFlow id="Flow_0l9vzsi" sourceRef="StartEvent_1" targetRef="Activity-1inxqgx" />
+    <bpmn:serviceTask id="Activity-1inxqgx" name="ServiceTask1">
       <bpmn:extensionElements>
         <spiffworkflow:serviceTaskOperator id="bamboohr/GetPayRate">
           <spiffworkflow:parameters>
@@ -21,7 +21,7 @@
     <bpmn:endEvent id="Event_0j8psiq">
       <bpmn:incoming>Flow_1fpsye7</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_16rdnn7" sourceRef="Activity_1inxqgx" targetRef="Activity_12erefa" />
+    <bpmn:sequenceFlow id="Flow_16rdnn7" sourceRef="Activity-1inxqgx" targetRef="Activity_12erefa" />
     <bpmn:sequenceFlow id="Flow_1fpsye7" sourceRef="Activity_12erefa" targetRef="Event_0j8psiq" />
     <bpmn:serviceTask id="Activity_12erefa" name="ServiceTask2">
       <bpmn:extensionElements>
@@ -40,7 +40,7 @@
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0wwg8c1_di" bpmnElement="Activity_1inxqgx">
+      <bpmndi:BPMNShape id="Activity_0wwg8c1_di" bpmnElement="Activity-1inxqgx">
         <dc:Bounds x="330" y="77" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>


### PR DESCRIPTION
Supports storing the response of a service task in task data. An optional `resultVariable` attribute is supported for naming the task data key. If one is not specified a variable name will be constructed based off the spec name. Tested via the front end, which after running a sample diagram to hit bamboohr:

```
Event_0fy5yvl: COMPLETED

{
  "current_user": {
    "id": "1",
    "username": "56457e8f-47c6-4f9f-a72b-473dea5edfeb"
  },
  "spiff__service_task_one_result": {
    "amount": "65000.00",
    "currency": "USD",
    "id": "4",
    "payRate": "65000.00 USD"
  }
}
```