### PR TITLE
add spec type property to task specs with BPMN names

### DIFF
--- a/SpiffWorkflow/bpmn/specs/BpmnSpecMixin.py
+++ b/SpiffWorkflow/bpmn/specs/BpmnSpecMixin.py
@@ -78,6 +78,10 @@ class BpmnSpecMixin(TaskSpec):
         self.data_input_associations = []
         self.data_output_associations = []
 
+    @property
+    def spec_type(self):
+        return 'BPMN Task'
+
     def is_loop_task(self):
         """
         Returns true if this task is a BPMN looping task

--- a/SpiffWorkflow/bpmn/specs/ExclusiveGateway.py
+++ b/SpiffWorkflow/bpmn/specs/ExclusiveGateway.py
@@ -49,6 +49,10 @@ class ExclusiveGateway(ExclusiveChoice, BpmnSpecMixin):
             if condition is None:
                 continue
 
+    @property
+    def spec_type(self):
+        return 'Exclusive Gateway'
+
     def serialize(self, serializer):
         return serializer.serialize_exclusive_gateway(self)
 

--- a/SpiffWorkflow/bpmn/specs/InclusiveGateway.py
+++ b/SpiffWorkflow/bpmn/specs/InclusiveGateway.py
@@ -62,6 +62,10 @@ class InclusiveGateway(UnstructuredJoin):
     specified, the Inclusive Gateway throws an exception.
     """
 
+    @property
+    def spec_type(self):
+        return 'Inclusive Gateway'
+
     def _check_threshold_unstructured(self, my_task, force=False):
 
         # Look at the tree to find all ready and waiting tasks (excluding ones

--- a/SpiffWorkflow/bpmn/specs/ManualTask.py
+++ b/SpiffWorkflow/bpmn/specs/ManualTask.py
@@ -27,6 +27,9 @@ class ManualTask(Simple, BpmnSpecMixin):
     def deserialize(self, serializer, wf_spec, s_state):
         return serializer.deserialize_generic(wf_spec, s_state, ManualTask)
 
-
     def is_engine_task(self):
         return False
+
+    @property
+    def spec_type(self):
+        return 'Manual Task'

--- a/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
+++ b/SpiffWorkflow/bpmn/specs/MultiInstanceTask.py
@@ -81,6 +81,10 @@ class MultiInstanceTask(TaskSpec):
 
         TaskSpec.__init__(self, wf_spec, name, **kwargs)
 
+    @property
+    def spec_type(self):
+        return 'MultiInstance Task'
+
     def _find_my_task(self, task):
         for thetask in task.workflow.task_tree:
             if thetask.thread_id != task.thread_id:
@@ -512,6 +516,7 @@ class MultiInstanceTask(TaskSpec):
         spec.prevtaskclass = s_state['prevtaskclass']
 
         return serializer.deserialize_multi_instance(wf_spec, s_state, spec)
+
 
 def getDynamicMIClass(id,prevclass):
     id = re.sub('(.+)_[0-9]$','\\1',id)

--- a/SpiffWorkflow/bpmn/specs/NoneTask.py
+++ b/SpiffWorkflow/bpmn/specs/NoneTask.py
@@ -25,6 +25,11 @@ class NoneTask(Simple, BpmnSpecMixin):
 
     def is_engine_task(self):
         return False
+
+    @property
+    def spec_type(self):
+        return 'Task'
+
     @classmethod
     def deserialize(self, serializer, wf_spec, s_state):
         return serializer.deserialize_generic(wf_spec, s_state, NoneTask)

--- a/SpiffWorkflow/bpmn/specs/ParallelGateway.py
+++ b/SpiffWorkflow/bpmn/specs/ParallelGateway.py
@@ -47,6 +47,10 @@ class ParallelGateway(UnstructuredJoin):
         return (force or len(completed_inputs) >= len(self.inputs),
                 waiting_tasks)
 
+    @property
+    def spec_type(self):
+        return 'Parallel Gateway'
+
     @classmethod
     def deserialize(self, serializer, wf_spec, s_state):
         return serializer.deserialize_generic(wf_spec, s_state, ParallelGateway)

--- a/SpiffWorkflow/bpmn/specs/ScriptTask.py
+++ b/SpiffWorkflow/bpmn/specs/ScriptTask.py
@@ -40,6 +40,10 @@ class ScriptTask(Simple, BpmnSpecMixin):
         super(ScriptTask, self).__init__(wf_spec, name, **kwargs)
         self.script = script
 
+    @property
+    def spec_type(self):
+        return 'Script Task'
+
     def _on_ready_hook(self, task):
         super(ScriptTask, self)._on_ready_hook(task)
         if task.workflow._is_busy_with_restore():

--- a/SpiffWorkflow/bpmn/specs/ServiceTask.py
+++ b/SpiffWorkflow/bpmn/specs/ServiceTask.py
@@ -22,6 +22,10 @@ class ServiceTask(Simple, BpmnSpecMixin):
         """
         super(ServiceTask, self).__init__(wf_spec, name, **kwargs)
 
+    @property
+    def spec_type(self):
+        return 'Service Task'
+
     def _execute(self, task):
         pass
 

--- a/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
+++ b/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
@@ -23,6 +23,10 @@ class SubWorkflowTask(SubWorkflow, BpmnSpecMixin):
         self.spec = subworkflow_spec
         self.transaction = transaction
 
+    @property
+    def spec_type(self):
+        return 'Subprocess'
+
     def test(self):
         TaskSpec.test(self)
 
@@ -103,6 +107,10 @@ class CallActivity(SubWorkflowTask):
     def __init__(self, wf_spec, name, subworkflow_spec, **kwargs):
         super(CallActivity, self).__init__(wf_spec, name, subworkflow_spec, False, **kwargs)
 
+    @property
+    def spec_type(self):
+        return 'Call Activity'
+
     @classmethod
     def deserialize(self, serializer, wf_spec, s_state):
         return serializer.deserialize_subworkflow_task(wf_spec, s_state, CallActivity)
@@ -111,6 +119,10 @@ class TransactionSubprocess(SubWorkflowTask):
 
     def __init__(self, wf_spec, name, subworkflow_spec, **kwargs):
         super(TransactionSubprocess, self).__init__(wf_spec, name, subworkflow_spec, True, **kwargs)
+
+    @property
+    def spec_type(self):
+        return 'Transactional Subprocess'
 
     @classmethod
     def deserialize(self, serializer, wf_spec, s_state):

--- a/SpiffWorkflow/bpmn/specs/UserTask.py
+++ b/SpiffWorkflow/bpmn/specs/UserTask.py
@@ -29,3 +29,7 @@ class UserTask(Simple, BpmnSpecMixin):
 
     def is_engine_task(self):
         return False
+
+    @property
+    def spec_type(self):
+        return 'User Task'

--- a/SpiffWorkflow/bpmn/specs/events/EndEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/EndEvent.py
@@ -45,6 +45,10 @@ class EndEvent(ThrowingEvent):
     def __init__(self, wf_spec, name, event_definition, **kwargs):
         super(EndEvent, self).__init__(wf_spec, name, event_definition, **kwargs)
 
+    @property
+    def spec_type(self):
+        return f'{self.event_definition.event_type} End Event'
+
     def _on_complete_hook(self, my_task):
 
         super(EndEvent, self)._on_complete_hook(my_task)

--- a/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
@@ -24,16 +24,32 @@ from ....specs.Simple import Simple
 from ....task import TaskState
 
 class SendTask(ThrowingEvent):
-    pass
+
+    @property
+    def spec_type(self):
+        return 'Send Task'
+
 
 class ReceiveTask(CatchingEvent):
-    pass
+
+    @property
+    def spec_type(self):
+        return 'Receive Task'
+
 
 class IntermediateCatchEvent(CatchingEvent):
-    pass
+
+    @property
+    def spec_type(self):
+        return f'{self.event_definition.event_type} Catching Event'
+
 
 class IntermediateThrowEvent(ThrowingEvent):
-    pass
+
+    @property
+    def spec_type(self):
+        return f'{self.event_definition.event_type} Throwing Event'
+
 
 class _BoundaryEventParent(Simple, BpmnSpecMixin):
     """This task is inserted before a task with boundary events."""
@@ -46,6 +62,10 @@ class _BoundaryEventParent(Simple, BpmnSpecMixin):
 
         super(_BoundaryEventParent, self).__init__(wf_spec, name)
         self.main_child_task_spec = main_child_task_spec
+    
+    @property
+    def spec_type(self):
+        return 'Boundary Event Parent'
 
     def _on_ready_hook(self, my_task):
 
@@ -104,6 +124,12 @@ class BoundaryEvent(CatchingEvent):
         """
         super(BoundaryEvent, self).__init__(wf_spec, name, event_definition, **kwargs)
         self.cancel_activity = cancel_activity
+
+    @property
+    def spec_type(self):
+        interrupting = 'Interrupting' if self.cancel_activity else 'Non-Interrupting'
+        return f'{interrupting} {self.event_definition.event_type} Event'
+
 
     def catches(self, my_task, event_definition, correlations=None):
         # Boundary events should only be caught while waiting

--- a/SpiffWorkflow/bpmn/specs/events/StartEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/StartEvent.py
@@ -17,7 +17,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
 
-from SpiffWorkflow.bpmn.specs.events.event_definitions import MessageEventDefinition
 from .event_types import CatchingEvent
 from ....task import TaskState
 
@@ -27,6 +26,10 @@ class StartEvent(CatchingEvent):
 
     def __init__(self, wf_spec, name, event_definition, **kwargs):
         super(StartEvent, self).__init__(wf_spec, name, event_definition, **kwargs)
+
+    @property
+    def spec_type(self):
+        return f'{self.event_definition.event_type} Start Event'
 
     def catch(self, my_task, event_definition):
 

--- a/SpiffWorkflow/bpmn/specs/events/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_definitions.py
@@ -40,6 +40,10 @@ class EventDefinition(object):
         # I don't want to write a separate deserializer for every every type.
         self.internal, self.external = True, True
 
+    @property
+    def event_type(self):
+        return f'{self.__class__.__module__}.{self.__class__.__name__}'
+
     def has_fired(self, my_task):
         return my_task._get_internal_data('event_fired', False)
 
@@ -118,6 +122,10 @@ class CancelEventDefinition(EventDefinition):
         super(CancelEventDefinition, self).__init__()
         self.internal = False
 
+    @property
+    def event_type(self):
+        return 'Cancel'
+
 
 class ErrorEventDefinition(NamedEventDefinition):
     """
@@ -129,6 +137,10 @@ class ErrorEventDefinition(NamedEventDefinition):
         super(ErrorEventDefinition, self).__init__(name)
         self.error_code = error_code
         self.internal = False
+
+    @property
+    def event_type(self):
+        return 'Error'
 
     def __eq__(self, other):
         return self.__class__.__name__ == other.__class__.__name__ and self.error_code in [ None, other.error_code ]
@@ -153,6 +165,10 @@ class EscalationEventDefinition(NamedEventDefinition):
         """
         super(EscalationEventDefinition, self).__init__(name)
         self.escalation_code = escalation_code
+
+    @property
+    def event_type(self):
+        return 'Escalation'
 
     def __eq__(self, other):
         return self.__class__.__name__ == other.__class__.__name__ and self.escalation_code in [ None, other.escalation_code ]
@@ -180,6 +196,10 @@ class MessageEventDefinition(NamedEventDefinition):
         self.correlation_properties = correlation_properties or []
         self.payload = None
         self.internal = False
+
+    @property
+    def event_type(self):
+        return 'Message'
 
     def catch(self, my_task, event_definition):
         self.update_internal_data(my_task, event_definition)
@@ -224,6 +244,10 @@ class NoneEventDefinition(EventDefinition):
     def __init__(self):
         self.internal, self.external = False, False
 
+    @property
+    def event_type(self):
+        return 'Default'
+
     def throw(self, my_task):
         pass
 
@@ -233,7 +257,10 @@ class NoneEventDefinition(EventDefinition):
 
 class SignalEventDefinition(NamedEventDefinition):
     """The SignalEventDefinition is the implementation of event definition used for Signal Events."""
-    pass
+
+    @property
+    def spec_type(self):
+        return 'Signal'
 
 class TerminateEventDefinition(EventDefinition):
     """The TerminateEventDefinition is the implementation of event definition used for Termination Events."""
@@ -241,6 +268,10 @@ class TerminateEventDefinition(EventDefinition):
     def __init__(self):
         super(TerminateEventDefinition, self).__init__()
         self.external = False
+
+    @property
+    def event_type(self):
+        return 'Terminate'
 
 class TimerEventDefinition(EventDefinition):
     """
@@ -261,6 +292,10 @@ class TimerEventDefinition(EventDefinition):
         super(TimerEventDefinition, self).__init__()
         self.label = label
         self.dateTime = dateTime
+
+    @property
+    def event_type(self):
+        return 'Timer'
 
     def has_fired(self, my_task):
         """
@@ -316,6 +351,10 @@ class CycleTimerEventDefinition(EventDefinition):
         # with a duration timer
         self.cycle_definition = cycle_definition
 
+    @property
+    def event_type(self):
+        return 'Cycle Timer'
+
     def has_fired(self, my_task):
         # We will fire this timer whenever a cycle completes
         # The task itself will manage counting how many times it fires
@@ -360,4 +399,3 @@ class CycleTimerEventDefinition(EventDefinition):
         retdict['label'] = self.label
         retdict['cycle_definition'] = self.cycle_definition
         return retdict
-

--- a/SpiffWorkflow/dmn/specs/BusinessRuleTask.py
+++ b/SpiffWorkflow/dmn/specs/BusinessRuleTask.py
@@ -21,6 +21,10 @@ class BusinessRuleTask(Simple, BpmnSpecMixin):
         self.res = None
         self.resDict = None
 
+    @property
+    def spec_class(self):
+        return 'Business Rule Task'
+
     def _on_complete_hook(self, my_task):
         try:
             self.res = self.dmnEngine.decide(my_task)

--- a/SpiffWorkflow/specs/Celery.py
+++ b/SpiffWorkflow/specs/Celery.py
@@ -133,7 +133,7 @@ class Celery(TaskSpec):
             args = _eval_args(self.args, my_task)
         if self.kwargs:
             kwargs = _eval_kwargs(self.kwargs, my_task)
-        logger.debug(f"{self.name} (task id {my_task.id}) calling {self.call}", my_task.log_info())
+        logger.debug(f"{self.name} (task id {my_task.id}) calling {self.call}", extra=my_task.log_info())
         async_call = default_app.send_task(self.call, args=args, kwargs=kwargs)
         my_task._set_internal_data(task_id=async_call.task_id)
         my_task.async_call = async_call

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -122,6 +122,10 @@ class TaskSpec(object):
         self.data.update(self.defines)
         assert self.id is not None
 
+    @property
+    def spec_type(self):
+        return f'{self.__class__.__module__}.{self.__class__.__name__}'
+
     def _connect_notify(self, taskspec):
         """
         Called by the previous task to let us know that it exists.

--- a/SpiffWorkflow/spiff/specs/manual_task.py
+++ b/SpiffWorkflow/spiff/specs/manual_task.py
@@ -4,3 +4,7 @@ class ManualTask(SpiffBpmnTask):
     
     def is_engine_task(self):
         return False
+
+    @property
+    def spec_type(self):
+        return 'Manual Task'

--- a/SpiffWorkflow/spiff/specs/none_task.py
+++ b/SpiffWorkflow/spiff/specs/none_task.py
@@ -4,3 +4,7 @@ class NoneTask(SpiffBpmnTask):
 
     def is_engine_task(self):
         return False
+
+    @property
+    def spec_type(self):
+        return 'Task'

--- a/SpiffWorkflow/spiff/specs/service_task.py
+++ b/SpiffWorkflow/spiff/specs/service_task.py
@@ -10,6 +10,10 @@ class ServiceTask(SpiffBpmnTask, ServiceTask):
         self.operation_params = operation_params
         self.result_variable = result_variable
 
+    @property
+    def spec_type(self):
+        return 'Service Task'
+
     def _result_variable(self, task):
         if self.result_variable is not None and len(self.result_variable) > 0:
             return self.result_variable

--- a/SpiffWorkflow/spiff/specs/spiff_task.py
+++ b/SpiffWorkflow/spiff/specs/spiff_task.py
@@ -13,6 +13,10 @@ class SpiffBpmnTask(BpmnSpecMixin):
         self.prescript = prescript
         self.postscript = postscript
 
+    @property
+    def spec_type(self):
+        return 'Spiff BPMN Task'
+
     def execute_script(self, my_task, script):
         try:
             my_task.workflow.script_engine.execute(my_task, script)

--- a/SpiffWorkflow/spiff/specs/subworkflow_task.py
+++ b/SpiffWorkflow/spiff/specs/subworkflow_task.py
@@ -13,6 +13,10 @@ class SubWorkflowTask(SpiffBpmnTask, SubWorkflowTask):
         self.in_assign = []
         self.out_assign = []
 
+    @property
+    def spec_type(self):
+        return 'Subprocess'
+
 class TransactionSubprocess(SpiffBpmnTask, TransactionSubprocess):
 
     def __init__(self, wf_spec, name, subworkflow_spec, transaction=True, **kwargs):
@@ -23,6 +27,10 @@ class TransactionSubprocess(SpiffBpmnTask, TransactionSubprocess):
         self.in_assign = []
         self.out_assign = []
 
+    @property
+    def spec_type(self):
+        return 'Transactional Subprocess'
+
 class CallActivity(SpiffBpmnTask, CallActivity):
 
     def __init__(self, wf_spec, name, subworkflow_spec, **kwargs):
@@ -31,3 +39,7 @@ class CallActivity(SpiffBpmnTask, CallActivity):
         self.spec = subworkflow_spec
         self.in_assign = []
         self.out_assign = []
+
+    @property
+    def spec_type(self):
+        return 'Call Activity'

--- a/SpiffWorkflow/spiff/specs/user_task.py
+++ b/SpiffWorkflow/spiff/specs/user_task.py
@@ -4,3 +4,7 @@ class UserTask(SpiffBpmnTask):
     
     def is_engine_task(self):
         return False
+    
+    @property
+    def spec_type(self):
+        return 'User Task'

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -295,14 +295,11 @@ class Task(object,  metaclass=DeprecatedMetaTask):
             'workflow': self.workflow.spec.name,
             'task_spec': self.task_spec.name,
             'task_id': self.id,
-            'task_type': self.task_spec_type(),
+            'task_type': self.task_spec.spec_type,
             'data': self.data if logger.level < 20 else None,
             'internal_data': self.internal_data if logger.level <= 10 else None,
         })
         return extra
-
-    def task_spec_type(self):
-        return self.task_spec.__class__.__name__
 
     def update_data_var(self, fieldid, value):
         model = {}
@@ -779,8 +776,7 @@ class Task(object,  metaclass=DeprecatedMetaTask):
         retval = self.task_spec._on_complete(self)
         extra = self.log_info({
             'action': 'Complete',
-            'elapsed': time.time() - start,
-            'task_type': self.task_spec_type(),
+            'elapsed': time.time() - start
         })
         metrics.debug('', extra=extra)
         return retval


### PR DESCRIPTION
Remove task_spec_type method in task and add spec_type property to specs containing the BPMN task types rather than the classes.