### PR TITLE
Bug/service task variable

### DIFF
--- a/SpiffWorkflow/spiff/specs/service_task.py
+++ b/SpiffWorkflow/spiff/specs/service_task.py
@@ -19,8 +19,14 @@ class ServiceTask(SpiffBpmnTask, ServiceTask):
         return f'spiff__{escaped_spec_name}_result'
 
     def _execute(self, task):
-        def evaluate(expression):
-            return task.workflow.script_engine.evaluate(task, repr(expression))
+        def evaluate(param):
+            try:
+                param['value'] = task.workflow.script_engine.evaluate(task,
+                        param['value'])
+            except:
+                pass
+
+            return param
 
         operation_params_var_name = 'spiff__operation_params'
         evaluated_params = {k: evaluate(v) for k, v in self.operation_params.items()}

--- a/tests/SpiffWorkflow/spiff/ServiceTaskTest.py
+++ b/tests/SpiffWorkflow/spiff/ServiceTaskTest.py
@@ -20,11 +20,11 @@ class ServiceTaskDelegate:
         if name == 'bamboohr/GetPayRate':
             assertEqual(len(params), 3)
             assertEqual(params['api_key']['value'], 'secret:BAMBOOHR_API_KEY')
-            assertEqual(params['employee_id']['value'], '4')
+            assertEqual(params['employee_id']['value'], 4)
             assertEqual(params['subdomain']['value'], 'ServiceTask')
         elif name == 'weather/CurrentTemp':
             assertEqual(len(params), 1)
-            assertEqual(params['zipcode']['value'], '22980')
+            assertEqual(params['zipcode']['value'], 22980)
         else:
             raise AssertionError('unexpected connector name')
 

--- a/tests/SpiffWorkflow/spiff/ServiceTaskVariableTest.py
+++ b/tests/SpiffWorkflow/spiff/ServiceTaskVariableTest.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+import json
+import os
+import sys
+import unittest
+
+dirname = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(dirname, '..', '..', '..'))
+
+from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from SpiffWorkflow.bpmn.exceptions import WorkflowTaskExecException
+from .BaseTestCase import BaseTestCase
+
+class ServiceTaskDelegate:
+    @staticmethod
+    def call_connector(name, params):
+        assertEqual(name, 'bamboohr/GetPayRate')
+        assertEqual(len(params), 3)
+        assertEqual(params['api_key']['value'], 'secret:BAMBOOHR_API_KEY')
+        assertEqual(params['employee_id']['value'], '109')
+        assertEqual(params['subdomain']['value'], 'ServiceTask')
+
+        sample_response = {
+            "amount": "65000.00",
+            "currency": "USD",
+            "id": "4",
+            "payRate": "65000.00 USD",
+        }
+
+        return json.dumps(sample_response)
+
+class ExampleCustomScriptEngine(PythonScriptEngine):
+    def available_service_task_external_methods(self):
+        return { 'ServiceTaskDelegate': ServiceTaskDelegate }
+
+class ServiceTaskVariableTest(BaseTestCase):
+
+    def setUp(self):
+        global assertEqual
+        assertEqual = self.assertEqual
+
+        spec, subprocesses = self.load_workflow_spec('service_task_variable.bpmn',
+                'Process_bd2e724555')
+        self.script_engine = ExampleCustomScriptEngine()
+        self.workflow = BpmnWorkflow(spec, subprocesses, script_engine=self.script_engine)
+
+    def testRunThroughHappy(self):
+        self.workflow.do_engine_steps()
+        self._assert_service_task()
+
+    def testRunThroughSaveRestore(self):
+        self.save_restore()
+        # Engine isn't preserved through save/restore, so we have to reset it.
+        self.workflow.script_engine = self.script_engine
+        self.workflow.do_engine_steps()
+        self.save_restore()
+        self._assert_service_task()
+
+    def _assert_service_tasks(self):
+        result = self.workflow.data['spiff__Activity_0xhr131_result']
+        self.assertEqual(len(result), 4)
+        self.assertEqual(result['amount'], '65000.00')
+        self.assertEqual(result['currency'], 'USD')
+        self.assertEqual(result['id'], '4')
+        self.assertEqual(result['payRate'], '65000.00 USD')
+
+def suite():
+    return unittest.TestLoader().loadTestsFromTestCase(ServiceTaskVariableTest)
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/spiff/ServiceTaskVariableTest.py
+++ b/tests/SpiffWorkflow/spiff/ServiceTaskVariableTest.py
@@ -19,7 +19,7 @@ class ServiceTaskDelegate:
         assertEqual(len(params), 3)
         assertEqual(params['api_key']['value'], 'secret:BAMBOOHR_API_KEY')
         assertEqual(params['employee_id']['value'], '109')
-        assertEqual(params['subdomain']['value'], 'ServiceTask')
+        assertEqual(params['subdomain']['value'], 'statusdemo')
 
         sample_response = {
             "amount": "65000.00",
@@ -57,7 +57,7 @@ class ServiceTaskVariableTest(BaseTestCase):
         self.save_restore()
         self._assert_service_task()
 
-    def _assert_service_tasks(self):
+    def _assert_service_task(self):
         result = self.workflow.data['spiff__Activity_0xhr131_result']
         self.assertEqual(len(result), 4)
         self.assertEqual(result['amount'], '65000.00')

--- a/tests/SpiffWorkflow/spiff/data/service_task_variable.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/service_task_variable.bpmn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Process_bd2e724555" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1tqygmt</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1tqygmt" sourceRef="StartEvent_1" targetRef="Activity_1shyq8p" />
+    <bpmn:endEvent id="Event_0i3s49y">
+      <bpmn:incoming>Flow_1h9lfz7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1h9lfz7" sourceRef="Activity_0xhr131" targetRef="Event_0i3s49y" />
+    <bpmn:serviceTask id="Activity_0xhr131" name="Service Task">
+      <bpmn:extensionElements>
+        <spiffworkflow:serviceTaskOperator id="bamboohr/GetPayRate">
+          <spiffworkflow:parameters>
+              <spiffworkflow:parameter id="api_key" type="str" value="secret:BAMBOOHR_API_KEY" />
+            <spiffworkflow:parameter id="employee_id" type="str" value="employeeID" />
+            <spiffworkflow:parameter id="subdomain" type="str" value="statusdemo" />
+          </spiffworkflow:parameters>
+        </spiffworkflow:serviceTaskOperator>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1boxww6</bpmn:incoming>
+      <bpmn:outgoing>Flow_1h9lfz7</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:dataObject id="DataObject_0zzgapz" />
+    <bpmn:sequenceFlow id="Flow_1boxww6" sourceRef="Activity_1shyq8p" targetRef="Activity_0xhr131" />
+    <bpmn:scriptTask id="Activity_1shyq8p" name="Set Employee ID">
+      <bpmn:incoming>Flow_1tqygmt</bpmn:incoming>
+      <bpmn:outgoing>Flow_1boxww6</bpmn:outgoing>
+      <bpmn:script>employeeID = "109"</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_bd2e724555">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0i3s49y_di" bpmnElement="Event_0i3s49y">
+        <dc:Bounds x="602" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_147g6ef_di" bpmnElement="Activity_0xhr131">
+        <dc:Bounds x="440" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jgpgla_di" bpmnElement="Activity_1shyq8p">
+        <dc:Bounds x="280" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tqygmt_di" bpmnElement="Flow_1tqygmt">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="280" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1h9lfz7_di" bpmnElement="Flow_1h9lfz7">
+        <di:waypoint x="540" y="177" />
+        <di:waypoint x="602" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1boxww6_di" bpmnElement="Flow_1boxww6">
+        <di:waypoint x="380" y="177" />
+        <di:waypoint x="440" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Fixes a bug reported by natalia/popster where a variable from a script task was not being evaluated properly for use in the service task. I had a bad feeling about that `repr` that was on main. This fixes the issue and uses the bpmn diagram from staging as the test case.