### PR TITLE
Remove bpmn imports from task.py

### DIFF
--- a/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
+++ b/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
@@ -97,6 +97,9 @@ class SubWorkflowTask(SubWorkflow, BpmnSpecMixin):
     def deserialize(self, serializer, wf_spec, s_state):
         return serializer.deserialize_subworkflow_task(wf_spec, s_state, SubWorkflowTask)
 
+    def task_will_set_children_future(self, my_task):
+        my_task.workflow.delete_subprocess(my_task)
+
 
 class CallActivity(SubWorkflowTask):
 

--- a/SpiffWorkflow/bpmn/specs/UnstructuredJoin.py
+++ b/SpiffWorkflow/bpmn/specs/UnstructuredJoin.py
@@ -158,6 +158,9 @@ class UnstructuredJoin(Join, BpmnSpecMixin):
 
         super(UnstructuredJoin, self)._update_hook(my_task)
 
+    def task_should_set_children_future(self, my_task):
+        return True
+
     def task_will_set_children_future(self, my_task):
         # go find all of the gateways with the same name as this one,
         # drop children and set state to WAITING

--- a/SpiffWorkflow/bpmn/specs/UnstructuredJoin.py
+++ b/SpiffWorkflow/bpmn/specs/UnstructuredJoin.py
@@ -157,3 +157,10 @@ class UnstructuredJoin(Join, BpmnSpecMixin):
             return
 
         super(UnstructuredJoin, self)._update_hook(my_task)
+
+    def task_will_set_children_future(self, my_task):
+        # go find all of the gateways with the same name as this one,
+        # drop children and set state to WAITING
+        for t in list(my_task.workflow.task_tree):
+            if t.task_spec.name == self.name and t.state == TaskState.COMPLETED:
+                t._set_state(TaskState.WAITING)

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -491,3 +491,11 @@ class TaskSpec(object):
         out.locks = s_state.get('locks')
         out.lookahead = s_state.get('lookahead')
         return out
+
+    def task_will_set_children_future(self, my_task):
+        """
+        Called right before a task runs the logic for set_children_future.
+
+        Subclasses can override to perform work during that stage of execution.
+        """
+        pass

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -492,9 +492,19 @@ class TaskSpec(object):
         out.lookahead = s_state.get('lookahead')
         return out
 
+    def task_should_set_children_future(self, my_task):
+        """
+        Hook to allow a task_spec to indicate if a task should
+        set_future_children.
+
+        Subclasses can override to influence this decision.
+        """
+        return my_task.state == TaskState.COMPLETED or my_task.state == TaskState.READY
+
     def task_will_set_children_future(self, my_task):
         """
-        Called right before a task runs the logic for set_children_future.
+        Called right before a task runs the logic for set_children_future if
+        task_should_set_children_future returns True.
 
         Subclasses can override to perform work during that stage of execution.
         """

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -366,21 +366,13 @@ class Task(object,  metaclass=DeprecatedMetaTask):
         'READY'
         """
         from .bpmn.specs.UnstructuredJoin import UnstructuredJoin
-        from .bpmn.specs.SubWorkflowTask import SubWorkflowTask
 
         if (self.state != TaskState.COMPLETED and self.state != TaskState.READY) and \
                 not (isinstance(self.task_spec, UnstructuredJoin)):
             return
 
-        if isinstance(self.task_spec,SubWorkflowTask):
-            self.workflow.delete_subprocess(self)
+        self.task_spec.task_will_set_children_future(self)
 
-        if isinstance(self.task_spec, UnstructuredJoin):
-            # go find all of the gateways with the same name as this one,
-            # drop children and set state to WAITING
-            for t in list(self.workflow.task_tree):
-                if t.task_spec.name == self.task_spec.name and t.state == TaskState.COMPLETED:
-                    t._set_state(TaskState.WAITING)
         # now we set this one to execute
 
         self._set_state(TaskState.MAYBE)

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -365,10 +365,8 @@ class Task(object,  metaclass=DeprecatedMetaTask):
         the inputs - otherwise our child process never gets marked as
         'READY'
         """
-        from .bpmn.specs.UnstructuredJoin import UnstructuredJoin
 
-        if (self.state != TaskState.COMPLETED and self.state != TaskState.READY) and \
-                not (isinstance(self.task_spec, UnstructuredJoin)):
+        if not self.task_spec.task_should_set_children_future(self):
             return
 
         self.task_spec.task_will_set_children_future(self)

--- a/tests/SpiffWorkflow/spiff/CorrelationTest.py
+++ b/tests/SpiffWorkflow/spiff/CorrelationTest.py
@@ -1,3 +1,10 @@
+import os
+import sys
+import unittest
+
+dirname = os.path.dirname(__file__)
+sys.path.insert(0, os.path.join(dirname, '..', '..', '..'))
+
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 
 from .BaseTestCase import BaseTestCase


### PR DESCRIPTION
task.py's `set_children_future` method imported two specs from bpmn to perform logic to see if the action should happen and perform some spec specific handling before the core logic ran. To remove the bpmn imports from core, the `TaskSpec` base class now has `task_should_set_children_future` and `task_will_set_children_future` methods that the specs can override. `SubWorkflowTask` and `UnstructuredJoin` override as appropriate.