### PR TITLE
Follow up on service task bug fix, quote string literals

### DIFF
--- a/SpiffWorkflow/spiff/specs/service_task.py
+++ b/SpiffWorkflow/spiff/specs/service_task.py
@@ -24,12 +24,7 @@ class ServiceTask(SpiffBpmnTask, ServiceTask):
 
     def _execute(self, task):
         def evaluate(param):
-            try:
-                param['value'] = task.workflow.script_engine.evaluate(task,
-                        param['value'])
-            except:
-                pass
-
+            param['value'] = task.workflow.script_engine.evaluate(task, param['value'])
             return param
 
         operation_params_var_name = 'spiff__operation_params'

--- a/tests/SpiffWorkflow/spiff/data/service_task.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/service_task.bpmn
@@ -9,9 +9,9 @@
       <bpmn:extensionElements>
         <spiffworkflow:serviceTaskOperator id="bamboohr/GetPayRate">
           <spiffworkflow:parameters>
-            <spiffworkflow:parameter id="api_key" type="string" value="secret:BAMBOOHR_API_KEY" />
+            <spiffworkflow:parameter id="api_key" type="string" value="'secret:BAMBOOHR_API_KEY'" />
             <spiffworkflow:parameter id="employee_id" type="string" value="4" />
-            <spiffworkflow:parameter id="subdomain" type="string" value="ServiceTask" />
+            <spiffworkflow:parameter id="subdomain" type="string" value="'ServiceTask'" />
           </spiffworkflow:parameters>
         </spiffworkflow:serviceTaskOperator>
       </bpmn:extensionElements>

--- a/tests/SpiffWorkflow/spiff/data/service_task_variable.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/service_task_variable.bpmn
@@ -13,9 +13,9 @@
       <bpmn:extensionElements>
         <spiffworkflow:serviceTaskOperator id="bamboohr/GetPayRate">
           <spiffworkflow:parameters>
-              <spiffworkflow:parameter id="api_key" type="str" value="secret:BAMBOOHR_API_KEY" />
+              <spiffworkflow:parameter id="api_key" type="str" value="'secret:BAMBOOHR_API_KEY'" />
             <spiffworkflow:parameter id="employee_id" type="str" value="employeeID" />
-            <spiffworkflow:parameter id="subdomain" type="str" value="statusdemo" />
+            <spiffworkflow:parameter id="subdomain" type="str" value="'statusdemo'" />
           </spiffworkflow:parameters>
         </spiffworkflow:serviceTaskOperator>
       </bpmn:extensionElements>


### PR DESCRIPTION
Implements changes requested in #233 - don't silently ignore scripting errors when resolving parameters for service tasks. This in turn will require string literals to be quoted in the bpmn files.