### PR TITLE
copy data objects before prescript execution

### DIFF
--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -25,13 +25,12 @@ from ..specs.ScriptTask import ScriptTask
 from ..specs.UserTask import UserTask
 from ..specs.events import _BoundaryEventParent, CancelEventDefinition
 from ..specs.MultiInstanceTask import getDynamicMIClass
-from ..specs.SubWorkflowTask import CallActivity, TransactionSubprocess
+from ..specs.SubWorkflowTask import CallActivity, TransactionSubprocess, SubWorkflowTask
 from ..specs.ExclusiveGateway import ExclusiveGateway
 from ...dmn.specs.BusinessRuleTask import BusinessRuleTask
 from ...operators import Attrib, PathAttrib
 from .util import one, first
 from .node_parser import NodeParser
-from ...specs.SubWorkflow import SubWorkflow
 
 STANDARDLOOPCOUNT = '25'
 
@@ -68,7 +67,7 @@ class TaskParser(NodeParser):
         # the current parser achitecture).  We should also consider separate classes for loop vs
         # multiinstance because having all these optional attributes is a nightmare
 
-        if not isinstance(self.task, (NoneTask,UserTask,BusinessRuleTask,ScriptTask,CallActivity,SubWorkflow)):
+        if not isinstance(self.task, (NoneTask, UserTask, BusinessRuleTask, ScriptTask, CallActivity, SubWorkflowTask)):
             raise ValidationException(
                 f'Unsupported MultiInstance Task: {self.task.__class__}',
                 node=self.node,

--- a/SpiffWorkflow/spiff/specs/spiff_task.py
+++ b/SpiffWorkflow/spiff/specs/spiff_task.py
@@ -34,9 +34,9 @@ class SpiffBpmnTask(BpmnSpecMixin):
             raise exc
 
     def _on_ready_hook(self, my_task):
+        super()._on_ready_hook(my_task)
         if self.prescript is not None:
             self.execute_script(my_task, self.prescript)
-        super()._on_ready_hook(my_task)
 
     def _on_complete_hook(self, my_task):
         if self.postscript is not None:

--- a/SpiffWorkflow/spiff/specs/subworkflow_task.py
+++ b/SpiffWorkflow/spiff/specs/subworkflow_task.py
@@ -1,7 +1,7 @@
 from SpiffWorkflow.bpmn.specs.SubWorkflowTask import SubWorkflowTask, TransactionSubprocess, CallActivity
 from SpiffWorkflow.spiff.specs.spiff_task import SpiffBpmnTask
 
-class SubWorkflowTask(SpiffBpmnTask, SubWorkflowTask):
+class SubWorkflowTask(SubWorkflowTask, SpiffBpmnTask):
 
     def __init__(self, wf_spec, name, subworkflow_spec, transaction=False, **kwargs):
 
@@ -13,11 +13,19 @@ class SubWorkflowTask(SpiffBpmnTask, SubWorkflowTask):
         self.in_assign = []
         self.out_assign = []
 
+    def _on_ready_hook(self, my_task):
+        SpiffBpmnTask._on_ready_hook(self, my_task)
+        self.start_workflow(my_task)
+
+    def _on_complete_hook(self, my_task):
+        SpiffBpmnTask._on_complete_hook(self, my_task)
+
     @property
     def spec_type(self):
         return 'Subprocess'
 
-class TransactionSubprocess(SpiffBpmnTask, TransactionSubprocess):
+
+class TransactionSubprocess(SubWorkflowTask, TransactionSubprocess):
 
     def __init__(self, wf_spec, name, subworkflow_spec, transaction=True, **kwargs):
 
@@ -31,7 +39,8 @@ class TransactionSubprocess(SpiffBpmnTask, TransactionSubprocess):
     def spec_type(self):
         return 'Transactional Subprocess'
 
-class CallActivity(SpiffBpmnTask, CallActivity):
+
+class CallActivity(SubWorkflowTask, CallActivity):
 
     def __init__(self, wf_spec, name, subworkflow_spec, **kwargs):
         

--- a/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
+++ b/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
@@ -17,6 +17,19 @@ class PrescriptPostsciptTest(BaseTestCase):
     def testCallActivitySaveRestore(self):
         self.call_activity_test(True)
 
+    def testDataObject(self):
+        
+        spec, subprocesses = self.load_workflow_spec('prescript_postscript_data_object.bpmn', 'Process_1')
+        self.workflow = BpmnWorkflow(spec, subprocesses)
+        # Set a on the workflow and b in the first task.
+        self.workflow.data['a'] = 1
+        self.set_process_data({'b': 2})
+        ready_tasks = self.workflow.get_tasks(TaskState.READY)
+        # This execute the same script as task_test
+        ready_tasks[0].complete()
+        # a should be removed, b should be unchanged, and c and z should be present (but not x & y)
+        self.assertDictEqual({'b': 2, 'c': 12, 'z': 6}, ready_tasks[0].data)
+
     def task_test(self, save_restore=False):
 
         spec, subprocesses = self.load_workflow_spec('prescript_postscript.bpmn', 'Process_1')

--- a/tests/SpiffWorkflow/spiff/data/prescript_postscript_data_object.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/prescript_postscript_data_object.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19o7vxg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:ioSpecification />
+    <bpmn:startEvent id="Event_1ftsuzw">
+      <bpmn:outgoing>Flow_1hjrex4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_1iqs4li" name="Any Task">
+      <bpmn:extensionElements>
+        <spiffworkflow:preScript>x = a * 2
+y = b * 2
+z = x + y</spiffworkflow:preScript>
+        <spiffworkflow:postScript>c = z * 2
+del x
+del y</spiffworkflow:postScript>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1hjrex4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xndbxy</bpmn:outgoing>
+      <bpmn:property id="Property_1bj3qrk" name="__targetRef_placeholder" />
+      <bpmn:dataInputAssociation id="DataInputAssociation_0qit1wt">
+        <bpmn:sourceRef>DataObjectReference_15lldo2</bpmn:sourceRef>
+        <bpmn:targetRef>Property_1bj3qrk</bpmn:targetRef>
+      </bpmn:dataInputAssociation>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1hjrex4" sourceRef="Event_1ftsuzw" targetRef="Activity_1iqs4li" />
+    <bpmn:endEvent id="Event_0c80924">
+      <bpmn:incoming>Flow_1xndbxy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1xndbxy" sourceRef="Activity_1iqs4li" targetRef="Event_0c80924" />
+    <bpmn:dataObjectReference id="DataObjectReference_15lldo2" name="a" dataObjectRef="a" />
+    <bpmn:dataObject id="a" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_1xndbxy_di" bpmnElement="Flow_1xndbxy">
+        <di:waypoint x="380" y="220" />
+        <di:waypoint x="432" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hjrex4_di" bpmnElement="Flow_1hjrex4">
+        <di:waypoint x="228" y="220" />
+        <di:waypoint x="280" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1ftsuzw_di" bpmnElement="Event_1ftsuzw">
+        <dc:Bounds x="192" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1iqs4li_di" bpmnElement="Activity_1iqs4li">
+        <dc:Bounds x="280" y="180" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c80924_di" bpmnElement="Event_0c80924">
+        <dc:Bounds x="432" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="DataObjectReference_15lldo2_di" bpmnElement="DataObjectReference_15lldo2">
+        <dc:Bounds x="312" y="75" width="36" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="328" y="38" width="7" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="DataInputAssociation_0qit1wt_di" bpmnElement="DataInputAssociation_0qit1wt">
+        <di:waypoint x="330" y="125" />
+        <di:waypoint x="330" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
This reworks subworkflow tasks so that when data objects are copied before a spiff prescript is executed, data input/output mappings in subprocesses still works as expected (ie, that you can use pre/post scripts to rename variables)

It also completely removes the base SubWorkflow spec from the SubWorkflow task (this is unrelated, but we no longer use that functionality so this is just an additional bit of cleanup).