### PR TITLE
do not install importlib-metadata if greater than python 3.7 w/ burnettk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='SpiffWorkflow',
       packages=find_packages(exclude=['tests', 'tests.*']),
       install_requires=['configparser', 'lxml', 'celery', 'dateparser', 'pytz',
           # required for python 3.7 - https://stackoverflow.com/a/73932581
-          'importlib-metadata<5.0'],
+          'importlib-metadata<5.0; python_version <= "3.7"'],
       keywords='spiff workflow bpmn engine',
       url='https://github.com/sartography/SpiffWorkflow',
       classifiers=[


### PR DESCRIPTION
importlib-metadata breaks python 3.10 at least so avoid installing it if we don't need to.