### PR TITLE
Parser Information about messages, correlation keys, and the presence of lanes

### DIFF
--- a/SpiffWorkflow/bpmn/parser/ProcessParser.py
+++ b/SpiffWorkflow/bpmn/parser/ProcessParser.py
@@ -52,6 +52,32 @@ class ProcessParser(NodeParser):
         """
         return self.node.get('name', default=self.get_id())
 
+    def has_lanes(self) -> bool:
+        """Returns true if this process has one or more named lanes """
+        elements = self.xpath("//bpmn:lane")
+        for el in elements:
+            if el.get("name"):
+                return True
+        return False
+
+    def start_messages(self):
+        """ This returns a list of messages that would cause this
+            process to start. """
+        messages = []
+        message_event_definitions = self.xpath(
+            "//bpmn:startEvent/bpmn:messageEventDefinition")
+        for message_event_definition in message_event_definitions:
+            message_model_identifier = message_event_definition.attrib.get(
+                "messageRef"
+            )
+            if message_model_identifier is None:
+                raise ValidationException(
+                    "Could not find messageRef from message event definition: {message_event_definition}"
+                )
+            messages.append(message_model_identifier)
+
+        return messages
+
     def parse_node(self, node):
         """
         Parses the specified child task node, and returns the task spec. This

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
@@ -19,11 +19,15 @@ class BpmnWorkflowTestCase(unittest.TestCase):
 
     serializer = BpmnWorkflowSerializer(wf_spec_converter)
 
-    def load_workflow_spec(self, filename, process_name, validate=True):
+    def get_parser(self, filename, validate=True):
         f = os.path.join(os.path.dirname(__file__), 'data', filename)
         validator = BpmnValidator() if validate else None
         parser = TestBpmnParser(validator=validator)
         parser.add_bpmn_files_by_glob(f)
+        return parser
+
+    def load_workflow_spec(self, filename, process_name, validate=True):
+        parser = self.get_parser(filename, validate)
         top_level_spec = parser.get_spec(process_name)
         subprocesses = parser.get_subprocess_specs(process_name)
         return top_level_spec, subprocesses

--- a/tests/SpiffWorkflow/bpmn/CollaborationTest.py
+++ b/tests/SpiffWorkflow/bpmn/CollaborationTest.py
@@ -6,10 +6,22 @@ from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 
 class CollaborationTest(BpmnWorkflowTestCase):
 
+    def testParserProvidesInfoOnMessagesAndCorrelations(self):
+        parser = self.get_parser('collaboration.bpmn')
+        self.assertEqual(list(parser.messages.keys()), ['love_letter', 'love_letter_response'])
+        self.assertEqual(parser.correlations,
+                         {'lover_name': {'name': "Lover's Name",
+                                         'retrieval_expressions': [
+                                             {'expression': 'lover_name',
+                                              'messageRef': 'love_letter'},
+                                             {'expression': 'from_name',
+                                              'messageRef': 'love_letter_response'}]}}
+                         )
+
     def testCollaboration(self):
 
         spec, subprocesses = self.load_collaboration('collaboration.bpmn', 'my_collaboration')
-        
+
         # Only executable processes should be started
         self.assertIn('process_buddy', subprocesses)
         self.assertNotIn('random_person_process', subprocesses)

--- a/tests/SpiffWorkflow/bpmn/SwimLaneTest.py
+++ b/tests/SpiffWorkflow/bpmn/SwimLaneTest.py
@@ -19,6 +19,12 @@ class SwimLaneTest(BpmnWorkflowTestCase):
         spec, subprocesses = self.load_workflow_spec('lanes.bpmn','lanes')
         self.workflow = BpmnWorkflow(spec, subprocesses)
 
+    def testBpmnParserKnowsLanesExist(self):
+        parser = self.get_parser('lanes.bpmn')
+        self.assertTrue(parser.get_process_parser('lanes').has_lanes())
+        parser = self.get_parser('random_fact.bpmn')
+        self.assertFalse(parser.get_process_parser('random_fact').has_lanes())
+
     def testRunThroughHappy(self):
 
         self.workflow.do_engine_steps()

--- a/tests/SpiffWorkflow/camunda/BaseTestCase.py
+++ b/tests/SpiffWorkflow/camunda/BaseTestCase.py
@@ -23,13 +23,17 @@ class BaseTestCase(BpmnWorkflowTestCase):
 
     serializer = BpmnWorkflowSerializer(wf_spec_converter)
 
-    def load_workflow_spec(self, filename, process_name, dmn_filename=None):
-        bpmn = os.path.join(os.path.dirname(__file__), 'data', filename)
+    def get_parser(self, filename, dmn_filename=None):
+        f = os.path.join(os.path.dirname(__file__), 'data', filename)
         parser = CamundaParser()
-        parser.add_bpmn_files_by_glob(bpmn)
+        parser.add_bpmn_files_by_glob(f)
         if dmn_filename is not None:
             dmn = os.path.join(os.path.dirname(__file__), 'data', 'dmn', dmn_filename)
             parser.add_dmn_files_by_glob(dmn)
+        return parser
+
+    def load_workflow_spec(self, filename, process_name, dmn_filename=None):
+        parser = self.get_parser(filename, dmn_filename)
         top_level_spec = parser.get_spec(process_name)
         subprocesses = parser.get_subprocess_specs(process_name)
         return top_level_spec, subprocesses

--- a/tests/SpiffWorkflow/camunda/StartMessageEventTest.py
+++ b/tests/SpiffWorkflow/camunda/StartMessageEventTest.py
@@ -14,6 +14,16 @@ class StartMessageTest(BaseTestCase):
         self.spec, self.subprocesses = self.load_workflow_spec('message_test.bpmn', 'ThrowCatch')
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses)
 
+    def testParserCanReturnStartMessages(self):
+        parser = self.get_parser('message_test.bpmn')
+        self.assertEqual(
+            parser.process_parsers['ThrowCatch'].start_messages(), ['Message_1rkbi27'])
+
+        parser = self.get_parser('random_fact.bpmn')
+        self.assertEqual(
+            parser.process_parsers['random_fact'].start_messages(), [])
+
+
     def testRunThroughHappy(self):
         self.actual_test(save_restore=False)
 


### PR DESCRIPTION
We are jumping through a lot of complex xml parsing in SpiffWorkflow-Backend because we need to know some basic information about a BPMN process at the moment it is saved.  Rather than do that work in the backend, it seems better to have SpiffWorkflow Parsers provide a bit of critical information before the actual parsing occurs (but after the files are added).  Makes the following information available:

  * What messages are defined at the top level of a BPMN Diagram
  * What correlation keys are defined at teh top level of a BPMN Diagram
  * If a message start event exists on a process, and what message it listens for
  * Whether a process contains lanes