### PR TITLE
Feature/multiple event definition

### DIFF
--- a/SpiffWorkflow/bpmn/parser/BpmnParser.py
+++ b/SpiffWorkflow/bpmn/parser/BpmnParser.py
@@ -29,7 +29,7 @@ from .ValidationException import ValidationException
 from ..specs.BpmnProcessSpec import BpmnProcessSpec
 from ..specs.events.EndEvent import EndEvent
 from ..specs.events.StartEvent import StartEvent
-from ..specs.events.IntermediateEvent import BoundaryEvent, IntermediateCatchEvent, IntermediateThrowEvent
+from ..specs.events.IntermediateEvent import BoundaryEvent, IntermediateCatchEvent, IntermediateThrowEvent, EventBasedGateway
 from ..specs.events.IntermediateEvent import SendTask, ReceiveTask
 from ..specs.SubWorkflowTask import CallActivity, SubWorkflowTask, TransactionSubprocess
 from ..specs.ExclusiveGateway import ExclusiveGateway
@@ -47,7 +47,7 @@ from .task_parsers import (UserTaskParser, NoneTaskParser, ManualTaskParser,
                            ExclusiveGatewayParser, ParallelGatewayParser, InclusiveGatewayParser,
                            CallActivityParser, ScriptTaskParser, SubWorkflowParser,
                            ServiceTaskParser)
-from .event_parsers import (StartEventParser, EndEventParser, BoundaryEventParser,
+from .event_parsers import (EventBasedGatewayParser, StartEventParser, EndEventParser, BoundaryEventParser,
                            IntermediateCatchEventParser, IntermediateThrowEventParser,
                            SendTaskParser, ReceiveTaskParser)
 
@@ -104,6 +104,7 @@ class BpmnParser(object):
         full_tag('boundaryEvent'): (BoundaryEventParser, BoundaryEvent),
         full_tag('receiveTask'): (ReceiveTaskParser, ReceiveTask),
         full_tag('sendTask'): (SendTaskParser, SendTask),
+        full_tag('eventBasedGateway'): (EventBasedGatewayParser, EventBasedGateway),
     }
 
     OVERRIDE_PARSER_CLASSES = {}

--- a/SpiffWorkflow/bpmn/parser/event_parsers.py
+++ b/SpiffWorkflow/bpmn/parser/event_parsers.py
@@ -109,7 +109,7 @@ class EventDefinitionParser(TaskParser):
                 correlations.append(CorrelationProperty(key, expression, used_by))
         return correlations
 
-    def _create_task(self, event_definition, cancel_activity=None):
+    def _create_task(self, event_definition, cancel_activity=None, parallel=None):
 
         if isinstance(event_definition, MessageEventDefinition):
             for prop in event_definition.correlation_properties:
@@ -126,9 +126,11 @@ class EventDefinitionParser(TaskParser):
         }
         if cancel_activity is not None:
             kwargs['cancel_activity'] = cancel_activity
+        if parallel is not None:
+            kwargs['parallel'] = parallel
         return self.spec_class(self.spec, self.get_task_spec_name(), event_definition, **kwargs)
 
-    def get_event_definition(self, xpaths, parallel=False):
+    def get_event_definition(self, xpaths):
         """Returns all event definitions it can find in given list of xpaths"""
 
         event_definitions = []
@@ -148,6 +150,8 @@ class EventDefinitionParser(TaskParser):
                     event_definitions.append(self.parse_escalation_event(event))
                 elif path == TERMINATION_EVENT_XPATH:
                     event_definitions.append(self.parse_terminate_event())
+
+        parallel = self.node.get('parallelMultiple') == 'true'
 
         if len(event_definitions) == 0:
             return NoneEventDefinition()

--- a/SpiffWorkflow/bpmn/parser/event_parsers.py
+++ b/SpiffWorkflow/bpmn/parser/event_parsers.py
@@ -237,3 +237,21 @@ class BoundaryEventParser(EventDefinitionParser):
             raise NotImplementedError('Unsupported Catch Event: %r', etree.tostring(self.node))
         return self._create_task(event_definition, cancel_activity)
 
+
+class EventBasedGatewayParser(EventDefinitionParser):
+
+    def create_task(self):
+        return self._create_task(MultipleEventDefinition())
+
+    def handles_multiple_outgoing(self):
+        return True
+
+    def connect_outgoing(self, outgoing_task, outgoing_task_node, sequence_flow_node, is_default):
+        self.task.event_definition.event_definitions.append(outgoing_task.event_definition)
+        self.task.connect_outgoing(
+            outgoing_task, 
+            sequence_flow_node.get('id'),
+            sequence_flow_node.get('name', None),
+            self.parse_documentation(sequence_flow_node)
+        )
+    

--- a/SpiffWorkflow/bpmn/serializer/bpmn_converters.py
+++ b/SpiffWorkflow/bpmn/serializer/bpmn_converters.py
@@ -7,7 +7,7 @@ from SpiffWorkflow.bpmn.specs.BpmnProcessSpec import BpmnDataSpecification
 
 from .dictionary import DictionaryConverter
 
-from ..specs.events.event_definitions import SignalEventDefinition, MessageEventDefinition, NoneEventDefinition
+from ..specs.events.event_definitions import MultipleEventDefinition, SignalEventDefinition, MessageEventDefinition, NoneEventDefinition
 from ..specs.events.event_definitions import TimerEventDefinition, CycleTimerEventDefinition, TerminateEventDefinition
 from ..specs.events.event_definitions import ErrorEventDefinition, EscalationEventDefinition, CancelEventDefinition
 from ..specs.events.event_definitions import CorrelationProperty, NamedEventDefinition
@@ -91,7 +91,7 @@ class BpmnTaskSpecConverter(DictionaryConverter):
 
         event_definitions = [ NoneEventDefinition, CancelEventDefinition, TerminateEventDefinition,
             SignalEventDefinition, MessageEventDefinition, ErrorEventDefinition, EscalationEventDefinition,
-            TimerEventDefinition, CycleTimerEventDefinition ]
+            TimerEventDefinition, CycleTimerEventDefinition , MultipleEventDefinition]
 
         for event_definition in event_definitions:
             self.register(
@@ -257,6 +257,9 @@ class BpmnTaskSpecConverter(DictionaryConverter):
             dct['error_code'] = event_definition.error_code
         if isinstance(event_definition, EscalationEventDefinition):
             dct['escalation_code'] = event_definition.escalation_code
+        if isinstance(event_definition, MultipleEventDefinition):
+            dct['event_definitions'] = [self.convert(e) for e in event_definition.event_definitions]
+            dct['parallel'] = event_definition.parallel
 
         return dct
 
@@ -273,6 +276,8 @@ class BpmnTaskSpecConverter(DictionaryConverter):
         internal, external = dct.pop('internal'), dct.pop('external')
         if 'correlation_properties' in dct:
             dct['correlation_properties'] = [CorrelationProperty(**prop) for prop in dct['correlation_properties']]
+        if 'event_definitions' in dct:
+            dct['event_definitions'] = [self.restore(d) for d in dct['event_definitions']]
         event_definition = definition_class(**dct)
         event_definition.internal = internal
         event_definition.external = external

--- a/SpiffWorkflow/bpmn/serializer/task_spec_converters.py
+++ b/SpiffWorkflow/bpmn/serializer/task_spec_converters.py
@@ -21,7 +21,7 @@ from ..specs.ParallelGateway import ParallelGateway
 
 from ..specs.events.StartEvent import StartEvent
 from ..specs.events.EndEvent import EndEvent
-from ..specs.events.IntermediateEvent import BoundaryEvent, IntermediateCatchEvent, IntermediateThrowEvent
+from ..specs.events.IntermediateEvent import BoundaryEvent, EventBasedGateway, IntermediateCatchEvent, IntermediateThrowEvent
 from ..specs.events.IntermediateEvent import _BoundaryEventParent, SendTask, ReceiveTask
 
 from ..workflow import BpmnWorkflow
@@ -52,6 +52,7 @@ class StartTaskConverter(BpmnTaskSpecConverter):
     def from_dict(self, dct):
         return self.task_spec_from_dict(dct)
 
+
 class LoopResetTaskConverter(BpmnTaskSpecConverter):
 
     def __init__(self, data_converter=None, typename=None):
@@ -69,6 +70,7 @@ class LoopResetTaskConverter(BpmnTaskSpecConverter):
         spec = self.task_spec_from_dict(dct)
         spec.destination_id = UUID(spec.destination_id)
         return spec
+
 
 class EndJoinConverter(BpmnTaskSpecConverter):
 
@@ -310,3 +312,9 @@ class BoundaryEventParentConverter(BpmnTaskSpecConverter):
 
     def from_dict(self, dct):
         return self.task_spec_from_dict(dct)
+
+
+class EventBasedGatewayConverter(EventConverter):
+
+    def __init__(self, data_converter=None, typename=None):
+        super().__init__(EventBasedGateway, data_converter, typename)

--- a/SpiffWorkflow/bpmn/serializer/workflow.py
+++ b/SpiffWorkflow/bpmn/serializer/workflow.py
@@ -17,7 +17,7 @@ from .task_spec_converters import SimpleTaskConverter, StartTaskConverter, EndJo
 from .task_spec_converters import NoneTaskConverter, UserTaskConverter, ManualTaskConverter, ScriptTaskConverter
 from .task_spec_converters import CallActivityTaskConverter, TransactionSubprocessTaskConverter
 from .task_spec_converters import StartEventConverter, EndEventConverter
-from .task_spec_converters import IntermediateCatchEventConverter, IntermediateThrowEventConverter
+from .task_spec_converters import IntermediateCatchEventConverter, IntermediateThrowEventConverter, EventBasedGatewayConverter
 from .task_spec_converters import SendTaskConverter, ReceiveTaskConverter
 from .task_spec_converters import BoundaryEventConverter, BoundaryEventParentConverter
 from .task_spec_converters import ParallelGatewayConverter, ExclusiveGatewayConverter, InclusiveGatewayConverter
@@ -27,7 +27,7 @@ DEFAULT_TASK_SPEC_CONVERTER_CLASSES = [
     NoneTaskConverter, UserTaskConverter, ManualTaskConverter, ScriptTaskConverter,
     CallActivityTaskConverter, TransactionSubprocessTaskConverter,
     StartEventConverter, EndEventConverter, SendTaskConverter, ReceiveTaskConverter,
-    IntermediateCatchEventConverter, IntermediateThrowEventConverter,
+    IntermediateCatchEventConverter, IntermediateThrowEventConverter, EventBasedGatewayConverter,
     BoundaryEventConverter, BoundaryEventParentConverter,
     ParallelGatewayConverter, ExclusiveGatewayConverter, InclusiveGatewayConverter
 ]

--- a/SpiffWorkflow/bpmn/specs/events/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_definitions.py
@@ -408,6 +408,10 @@ class MultipleEventDefinition(EventDefinition):
         self.event_definitions = event_definitions or []
         self.parallel = parallel
 
+    @property
+    def event_type(self):
+        return 'Multiple'
+
     def catch(self, my_task, event_definition=None):
         if self.parallel:
             # Parallel multiple need to match all events
@@ -430,3 +434,12 @@ class MultipleEventDefinition(EventDefinition):
                 return True        
         else:
             return False
+    
+    def throw(self, my_task):
+        # Mutiple events throw all associated events when they fire
+        for event_definition in self.event_definitions:
+            self._throw(
+                event=event_definition,
+                workflow=my_task.workflow,
+                outer_workflow=my_task.workflow.outer_workflow
+            )

--- a/SpiffWorkflow/bpmn/specs/events/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_definitions.py
@@ -19,7 +19,6 @@
 
 import datetime
 from copy import deepcopy
-from tkinter import W
 
 
 class EventDefinition(object):
@@ -434,9 +433,8 @@ class MultipleEventDefinition(EventDefinition):
         # This event can catch any of the events associated with it
         for event in self.event_definitions:
             if event == other:
-                return True        
-        else:
-            return False
+                return True
+        return False
     
     def throw(self, my_task):
         # Mutiple events throw all associated events when they fire

--- a/SpiffWorkflow/bpmn/specs/events/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_definitions.py
@@ -19,6 +19,7 @@
 
 import datetime
 from copy import deepcopy
+from tkinter import W
 
 
 class EventDefinition(object):
@@ -92,6 +93,7 @@ class EventDefinition(object):
         obj.internal, obj.external = internal, external
         return obj
 
+
 class NamedEventDefinition(EventDefinition):
     """
     Extend the base event class to provide a name for the event.  Most throw/catch events
@@ -114,7 +116,6 @@ class NamedEventDefinition(EventDefinition):
         retdict = super(NamedEventDefinition, self).serialize()
         retdict['name'] = self.name
         return retdict
-
 
 class CancelEventDefinition(EventDefinition):
     """
@@ -398,3 +399,19 @@ class CycleTimerEventDefinition(EventDefinition):
         retdict['label'] = self.label
         retdict['cycle_definition'] = self.cycle_definition
         return retdict
+
+
+class MultipleEventDefinition(EventDefinition):
+
+    def __init__(self, event_definitions=None, parallel=False):
+        super().__init__()
+        self.event_definitions = event_definitions or []
+        self.parallel = False
+
+    def __eq__(self, other):
+        # This event can catch any of the events associated with it
+        for event in self.event_definitions:
+            if event == other:
+                return True        
+        else:
+            return False

--- a/tests/SpiffWorkflow/bpmn/data/event-gateway.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/event-gateway.bpmn
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1jaorpt" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_0pvx19v" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0w4b5t2</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0w4b5t2" sourceRef="StartEvent_1" targetRef="Gateway_1434v9l" />
+    <bpmn:eventBasedGateway id="Gateway_1434v9l">
+      <bpmn:incoming>Flow_0w4b5t2</bpmn:incoming>
+      <bpmn:outgoing>Flow_0gge7fn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0px7ksu</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1rfbrlf</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="message_1_event">
+      <bpmn:incoming>Flow_0gge7fn</bpmn:incoming>
+      <bpmn:outgoing>Flow_1g4g85l</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_158nhox" messageRef="Message_0lyfmat" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0gge7fn" sourceRef="Gateway_1434v9l" targetRef="message_1_event" />
+    <bpmn:intermediateCatchEvent id="message_2_event">
+      <bpmn:incoming>Flow_0px7ksu</bpmn:incoming>
+      <bpmn:outgoing>Flow_18v90rx</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1w1pnze" messageRef="Message_1ntpwce" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0px7ksu" sourceRef="Gateway_1434v9l" targetRef="message_2_event" />
+    <bpmn:intermediateCatchEvent id="timer_event">
+      <bpmn:incoming>Flow_1rfbrlf</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mppjk9</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0reo0gl">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">timedelta(seconds=1)</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1rfbrlf" sourceRef="Gateway_1434v9l" targetRef="timer_event" />
+    <bpmn:endEvent id="timer">
+      <bpmn:incoming>Flow_0mppjk9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0mppjk9" sourceRef="timer_event" targetRef="timer" />
+    <bpmn:endEvent id="message_1_end">
+      <bpmn:incoming>Flow_1g4g85l</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1g4g85l" sourceRef="message_1_event" targetRef="message_1_end" />
+    <bpmn:endEvent id="message_2_end">
+      <bpmn:incoming>Flow_18v90rx</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_18v90rx" sourceRef="message_2_event" targetRef="message_2_end" />
+  </bpmn:process>
+  <bpmn:message id="Message_0lyfmat" name="message_1" />
+  <bpmn:message id="Message_1ntpwce" name="message_2" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0pvx19v">
+      <bpmndi:BPMNEdge id="Flow_18v90rx_di" bpmnElement="Flow_18v90rx">
+        <di:waypoint x="408" y="230" />
+        <di:waypoint x="472" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g4g85l_di" bpmnElement="Flow_1g4g85l">
+        <di:waypoint x="408" y="117" />
+        <di:waypoint x="472" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mppjk9_di" bpmnElement="Flow_0mppjk9">
+        <di:waypoint x="408" y="340" />
+        <di:waypoint x="472" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rfbrlf_di" bpmnElement="Flow_1rfbrlf">
+        <di:waypoint x="290" y="142" />
+        <di:waypoint x="290" y="340" />
+        <di:waypoint x="372" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0px7ksu_di" bpmnElement="Flow_0px7ksu">
+        <di:waypoint x="290" y="142" />
+        <di:waypoint x="290" y="230" />
+        <di:waypoint x="372" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gge7fn_di" bpmnElement="Flow_0gge7fn">
+        <di:waypoint x="315" y="117" />
+        <di:waypoint x="372" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0w4b5t2_di" bpmnElement="Flow_0w4b5t2">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="265" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0gplu2e_di" bpmnElement="Gateway_1434v9l">
+        <dc:Bounds x="265" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1og7irs_di" bpmnElement="message_1_event">
+        <dc:Bounds x="372" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0quxwe6_di" bpmnElement="message_2_event">
+        <dc:Bounds x="372" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ea7gov_di" bpmnElement="timer_event">
+        <dc:Bounds x="372" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0emrepu_di" bpmnElement="timer">
+        <dc:Bounds x="472" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0x07cac_di" bpmnElement="message_1_end">
+        <dc:Bounds x="472" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p7slpj_di" bpmnElement="message_2_end">
+        <dc:Bounds x="472" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/multiple-start-parallel.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/multiple-start-parallel.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19o7vxg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:process id="main" name="Main" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" parallelMultiple="true">
+      <bpmn:outgoing>Flow_1tr2mqr</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_158nhox" messageRef="Message_0lyfmat" />
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1w1pnze" messageRef="Message_1ntpwce" />
+    </bpmn:startEvent>
+    <bpmn:task id="any_task" name="Any Task">
+      <bpmn:incoming>Flow_1tr2mqr</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qjctmo</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1tr2mqr" sourceRef="StartEvent_1" targetRef="any_task" />
+    <bpmn:endEvent id="Event_0hamwsf">
+      <bpmn:incoming>Flow_1qjctmo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1qjctmo" sourceRef="any_task" targetRef="Event_0hamwsf" />
+  </bpmn:process>
+  <bpmn:message id="Message_0lyfmat" name="message_1" />
+  <bpmn:message id="Message_1ntpwce" name="message_2" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="main">
+      <bpmndi:BPMNShape id="Event_1mddj6x_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="169" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bn6xph_di" bpmnElement="any_task">
+        <dc:Bounds x="270" y="147" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hamwsf_di" bpmnElement="Event_0hamwsf">
+        <dc:Bounds x="432" y="169" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tr2mqr_di" bpmnElement="Flow_1tr2mqr">
+        <di:waypoint x="215" y="187" />
+        <di:waypoint x="270" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qjctmo_di" bpmnElement="Flow_1qjctmo">
+        <di:waypoint x="370" y="187" />
+        <di:waypoint x="432" y="187" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/multiple-start.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/multiple-start.bpmn
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19o7vxg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:process id="main" name="Main" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1tr2mqr</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_158nhox" messageRef="Message_0lyfmat" />
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1w1pnze" messageRef="Message_1ntpwce" />
+    </bpmn:startEvent>
+    <bpmn:task id="any_task" name="Any Task">
+      <bpmn:incoming>Flow_1tr2mqr</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qjctmo</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1tr2mqr" sourceRef="StartEvent_1" targetRef="any_task" />
+    <bpmn:endEvent id="Event_0hamwsf">
+      <bpmn:incoming>Flow_1qjctmo</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1qjctmo" sourceRef="any_task" targetRef="Event_0hamwsf" />
+  </bpmn:process>
+  <bpmn:message id="Message_0lyfmat" name="message_1" />
+  <bpmn:message id="Message_1ntpwce" name="message_2" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="main">
+      <bpmndi:BPMNShape id="Event_1mddj6x_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="169" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bn6xph_di" bpmnElement="any_task">
+        <dc:Bounds x="270" y="147" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hamwsf_di" bpmnElement="Event_0hamwsf">
+        <dc:Bounds x="432" y="169" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tr2mqr_di" bpmnElement="Flow_1tr2mqr">
+        <di:waypoint x="215" y="187" />
+        <di:waypoint x="270" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qjctmo_di" bpmnElement="Flow_1qjctmo">
+        <di:waypoint x="370" y="187" />
+        <di:waypoint x="432" y="187" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/multiple-throw-start.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/multiple-throw-start.bpmn
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19o7vxg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:message id="Message_0lyfmat" name="message_1" />
+  <bpmn:message id="Message_1ntpwce" name="message_2" />
+  <bpmn:collaboration id="top">
+    <bpmn:participant id="responder" name="Responder" processRef="respond" />
+    <bpmn:participant id="initiator" name="Initiator" processRef="initiate" />
+  </bpmn:collaboration>
+  <bpmn:process id="respond" name="Respond" isExecutable="true">
+    <bpmn:startEvent id="Event_07g2lnb" parallelMultiple="true">
+      <bpmn:outgoing>Flow_04uk4n8</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_158nhox" messageRef="Message_0lyfmat" />
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1w1pnze" messageRef="Message_1ntpwce" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0hamwsf">
+      <bpmn:incoming>Flow_08al33k</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="any_task" name="Any Task">
+      <bpmn:incoming>Flow_04uk4n8</bpmn:incoming>
+      <bpmn:outgoing>Flow_08al33k</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_04uk4n8" sourceRef="Event_07g2lnb" targetRef="any_task" />
+    <bpmn:sequenceFlow id="Flow_08al33k" sourceRef="any_task" targetRef="Event_0hamwsf" />
+  </bpmn:process>
+  <bpmn:process id="initiate" name="Initiate" isExecutable="true">
+    <bpmn:startEvent id="Event_0jamixt">
+      <bpmn:outgoing>Flow_1wgdi4h</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1wgdi4h" sourceRef="Event_0jamixt" targetRef="Event_0n8a7vh" />
+    <bpmn:sequenceFlow id="Flow_1wxjn4e" sourceRef="Event_0n8a7vh" targetRef="Event_0vork94" />
+    <bpmn:endEvent id="Event_0vork94">
+      <bpmn:incoming>Flow_1wxjn4e</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:intermediateThrowEvent id="Event_0n8a7vh">
+      <bpmn:incoming>Flow_1wgdi4h</bpmn:incoming>
+      <bpmn:outgoing>Flow_1wxjn4e</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_158nhox_throw" messageRef="Message_0lyfmat" />
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1w1pnze_throw" messageRef="Message_1ntpwce" />
+    </bpmn:intermediateThrowEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="top">
+      <bpmndi:BPMNShape id="Participant_0ctz0ow_di" bpmnElement="responder" isHorizontal="true">
+        <dc:Bounds x="120" y="62" width="430" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07g2lnb_di" bpmnElement="Event_07g2lnb">
+        <dc:Bounds x="192" y="169" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hamwsf_di" bpmnElement="Event_0hamwsf">
+        <dc:Bounds x="432" y="169" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1yaipjy_di" bpmnElement="any_task">
+        <dc:Bounds x="280" y="147" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_04uk4n8_di" bpmnElement="Flow_04uk4n8">
+        <di:waypoint x="228" y="187" />
+        <di:waypoint x="280" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08al33k_di" bpmnElement="Flow_08al33k">
+        <di:waypoint x="380" y="187" />
+        <di:waypoint x="432" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0gyj8ha_di" bpmnElement="initiator" isHorizontal="true">
+        <dc:Bounds x="120" y="350" width="430" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jamixt_di" bpmnElement="Event_0jamixt">
+        <dc:Bounds x="192" y="452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vork94_di" bpmnElement="Event_0vork94">
+        <dc:Bounds x="432" y="452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0n8a7vh_di" bpmnElement="Event_0n8a7vh">
+        <dc:Bounds x="322" y="452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1wgdi4h_di" bpmnElement="Flow_1wgdi4h">
+        <di:waypoint x="228" y="470" />
+        <di:waypoint x="322" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wxjn4e_di" bpmnElement="Flow_1wxjn4e">
+        <di:waypoint x="358" y="470" />
+        <di:waypoint x="432" y="470" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/multiple-throw.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/multiple-throw.bpmn
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19o7vxg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:message id="Message_0lyfmat" name="message_1" />
+  <bpmn:message id="Message_1ntpwce" name="message_2" />
+  <bpmn:collaboration id="top">
+    <bpmn:participant id="responder" name="Responder" processRef="respond" />
+    <bpmn:participant id="initiator" name="Initiator" processRef="initiate" />
+  </bpmn:collaboration>
+  <bpmn:process id="respond" name="Respond" isExecutable="true">
+    <bpmn:endEvent id="Event_0hamwsf">
+      <bpmn:incoming>Flow_1tr2mqr</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1tr2mqr" sourceRef="StartEvent_1" targetRef="Event_0hamwsf" />
+    <bpmn:intermediateCatchEvent id="StartEvent_1" parallelMultiple="true">
+      <bpmn:incoming>Flow_1wohnl8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1tr2mqr</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_158nhox" messageRef="Message_0lyfmat" />
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1w1pnze" messageRef="Message_1ntpwce" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:startEvent id="Event_07g2lnb">
+      <bpmn:outgoing>Flow_1wohnl8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1wohnl8" sourceRef="Event_07g2lnb" targetRef="StartEvent_1" />
+  </bpmn:process>
+  <bpmn:process id="initiate" name="Initiate" isExecutable="true">
+    <bpmn:startEvent id="Event_0jamixt">
+      <bpmn:outgoing>Flow_1wgdi4h</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1wgdi4h" sourceRef="Event_0jamixt" targetRef="Event_0n8a7vh" />
+    <bpmn:sequenceFlow id="Flow_1wxjn4e" sourceRef="Event_0n8a7vh" targetRef="Event_0vork94" />
+    <bpmn:endEvent id="Event_0vork94">
+      <bpmn:incoming>Flow_1wxjn4e</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:intermediateThrowEvent id="Event_0n8a7vh">
+      <bpmn:incoming>Flow_1wgdi4h</bpmn:incoming>
+      <bpmn:outgoing>Flow_1wxjn4e</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_158nhox_throw" messageRef="Message_0lyfmat" />
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1w1pnze_throw" messageRef="Message_1ntpwce" />
+    </bpmn:intermediateThrowEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="top">
+      <bpmndi:BPMNShape id="Participant_0ctz0ow_di" bpmnElement="responder" isHorizontal="true">
+        <dc:Bounds x="120" y="62" width="430" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0hamwsf_di" bpmnElement="Event_0hamwsf">
+        <dc:Bounds x="432" y="169" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mddj6x_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="312" y="169" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07g2lnb_di" bpmnElement="Event_07g2lnb">
+        <dc:Bounds x="192" y="169" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tr2mqr_di" bpmnElement="Flow_1tr2mqr">
+        <di:waypoint x="348" y="187" />
+        <di:waypoint x="432" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wohnl8_di" bpmnElement="Flow_1wohnl8">
+        <di:waypoint x="228" y="187" />
+        <di:waypoint x="312" y="187" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0gyj8ha_di" bpmnElement="initiator" isHorizontal="true">
+        <dc:Bounds x="120" y="350" width="430" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jamixt_di" bpmnElement="Event_0jamixt">
+        <dc:Bounds x="192" y="452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vork94_di" bpmnElement="Event_0vork94">
+        <dc:Bounds x="432" y="452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0n8a7vh_di" bpmnElement="Event_0n8a7vh">
+        <dc:Bounds x="322" y="452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1wgdi4h_di" bpmnElement="Flow_1wgdi4h">
+        <di:waypoint x="228" y="470" />
+        <di:waypoint x="322" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wxjn4e_di" bpmnElement="Flow_1wxjn4e">
+        <di:waypoint x="358" y="470" />
+        <di:waypoint x="432" y="470" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/events/EventBasedGatewayTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/EventBasedGatewayTest.py
@@ -35,3 +35,12 @@ class EventBsedGatewayTest(BpmnWorkflowTestCase):
         self.assertEqual(self.workflow.get_tasks_from_spec_name('message_1_event')[0].state, TaskState.COMPLETED)
         self.assertEqual(self.workflow.get_tasks_from_spec_name('message_2_event')[0].state, TaskState.CANCELLED)
         self.assertEqual(self.workflow.get_tasks_from_spec_name('timer_event')[0].state, TaskState.CANCELLED)
+
+    def testMultipleStart(self):
+        spec, subprocess = self.load_workflow_spec('multiple-start-parallel.bpmn', 'main')
+        workflow = BpmnWorkflow(spec)
+        workflow.do_engine_steps()
+        workflow.catch(MessageEventDefinition('message_1'))
+        workflow.catch(MessageEventDefinition('message_2'))
+        workflow.refresh_waiting_tasks()
+        workflow.do_engine_steps()

--- a/tests/SpiffWorkflow/bpmn/events/EventBasedGatewayTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/EventBasedGatewayTest.py
@@ -1,0 +1,37 @@
+from datetime import timedelta
+
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.specs.events.event_definitions import MessageEventDefinition
+from SpiffWorkflow.task import TaskState
+
+from ..BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+class EventBsedGatewayTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        self.spec, self.subprocesses = self.load_workflow_spec('event-gateway.bpmn', 'Process_0pvx19v')
+        self.script_engine = PythonScriptEngine(default_globals={"timedelta": timedelta})
+        self.workflow = BpmnWorkflow(self.spec, script_engine=self.script_engine)
+
+    def testEventBasedGateway(self):
+        self.actual_test()
+
+    def testEventBasedGatewaySaveRestore(self):
+        self.actual_test(True)
+    
+    def actual_test(self, save_restore=False):
+
+        self.workflow.do_engine_steps()
+        waiting_tasks = self.workflow.get_waiting_tasks()
+        if save_restore:
+            self.save_restore()
+            self.workflow.script_engine = self.script_engine
+        self.assertEqual(len(waiting_tasks), 1)
+        self.workflow.catch(MessageEventDefinition('message_1'))
+        self.workflow.refresh_waiting_tasks()
+        self.workflow.do_engine_steps()
+        self.assertEqual(self.workflow.is_completed(), True)
+        self.assertEqual(self.workflow.get_tasks_from_spec_name('message_1_event')[0].state, TaskState.COMPLETED)
+        self.assertEqual(self.workflow.get_tasks_from_spec_name('message_2_event')[0].state, TaskState.CANCELLED)
+        self.assertEqual(self.workflow.get_tasks_from_spec_name('timer_event')[0].state, TaskState.CANCELLED)

--- a/tests/SpiffWorkflow/bpmn/events/MultipleCatchEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MultipleCatchEventTest.py
@@ -1,0 +1,81 @@
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from SpiffWorkflow.bpmn.specs.events.event_definitions import MessageEventDefinition
+
+from ..BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+
+class MultipleStartEventTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        self.spec, self.subprocesses = self.load_workflow_spec('multiple-start.bpmn', 'main')
+        self.workflow = BpmnWorkflow(self.spec)
+
+    def testMultipleStartEvent(self):
+        self.actual_test()
+
+    def testMultipleStartEventSaveRestore(self):
+        self.actual_test(True)
+    
+    def actual_test(self, save_restore=False):
+
+        self.workflow.do_engine_steps()
+        waiting_tasks = self.workflow.get_waiting_tasks()
+
+        if save_restore:
+            self.save_restore()
+
+        # The start event should be waiting
+        self.assertEqual(len(waiting_tasks), 1)
+        self.assertEqual(waiting_tasks[0].task_spec.name, 'StartEvent_1')
+
+        self.workflow.catch(MessageEventDefinition('message_1'))
+        self.workflow.refresh_waiting_tasks()
+        self.workflow.do_engine_steps()
+
+        # Now the first task should be ready
+        ready_tasks = self.workflow.get_ready_user_tasks()
+        self.assertEqual(len(ready_tasks), 1)
+        self.assertEqual(ready_tasks[0].task_spec.name, 'any_task')
+
+
+class ParallelStartEventTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        self.spec, self.subprocesses = self.load_workflow_spec('multiple-start-parallel.bpmn', 'main')
+        self.workflow = BpmnWorkflow(self.spec)
+
+    def testParallelStartEvent(self):
+        self.actual_test()
+
+    def testParallelStartEventSaveRestore(self):
+        self.actual_test(True)
+    
+    def actual_test(self, save_restore=False):
+
+        self.workflow.do_engine_steps()
+        waiting_tasks = self.workflow.get_waiting_tasks()
+
+        if save_restore:
+            self.save_restore()
+
+        # The start event should be waiting
+        self.assertEqual(len(waiting_tasks), 1)
+        self.assertEqual(waiting_tasks[0].task_spec.name, 'StartEvent_1')
+
+        self.workflow.catch(MessageEventDefinition('message_1'))
+        self.workflow.refresh_waiting_tasks()
+        self.workflow.do_engine_steps()
+
+        # It should still be waiting because it has to receive both messages
+        waiting_tasks = self.workflow.get_waiting_tasks()
+        self.assertEqual(len(waiting_tasks), 1)
+        self.assertEqual(waiting_tasks[0].task_spec.name, 'StartEvent_1')
+
+        self.workflow.catch(MessageEventDefinition('message_2'))
+        self.workflow.refresh_waiting_tasks()
+        self.workflow.do_engine_steps()
+
+        # Now the first task should be ready
+        ready_tasks = self.workflow.get_ready_user_tasks()
+        self.assertEqual(len(ready_tasks), 1)
+        self.assertEqual(ready_tasks[0].task_spec.name, 'any_task')

--- a/tests/SpiffWorkflow/bpmn/events/MultipleThrowEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MultipleThrowEventTest.py
@@ -1,0 +1,23 @@
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+
+from ..BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+
+class MultipleThrowEventTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        self.spec, subprocesses = self.load_collaboration('multiple-throw.bpmn','top')
+        self.workflow = BpmnWorkflow(self.spec, subprocesses)
+
+    def testMultipleThrowEvent(self):
+        self.actual_test()
+
+    def testMultipleThrowEventSaveRestore(self):
+        self.actual_test(True)
+
+    def actual_test(self, save_restore=False):
+        if save_restore:
+            self.save_restore()
+        self.workflow.do_engine_steps()
+        self.assertEqual(len(self.workflow.get_waiting_tasks()), 0)
+        self.assertEqual(self.workflow.is_completed(), True)

--- a/tests/SpiffWorkflow/bpmn/events/MultipleThrowEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MultipleThrowEventTest.py
@@ -3,16 +3,16 @@ from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from ..BpmnWorkflowTestCase import BpmnWorkflowTestCase
 
 
-class MultipleThrowEventTest(BpmnWorkflowTestCase):
+class MultipleThrowEventIntermediateCatchTest(BpmnWorkflowTestCase):
 
     def setUp(self):
         self.spec, subprocesses = self.load_collaboration('multiple-throw.bpmn','top')
         self.workflow = BpmnWorkflow(self.spec, subprocesses)
 
-    def testMultipleThrowEvent(self):
+    def testMultipleThrowEventIntermediateCatch(self):
         self.actual_test()
 
-    def testMultipleThrowEventSaveRestore(self):
+    def testMultipleThrowEventIntermediateCatchSaveRestore(self):
         self.actual_test(True)
 
     def actual_test(self, save_restore=False):
@@ -20,4 +20,28 @@ class MultipleThrowEventTest(BpmnWorkflowTestCase):
             self.save_restore()
         self.workflow.do_engine_steps()
         self.assertEqual(len(self.workflow.get_waiting_tasks()), 0)
+        self.assertEqual(self.workflow.is_completed(), True)
+
+
+class MultipleThrowEventStartsEventTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        specs = self.get_all_specs('multiple-throw-start.bpmn')
+        self.spec = specs.pop('initiate')
+        self.workflow = BpmnWorkflow(self.spec, specs)
+
+    def testMultipleThrowEventStartEvent(self):
+        self.actual_test()
+
+    def testMultipleThrowEventStartEventSaveRestore(self):
+        self.actual_test(True)
+
+    def actual_test(self, save_restore=False):
+        if save_restore:
+            self.save_restore()
+        self.workflow.do_engine_steps()
+        ready_tasks = self.workflow.get_ready_user_tasks()
+        self.assertEqual(len(ready_tasks), 1)
+        ready_tasks[0].complete()
+        self.workflow.do_engine_steps()
         self.assertEqual(self.workflow.is_completed(), True)


### PR DESCRIPTION
This adds a `MultipleEventDefinition` which can be used by flow-based event based gateways.  Now that this event definition exists, we get `Multiple` and `MultipleParallel` events for other types "for free".  We can't create these in BPMN js, but the XML can be hand-edited and the multiple events will be parsed correctly.  When we add support for these in the frontend, we should improve the testing around them; since the request was for event-based gateway support, I am leaving that until later.