### PR TITLE
Fix ResourceWarning: unclosed file BpmnParser.py:60

### DIFF
--- a/SpiffWorkflow/bpmn/parser/BpmnParser.py
+++ b/SpiffWorkflow/bpmn/parser/BpmnParser.py
@@ -57,7 +57,8 @@ XSD_PATH = os.path.join(os.path.dirname(__file__), 'schema', 'BPMN20.xsd')
 class BpmnValidator:
 
     def __init__(self, xsd_path=XSD_PATH, imports=None):
-        schema = etree.parse(open(xsd_path))
+        with open(xsd_path) as xsd:
+            schema = etree.parse(xsd)
         if imports is not None:
             for ns, fn in imports.items():
                 elem = etree.Element(


### PR DESCRIPTION
Fixes a warning that can be seen when running the tests:

```
testBusinessRule (tests.SpiffWorkflow.spiff.BusinessRuleTaskTest.BusinessRuleTaskTest.testBusinessRule) ... /home/jon/projects/github/sartography/SpiffWorkflow/SpiffWorkflow/bpmn/parser/BpmnParser.py:60: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/jon/projects/github/sartography/SpiffWorkflow/SpiffWorkflow/dmn/parser/schema/DMN13.xsd' mode='r' encoding='UTF-8'>
  schema = etree.parse(open(xsd_path))
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

after:

```
testBusinessRule (tests.SpiffWorkflow.spiff.BusinessRuleTaskTest.BusinessRuleTaskTest.testBusinessRule) ... ok
```