### PR TITLE
Option to run tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,11 @@ tests:
 
 .PHONY : tests-par
 tests-par:
+	if ! command -v unittest-parallel >/dev/null 2>&1; then \
+		echo "unittest-parallel not found. Please install it with:"; \
+		echo "  pip install unittest-parallel"; \
+		exit 1; \
+	fi
 	unittest-parallel --module-fixtures -vs tests/SpiffWorkflow -p \*Test.py -t .
 
 .PHONY : tests-cov

--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,11 @@ uninstall:
 
 .PHONY : tests
 tests:
-	cd tests/$(NAME)
-	PYTHONPATH=../.. python -m unittest discover -v . "*Test.py"
+	python -m unittest discover -vs tests/SpiffWorkflow -p \*Test.py -t .
+
+.PHONY : tests-par
+tests-par:
+	unittest-parallel --module-fixtures -vs tests/SpiffWorkflow -p \*Test.py -t .
 
 .PHONY : tests-cov
 tests-cov:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ tests:
 
 .PHONY : tests-par
 tests-par:
-	if ! command -v unittest-parallel >/dev/null 2>&1; then \
+	@if ! command -v unittest-parallel >/dev/null 2>&1; then \
 		echo "unittest-parallel not found. Please install it with:"; \
 		echo "  pip install unittest-parallel"; \
 		exit 1; \

--- a/tests/SpiffWorkflow/specs/ExecuteTest.py
+++ b/tests/SpiffWorkflow/specs/ExecuteTest.py
@@ -3,9 +3,7 @@
 
 
 import os
-import sys
 import unittest
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
 from tests.SpiffWorkflow.util import run_workflow
 from .TaskSpecTest import TaskSpecTest
@@ -25,7 +23,8 @@ class ExecuteTest(TaskSpecTest):
                        args=self.cmd_args)
 
     def setUp(self):
-        self.cmd_args = ["python", "ExecuteProcessMock.py"]
+        script_path = os.path.join(os.path.dirname(__file__), '..', 'ExecuteProcessMock.py')
+        self.cmd_args = ["python", script_path]
         TaskSpecTest.setUp(self)
 
     def testConstructor(self):


### PR DESCRIPTION
Found an existing tool [unittest-parallel](https://github.com/craigahobbs/unittest-parallel) that provides a custom test runner to support running unit tests in parallel. If you want to install it, there is a new `make tests-par` option which greatly reduces time needed to run the test suite. Minor tweaks to paths, and made the `make tests` invocation work more like `make tests-par`.

make tests:

```
----------------------------------------------------------------------
Ran 550 tests in 13.572s

OK (skipped=2)

```

make tests-par:

```
----------------------------------------------------------------------
Ran 550 tests in 2.928s

OK (skipped=2)

```