### PR TITLE
fix for workflowspec dump

### DIFF
--- a/SpiffWorkflow/specs/WorkflowSpec.py
+++ b/SpiffWorkflow/specs/WorkflowSpec.py
@@ -152,33 +152,35 @@ class WorkflowSpec(object):
         def recursive_dump(task_spec, indent):
             if task_spec in done:
                 return '[shown earlier] %s (%s:%s)' % (
-                    task_spec.name, task_spec.__class__.__name__,
-                    hex(id(task_spec))) + '\n'
-
+                    task_spec.name,
+                    task_spec.__class__.__name__,
+                    hex(id(task_spec))
+                ) + '\n'
             done.add(task_spec)
             dump = '%s (%s:%s)' % (
                 task_spec.name,
-                task_spec.__class__.__name__, hex(id(task_spec))) + '\n'
+                task_spec.__class__.__name__,
+                hex(id(task_spec))
+            ) + '\n'
             if verbose:
                 if task_spec.inputs:
-                    dump += indent + '-  IN: ' + \
-                        ','.join(['%s (%s)' % (t.name, hex(id(t)))
-                                  for t in task_spec.inputs]) + '\n'
+                    dump += indent + \
+                        '- IN: ' + \
+                        ','.join(['%s (%s)' % (t.name, hex(id(t))) for t in task_spec.inputs]) + \
+                        '\n'
                 if task_spec.outputs:
-                    dump += indent + '- OUT: ' + \
-                        ','.join(['%s (%s)' % (t.name, hex(id(t)))
-                                  for t in task_spec.outputs]) + '\n'
-            sub_specs = ([task_spec.spec.start] if hasattr(
-                task_spec, 'spec') else []) + task_spec.outputs
-            for i, t in enumerate(sub_specs):
-                dump += indent + '   --> ' + \
-                    recursive_dump(
-                        t, indent + ('   |   ' if i + 1 < len(sub_specs) else
-                                     '       '))
+                    dump += indent + \
+                        '- OUT: ' + \
+                        ','.join(['%s (%s)' % (t.name, hex(id(t))) for t in task_spec.outputs]) + \
+                        '\n'
+            # sub_specs = ([task_spec.spec.start] if hasattr(task_spec, 'spec') else []) + task_spec.outputs
+            for i, t in enumerate(task_spec.outputs):
+                dump += indent + \
+                    '   --> ' + \
+                    recursive_dump(t, indent + ('   |   ' if i + 1 < len(task_spec.outputs) else '       '))
             return dump
 
         dump = recursive_dump(self.start, '')
-
         return dump
 
     def dump(self):


### PR DESCRIPTION
@essweine 
Please review the changes.
- When I used WorkflowSpec::get_dump() function, it was throwing exception  while accessing `task_spec.spec.start`
- `task_spec` in this case is `CallActivity`. It's `self.spec` is actually a string and does not have `start` atribute.
- Problem could be when creating `CallActivity`, it is not being initialized properly.

Changes:
- `task_spec.outputs` has the children tasks, hence avoiding accessing `task_spec.spec.start`