### PR TITLE
Allow for other PythonScriptEngine environments besides task data

### DIFF
--- a/SpiffWorkflow/bpmn/FeelLikeScriptEngine.py
+++ b/SpiffWorkflow/bpmn/FeelLikeScriptEngine.py
@@ -266,8 +266,8 @@ class FeelLikeScriptEngine(PythonScriptEngine):
     provide a specialised subclass that parses and executes the scripts /
     expressions in a mini-language of your own.
     """
-    def __init__(self):
-        super().__init__()
+    def __init__(self, environment=None):
+        super().__init__(environment=environment)
 
     def validate(self, expression):
         super().validate(self.patch_expression(expression))

--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -197,11 +197,11 @@ class PythonScriptEngine(object):
 
     def _evaluate(self, expression, context, external_methods=None):
 
-        globals = copy.copy(self.globals)  # else we pollute all later evals.
+        my_globals = copy.copy(self.globals)  # else we pollute all later evals.
         self.convert_to_box(context)
-        globals.update(external_methods or {})
-        globals.update(context)
-        return eval(expression, globals)
+        my_globals.update(external_methods or {})
+        my_globals.update(context)
+        return eval(expression, my_globals)
 
     def _execute(self, script, context, external_methods=None):
 

--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -3,6 +3,7 @@ import ast
 import copy
 import sys
 import traceback
+import warnings
 
 from .PythonScriptEngineEnvironment import TaskDataEnvironment
 from ..exceptions import SpiffWorkflowException, WorkflowTaskException
@@ -39,6 +40,10 @@ class PythonScriptEngine(object):
     """
 
     def __init__(self, default_globals=None, scripting_additions=None, environment=None):
+        if default_globals is not None or scripting_additions is not None:
+            warnings.warn(f'default_globals and scripting_additions are deprecated.  '
+                          f'Please provide an environment such as TaskDataEnvrionment',
+                          DeprecationWarning, stacklevel=2)
         if environment is None:
             environment_globals = {}
             environment_globals.update(default_globals or {})

--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -4,6 +4,7 @@ import copy
 import sys
 import traceback
 
+from .PythonScriptEngineEnvironment import TaskDataEnvironment
 from ..exceptions import SpiffWorkflowException, WorkflowTaskException
 from ..operators import Operator
 
@@ -26,66 +27,6 @@ from ..operators import Operator
 # 02110-1301  USA
 
 
-class Box(dict):
-    """
-    Example:
-    m = Box({'first_name': 'Eduardo'}, last_name='Pool', age=24, sports=['Soccer'])
-    """
-
-    def __init__(self, *args, **kwargs):
-        super(Box, self).__init__(*args, **kwargs)
-        for arg in args:
-            if isinstance(arg, dict):
-                for k, v in arg.items():
-                    if isinstance(v, dict):
-                        self[k] = Box(v)
-                    else:
-                        self[k] = v
-
-        if kwargs:
-            for k, v in kwargs.items():
-                if isinstance(v, dict):
-                    self[k] = Box(v)
-                else:
-                    self[k] = v
-
-    def __deepcopy__(self, memodict=None):
-        if memodict is None:
-            memodict = {}
-        my_copy = Box()
-        for k, v in self.items():
-            my_copy[k] = copy.deepcopy(v)
-        return my_copy
-
-    def __getattr__(self, attr):
-        try:
-            output = self[attr]
-        except:
-            raise AttributeError(
-                "Dictionary has no attribute '%s' " % str(attr))
-        return output
-
-    def __setattr__(self, key, value):
-        self.__setitem__(key, value)
-
-    def __setitem__(self, key, value):
-        super(Box, self).__setitem__(key, value)
-        self.__dict__.update({key: value})
-
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, state):
-        self.__init__(state)
-
-    def __delattr__(self, item):
-        self.__delitem__(item)
-
-    def __delitem__(self, key):
-        super(Box, self).__delitem__(key)
-        del self.__dict__[key]
-
-
 class PythonScriptEngine(object):
     """
     This should serve as a base for all scripting & expression evaluation
@@ -97,10 +38,14 @@ class PythonScriptEngine(object):
     expressions in a different way.
     """
 
-    def __init__(self, default_globals=None, scripting_additions=None):
-
-        self.globals = default_globals or {}
-        self.globals.update(scripting_additions or {})
+    def __init__(self, default_globals=None, scripting_additions=None, environment=None):
+        if environment is None:
+            environment_globals = {}
+            environment_globals.update(default_globals or {})
+            environment_globals.update(scripting_additions or {})
+            self.environment = TaskDataEnvironment(environment_globals)
+        else:
+            self.environment = environment
         self.error_tasks = {}
 
     def validate(self, expression):
@@ -175,7 +120,7 @@ class PythonScriptEngine(object):
         same name as a pre-defined script, rending the script un-callable.
         This results in a nearly indecipherable error.  Better to fail
         fast with a sensible error message."""
-        func_overwrites = set(self.globals).intersection(task.data)
+        func_overwrites = set(self.environment.globals).intersection(task.data)
         func_overwrites.update(set(external_methods).intersection(task.data))
         if len(func_overwrites) > 0:
             msg = f"You have task data that overwrites a predefined " \
@@ -183,45 +128,8 @@ class PythonScriptEngine(object):
                   f"field name(s) to something else: {func_overwrites}"
             raise WorkflowTaskException(msg, task=task)
 
-    def convert_to_box(self, data):
-        if isinstance(data, dict):
-            for key, value in data.items():
-                if not isinstance(value, Box):
-                    data[key] = self.convert_to_box(value)
-            return Box(data)
-        if isinstance(data, list):
-            for idx, value in enumerate(data):
-                data[idx] = self.convert_to_box(value)
-            return data
-        return data
-
     def _evaluate(self, expression, context, external_methods=None):
-
-        my_globals = copy.copy(self.globals)  # else we pollute all later evals.
-        self.convert_to_box(context)
-        my_globals.update(external_methods or {})
-        my_globals.update(context)
-        return eval(expression, my_globals)
+        return self.environment.evaluate(expression, context, external_methods)
 
     def _execute(self, script, context, external_methods=None):
-
-        my_globals = copy.copy(self.globals)
-        self.convert_to_box(context)
-        my_globals.update(external_methods or {})
-        context.update(my_globals)
-        try:
-            exec(script, context)
-        finally:
-            self.remove_globals_and_functions_from_context(context,
-                                                           external_methods)
-
-    def remove_globals_and_functions_from_context(self, context,
-                                                  external_methods=None):
-        """When executing a script, don't leave the globals, functions
-        and external methods in the context that we have modified."""
-        for k in list(context):
-            if k == "__builtins__" or \
-                    hasattr(context[k], '__call__') or \
-                    k in self.globals or \
-                    external_methods and k in external_methods:
-                context.pop(k)
+        self.environment.execute(script, context, external_methods)

--- a/SpiffWorkflow/bpmn/PythonScriptEngineEnvironment.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngineEnvironment.py
@@ -1,0 +1,112 @@
+import copy
+
+class BasePythonScriptEngineEnvironment:
+    def evaluate(self, expression, context, external_methods=None):
+        raise NotImplementedError("Subclass must implement this method")
+
+    def execute(self, script, context, external_methods=None):
+        raise NotImplementedError("Subclass must implement this method")
+
+class Box(dict):
+    """
+    Example:
+    m = Box({'first_name': 'Eduardo'}, last_name='Pool', age=24, sports=['Soccer'])
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(Box, self).__init__(*args, **kwargs)
+        for arg in args:
+            if isinstance(arg, dict):
+                for k, v in arg.items():
+                    if isinstance(v, dict):
+                        self[k] = Box(v)
+                    else:
+                        self[k] = v
+
+        if kwargs:
+            for k, v in kwargs.items():
+                if isinstance(v, dict):
+                    self[k] = Box(v)
+                else:
+                    self[k] = v
+
+    def __deepcopy__(self, memodict=None):
+        if memodict is None:
+            memodict = {}
+        my_copy = Box()
+        for k, v in self.items():
+            my_copy[k] = copy.deepcopy(v)
+        return my_copy
+
+    def __getattr__(self, attr):
+        try:
+            output = self[attr]
+        except:
+            raise AttributeError(
+                "Dictionary has no attribute '%s' " % str(attr))
+        return output
+
+    def __setattr__(self, key, value):
+        self.__setitem__(key, value)
+
+    def __setitem__(self, key, value):
+        super(Box, self).__setitem__(key, value)
+        self.__dict__.update({key: value})
+
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, state):
+        self.__init__(state)
+
+    def __delattr__(self, item):
+        self.__delitem__(item)
+
+    def __delitem__(self, key):
+        super(Box, self).__delitem__(key)
+        del self.__dict__[key]
+
+    @classmethod
+    def convert_to_box(cls, data):
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if not isinstance(value, Box):
+                    data[key] = cls.convert_to_box(value)
+            return Box(data)
+        if isinstance(data, list):
+            for idx, value in enumerate(data):
+                data[idx] = cls.convert_to_box(value)
+            return data
+        return data
+
+class TaskDataEnvironment(BasePythonScriptEngineEnvironment):
+    def __init__(self, environment_globals):
+        self.globals = environment_globals
+
+    def evaluate(self, expression, context, external_methods=None):
+        my_globals = copy.copy(self.globals)  # else we pollute all later evals.
+        Box.convert_to_box(context)
+        my_globals.update(external_methods or {})
+        my_globals.update(context)
+        return eval(expression, my_globals)
+
+    def execute(self, script, context, external_methods=None):
+        my_globals = copy.copy(self.globals)
+        Box.convert_to_box(context)
+        my_globals.update(external_methods or {})
+        context.update(my_globals)
+        try:
+            exec(script, context)
+        finally:
+            self._remove_globals_and_functions_from_context(context, external_methods)
+
+    def _remove_globals_and_functions_from_context(self, context,
+                                                  external_methods=None):
+        """When executing a script, don't leave the globals, functions
+        and external methods in the context that we have modified."""
+        for k in list(context):
+            if k == "__builtins__" or \
+                    hasattr(context[k], '__call__') or \
+                    k in self.globals or \
+                    external_methods and k in external_methods:
+                context.pop(k)

--- a/SpiffWorkflow/bpmn/PythonScriptEngineEnvironment.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngineEnvironment.py
@@ -1,6 +1,9 @@
 import copy
 
 class BasePythonScriptEngineEnvironment:
+    def __init__(self, environment_globals):
+        self.globals = environment_globals
+
     def evaluate(self, expression, context, external_methods=None):
         raise NotImplementedError("Subclass must implement this method")
 
@@ -80,9 +83,6 @@ class Box(dict):
         return data
 
 class TaskDataEnvironment(BasePythonScriptEngineEnvironment):
-    def __init__(self, environment_globals):
-        self.globals = environment_globals
-
     def evaluate(self, expression, context, external_methods=None):
         my_globals = copy.copy(self.globals)  # else we pollute all later evals.
         Box.convert_to_box(context)

--- a/tests/SpiffWorkflow/bpmn/BoxDeepCopyTest.py
+++ b/tests/SpiffWorkflow/bpmn/BoxDeepCopyTest.py
@@ -1,6 +1,6 @@
 import unittest
 
-from SpiffWorkflow.bpmn.PythonScriptEngine import Box
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import Box
 
 
 class BoxDeepCopyTest(unittest.TestCase):

--- a/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
+++ b/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
@@ -4,6 +4,7 @@ import unittest
 from SpiffWorkflow.exceptions import WorkflowTaskException
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 
@@ -17,8 +18,8 @@ class CustomBpmnScriptEngine(PythonScriptEngine):
     It will execute python code read in from the bpmn.  It will also make any scripts in the
      scripts directory available for execution. """
     def __init__(self):
-        augment_methods = {'custom_function': my_custom_function}
-        super().__init__(scripting_additions=augment_methods)
+        environment = TaskDataEnvironment({'custom_function': my_custom_function})
+        super().__init__(environment=environment)
 
 
 class CustomInlineScriptTest(BpmnWorkflowTestCase):

--- a/tests/SpiffWorkflow/bpmn/FeelExpressionEngineTest.py
+++ b/tests/SpiffWorkflow/bpmn/FeelExpressionEngineTest.py
@@ -3,6 +3,7 @@
 import unittest
 
 from SpiffWorkflow.bpmn.FeelLikeScriptEngine import FeelLikeScriptEngine, FeelInterval
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import BoxedTaskDataEnvironment
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 import datetime
 
@@ -12,7 +13,7 @@ __author__ = 'matth'
 class FeelExpressionTest(BpmnWorkflowTestCase):
 
     def setUp(self):
-        self.expressionEngine = FeelLikeScriptEngine()
+        self.expressionEngine = FeelLikeScriptEngine(environment=BoxedTaskDataEnvironment())
 
     def testRunThroughExpressions(self):
         tests = [("string length('abcd')", 4, {}),
@@ -62,7 +63,7 @@ class FeelExpressionTest(BpmnWorkflowTestCase):
             ]
         }
         x = self.expressionEngine._evaluate(
-            """sum([1 for x in exclusive if x.get('ExclusiveSpaceAMComputingID',None)==None])""", 
+            """sum([1 for x in exclusive if x.get('ExclusiveSpaceAMComputingID',None)==None])""",
             data
         )
         self.assertEqual(x, 1)

--- a/tests/SpiffWorkflow/bpmn/PythonScriptEngineEnvironmentTest.py
+++ b/tests/SpiffWorkflow/bpmn/PythonScriptEngineEnvironmentTest.py
@@ -26,7 +26,7 @@ class PythonScriptEngineEnvironmentTest(BpmnWorkflowTestCase):
         d_uniques = set(self.workflow.data["d"])
         d_len = len(self.workflow.data["d"])
 
-        self.assertLess(task_data_len, 1024)
+        #self.assertLess(task_data_len, 1024)
         self.assertEqual(d_len, 512*3)
         self.assertEqual(d_uniques, {"a", "b", "c"})
 

--- a/tests/SpiffWorkflow/bpmn/PythonScriptEngineEnvironmentTest.py
+++ b/tests/SpiffWorkflow/bpmn/PythonScriptEngineEnvironmentTest.py
@@ -1,8 +1,31 @@
 import json
 
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import BasePythonScriptEngineEnvironment
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from SpiffWorkflow.task import TaskState
+
+def example_global():
+    pass
+
+class NonTaskDataExampleEnvironment(BasePythonScriptEngineEnvironment):
+    def __init__(self, environment_globals, environment):
+        self.environment = environment
+        self.environment.update(environment_globals)
+        super().__init__(environment_globals)
+
+    def evaluate(self, expression, context, external_methods=None):
+        pass
+
+    def execute(self, script, context, external_methods=None):
+        self.environment.update(context)
+        self.environment.update(external_methods or {})
+        exec(script, self.environment)
+        self.environment = {k: v for k, v in self.environment.items() if k not in external_methods}
+
+    def user_defined_values(self):
+        return {k: v for k, v in self.environment.items() if k not in self.globals}
 
 class PythonScriptEngineEnvironmentTest(BpmnWorkflowTestCase):
 
@@ -12,21 +35,39 @@ class PythonScriptEngineEnvironmentTest(BpmnWorkflowTestCase):
 
     def testTaskDataSizeWithDefaultPythonScriptEngine(self):
         self.workflow.do_engine_steps()
+
+        self.assertIn("a", self.workflow.data)
+        self.assertIn("b", self.workflow.data)
+        self.assertIn("c", self.workflow.data)
+        self.assertIn("d", self.workflow.data)
+
         task_data_len = self._get_task_data_len()
         d_uniques = set(self.workflow.data["d"])
         d_len = len(self.workflow.data["d"])
 
-        self.assertGreater(task_data_len, 1024)
+        self.assertGreater(task_data_len, 15000)
         self.assertEqual(d_len, 512*3)
         self.assertEqual(d_uniques, {"a", "b", "c"})
 
-    def testTaskDataSizeWithEnvironmentBasedPythonScriptEngine(self):
+    def testTaskDataSizeWithNonTaskDataEnvironmentBasedPythonScriptEngine(self):
+        script_engine_environment = NonTaskDataExampleEnvironment({"example_global": example_global}, {})
+        script_engine = PythonScriptEngine(environment=script_engine_environment)
+        self.workflow.script_engine = script_engine
+
         self.workflow.do_engine_steps()
+        self.workflow.data.update(script_engine.environment.user_defined_values())
+
+        self.assertIn("a", self.workflow.data)
+        self.assertIn("b", self.workflow.data)
+        self.assertIn("c", self.workflow.data)
+        self.assertIn("d", self.workflow.data)
+        self.assertNotIn("example_global", self.workflow.data)
+
         task_data_len = self._get_task_data_len()
         d_uniques = set(self.workflow.data["d"])
         d_len = len(self.workflow.data["d"])
 
-        #self.assertLess(task_data_len, 1024)
+        self.assertLess(task_data_len, 50)
         self.assertEqual(d_len, 512*3)
         self.assertEqual(d_uniques, {"a", "b", "c"})
 

--- a/tests/SpiffWorkflow/bpmn/PythonScriptEngineEnvironmentTest.py
+++ b/tests/SpiffWorkflow/bpmn/PythonScriptEngineEnvironmentTest.py
@@ -67,13 +67,14 @@ class PythonScriptEngineEnvironmentTest(BpmnWorkflowTestCase):
         d_uniques = set(self.workflow.data["d"])
         d_len = len(self.workflow.data["d"])
 
-        self.assertLess(task_data_len, 50)
+        self.assertEqual(task_data_len, 2)
         self.assertEqual(d_len, 512*3)
         self.assertEqual(d_uniques, {"a", "b", "c"})
 
     def _get_task_data_len(self):
         tasks_to_check = self.workflow.get_tasks(TaskState.FINISHED_MASK)
         task_data = [task.data for task in tasks_to_check]
-        task_data_len = len(json.dumps(task_data))
+        task_data_to_check = list(filter(len, task_data))
+        task_data_len = len(json.dumps(task_data_to_check))
         return task_data_len
 

--- a/tests/SpiffWorkflow/bpmn/PythonScriptEngineEnvironmentTest.py
+++ b/tests/SpiffWorkflow/bpmn/PythonScriptEngineEnvironmentTest.py
@@ -13,8 +13,22 @@ class PythonScriptEngineEnvironmentTest(BpmnWorkflowTestCase):
     def testTaskDataSizeWithDefaultPythonScriptEngine(self):
         self.workflow.do_engine_steps()
         task_data_len = self._get_task_data_len()
+        d_uniques = set(self.workflow.data["d"])
+        d_len = len(self.workflow.data["d"])
 
         self.assertGreater(task_data_len, 1024)
+        self.assertEqual(d_len, 512*3)
+        self.assertEqual(d_uniques, {"a", "b", "c"})
+
+    def testTaskDataSizeWithEnvironmentBasedPythonScriptEngine(self):
+        self.workflow.do_engine_steps()
+        task_data_len = self._get_task_data_len()
+        d_uniques = set(self.workflow.data["d"])
+        d_len = len(self.workflow.data["d"])
+
+        self.assertLess(task_data_len, 1024)
+        self.assertEqual(d_len, 512*3)
+        self.assertEqual(d_uniques, {"a", "b", "c"})
 
     def _get_task_data_len(self):
         tasks_to_check = self.workflow.get_tasks(TaskState.FINISHED_MASK)

--- a/tests/SpiffWorkflow/bpmn/PythonScriptEngineEnvironmentTest.py
+++ b/tests/SpiffWorkflow/bpmn/PythonScriptEngineEnvironmentTest.py
@@ -1,0 +1,24 @@
+import json
+
+from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from SpiffWorkflow.task import TaskState
+
+class PythonScriptEngineEnvironmentTest(BpmnWorkflowTestCase):
+
+    def setUp(self):
+        spec, subprocesses = self.load_workflow_spec('task_data_size.bpmn', 'Process_ccz6oq2')
+        self.workflow = BpmnWorkflow(spec, subprocesses)
+
+    def testTaskDataSizeWithDefaultPythonScriptEngine(self):
+        self.workflow.do_engine_steps()
+        task_data_len = self._get_task_data_len()
+
+        self.assertGreater(task_data_len, 1024)
+
+    def _get_task_data_len(self):
+        tasks_to_check = self.workflow.get_tasks(TaskState.FINISHED_MASK)
+        task_data = [task.data for task in tasks_to_check]
+        task_data_len = len(json.dumps(task_data))
+        return task_data_len
+

--- a/tests/SpiffWorkflow/bpmn/TooManyLoopsTest.py
+++ b/tests/SpiffWorkflow/bpmn/TooManyLoopsTest.py
@@ -4,6 +4,7 @@ import datetime
 import unittest
 
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 
@@ -14,10 +15,10 @@ class CustomScriptEngine(PythonScriptEngine):
     It will execute python code read in from the bpmn.  It will also make any scripts in the
      scripts directory available for execution. """
     def __init__(self):
-        augment_methods = {
+        environment = TaskDataEnvironment({
             'timedelta': datetime.timedelta,
-        }
-        super().__init__(scripting_additions=augment_methods)
+        })
+        super().__init__(environment=environment)
 
 class TooManyLoopsTest(BpmnWorkflowTestCase):
 

--- a/tests/SpiffWorkflow/bpmn/data/task_data_size.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/task_data_size.bpmn
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Process_ccz6oq2" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_177wrsb</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_177wrsb" sourceRef="StartEvent_1" targetRef="Activity_0tbghnr" />
+    <bpmn:sequenceFlow id="Flow_0eductu" sourceRef="Activity_0tbghnr" targetRef="Activity_1b4i250" />
+    <bpmn:endEvent id="Event_1ncs6fv">
+      <bpmn:incoming>Flow_0hkxb5e</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1xryi5d" sourceRef="Activity_1b4i250" targetRef="Activity_0k6ipvz" />
+    <bpmn:scriptTask id="Activity_0tbghnr" name="512 a">
+      <bpmn:incoming>Flow_177wrsb</bpmn:incoming>
+      <bpmn:outgoing>Flow_0eductu</bpmn:outgoing>
+      <bpmn:script>a="a"*512</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_1b4i250" name="512 b">
+      <bpmn:incoming>Flow_0eductu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xryi5d</bpmn:outgoing>
+      <bpmn:script>b="b"*512</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1of7r00" sourceRef="Activity_0k6ipvz" targetRef="Activity_1i88z55" />
+    <bpmn:scriptTask id="Activity_0k6ipvz" name="512 c">
+      <bpmn:incoming>Flow_1xryi5d</bpmn:incoming>
+      <bpmn:outgoing>Flow_1of7r00</bpmn:outgoing>
+      <bpmn:script>c="c"*512</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_0hkxb5e" sourceRef="Activity_1i88z55" targetRef="Event_1ncs6fv" />
+    <bpmn:scriptTask id="Activity_1i88z55" name="a+b+c">
+      <bpmn:incoming>Flow_1of7r00</bpmn:incoming>
+      <bpmn:outgoing>Flow_0hkxb5e</bpmn:outgoing>
+      <bpmn:script>d=a+b+c</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_ccz6oq2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="202" y="42" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kxr618_di" bpmnElement="Activity_0tbghnr">
+        <dc:Bounds x="170" y="110" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wp0pql_di" bpmnElement="Activity_1b4i250">
+        <dc:Bounds x="170" y="220" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0975bxc_di" bpmnElement="Activity_0k6ipvz">
+        <dc:Bounds x="170" y="330" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ncs6fv_di" bpmnElement="Event_1ncs6fv">
+        <dc:Bounds x="202" y="562" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1w8fetn_di" bpmnElement="Activity_1i88z55">
+        <dc:Bounds x="170" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_177wrsb_di" bpmnElement="Flow_177wrsb">
+        <di:waypoint x="220" y="78" />
+        <di:waypoint x="220" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eductu_di" bpmnElement="Flow_0eductu">
+        <di:waypoint x="220" y="190" />
+        <di:waypoint x="220" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xryi5d_di" bpmnElement="Flow_1xryi5d">
+        <di:waypoint x="220" y="300" />
+        <di:waypoint x="220" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1of7r00_di" bpmnElement="Flow_1of7r00">
+        <di:waypoint x="220" y="410" />
+        <di:waypoint x="220" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hkxb5e_di" bpmnElement="Flow_0hkxb5e">
+        <di:waypoint x="220" y="520" />
+        <di:waypoint x="220" y="562" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/events/EventBasedGatewayTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/EventBasedGatewayTest.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from SpiffWorkflow.bpmn.specs.events.event_definitions import MessageEventDefinition
 from SpiffWorkflow.task import TaskState
 
@@ -11,7 +12,7 @@ class EventBsedGatewayTest(BpmnWorkflowTestCase):
 
     def setUp(self):
         self.spec, self.subprocesses = self.load_workflow_spec('event-gateway.bpmn', 'Process_0pvx19v')
-        self.script_engine = PythonScriptEngine(default_globals={"timedelta": timedelta})
+        self.script_engine = PythonScriptEngine(environment=TaskDataEnvironment({"timedelta": timedelta}))
         self.workflow = BpmnWorkflow(self.spec, script_engine=self.script_engine)
 
     def testEventBasedGateway(self):

--- a/tests/SpiffWorkflow/bpmn/events/TimerCycleStartTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerCycleStartTest.py
@@ -5,6 +5,7 @@ import unittest
 import time
 
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 
@@ -24,11 +25,11 @@ class CustomScriptEngine(PythonScriptEngine):
     It will execute python code read in from the bpmn.  It will also make any scripts in the
      scripts directory available for execution. """
     def __init__(self):
-        augment_methods = {
+        environment = TaskDataEnvironment({
             'custom_function': my_custom_function,
             'timedelta': datetime.timedelta,
-        }
-        super().__init__(scripting_additions=augment_methods)
+        })
+        super().__init__(environment=environment)
 
 
 class TimerCycleStartTest(BpmnWorkflowTestCase):

--- a/tests/SpiffWorkflow/bpmn/events/TimerCycleTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerCycleTest.py
@@ -5,6 +5,7 @@ import unittest
 import time
 
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
@@ -22,11 +23,11 @@ class CustomScriptEngine(PythonScriptEngine):
     It will execute python code read in from the bpmn.  It will also make any scripts in the
      scripts directory available for execution. """
     def __init__(self):
-        augment_methods = {
+        environment = TaskDataEnvironment({
             'custom_function': my_custom_function,
             'timedelta': datetime.timedelta,
-        }
-        super().__init__(scripting_additions=augment_methods)
+        })
+        super().__init__(environment=environment)
 
 
 

--- a/tests/SpiffWorkflow/bpmn/events/TimerDateTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDateTest.py
@@ -6,6 +6,7 @@ import time
 
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 
 __author__ = 'kellym'
@@ -14,10 +15,10 @@ __author__ = 'kellym'
 class TimerDateTest(BpmnWorkflowTestCase):
 
     def setUp(self):
-        self.script_engine = PythonScriptEngine(default_globals={
+        self.script_engine = PythonScriptEngine(environment=TaskDataEnvironment({
             "datetime": datetime.datetime,
             "timedelta": datetime.timedelta,
-        })
+        }))
         self.spec, self.subprocesses = self.load_workflow_spec('timer-date-start.bpmn', 'date_timer')
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses, script_engine=self.script_engine)
 

--- a/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryOnTaskTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryOnTaskTest.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 __author__ = 'kellym'
 
@@ -13,7 +14,7 @@ __author__ = 'kellym'
 class TimerDurationTest(BpmnWorkflowTestCase):
 
     def setUp(self):
-        self.script_engine = PythonScriptEngine(default_globals={"timedelta": timedelta})
+        self.script_engine = PythonScriptEngine(environment=TaskDataEnvironment({"timedelta": timedelta}))
         self.spec, self.subprocesses = self.load_workflow_spec('boundary_timer_on_task.bpmn', 'test_timer')
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses, script_engine=self.script_engine)
 

--- a/tests/SpiffWorkflow/bpmn/events/TimerDurationTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDurationTest.py
@@ -5,6 +5,7 @@ import time
 from datetime import datetime, timedelta
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 
 __author__ = 'kellym'
@@ -13,7 +14,7 @@ __author__ = 'kellym'
 class TimerDurationTest(BpmnWorkflowTestCase):
 
     def setUp(self):
-        self.script_engine = PythonScriptEngine(default_globals={"timedelta": timedelta})
+        self.script_engine = PythonScriptEngine(environment=TaskDataEnvironment({"timedelta": timedelta}))
         self.spec, self.subprocesses = self.load_workflow_spec('timer.bpmn', 'timer')
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses, script_engine=self.script_engine)
 

--- a/tests/SpiffWorkflow/bpmn/serializer/VersionMigrationTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/VersionMigrationTest.py
@@ -3,6 +3,7 @@ import time
 
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 
 from .BaseTestCase import BaseTestCase
 
@@ -24,7 +25,7 @@ class VersionMigrationTest(BaseTestCase):
     def test_convert_1_1_to_1_2(self):
         fn = os.path.join(self.DATA_DIR, 'serialization', 'v1-1.json')
         wf = self.serializer.deserialize_json(open(fn).read())
-        wf.script_engine = PythonScriptEngine(default_globals={"time": time})
+        wf.script_engine = PythonScriptEngine(environment=TaskDataEnvironment({"time": time}))
         wf.refresh_waiting_tasks()
         wf.do_engine_steps()
         self.assertTrue(wf.is_completed())

--- a/tests/SpiffWorkflow/camunda/DMNCustomScriptTest.py
+++ b/tests/SpiffWorkflow/camunda/DMNCustomScriptTest.py
@@ -1,5 +1,6 @@
 import unittest
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 
 from .BaseTestCase import BaseTestCase
@@ -12,8 +13,8 @@ def my_custom_function(txt):
 class CustomScriptEngine(PythonScriptEngine):
 
     def __init__(self):
-        augment_methods = {'my_custom_function': my_custom_function}
-        super().__init__(scripting_additions=augment_methods)
+        environment = TaskDataEnvironment({'my_custom_function': my_custom_function})
+        super().__init__(environment=environment)
 
 
 class DMNCustomScriptTest(BaseTestCase):

--- a/tests/SpiffWorkflow/camunda/MessageBoundaryEventTest.py
+++ b/tests/SpiffWorkflow/camunda/MessageBoundaryEventTest.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 from .BaseTestCase import BaseTestCase
 
 __author__ = 'kellym'
@@ -15,7 +16,7 @@ __author__ = 'kellym'
 class MessageBoundaryTest(BaseTestCase):
 
     def setUp(self):
-        self.script_engine = PythonScriptEngine(default_globals={"timedelta": timedelta})
+        self.script_engine = PythonScriptEngine(environment=TaskDataEnvironment({"timedelta": timedelta}))
         self.spec, self.subprocesses = self.load_workflow_spec('MessageBoundary.bpmn', 'Process_1kjyavs')
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses, script_engine=self.script_engine)
 

--- a/tests/SpiffWorkflow/camunda/MultiInstanceDMNTest.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceDMNTest.py
@@ -1,6 +1,8 @@
 import unittest
 
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import BoxedTaskDataEnvironment
 
 from .BaseTestCase import BaseTestCase
 
@@ -10,12 +12,13 @@ class MultiInstanceDMNTest(BaseTestCase):
         self.spec, subprocesses = self.load_workflow_spec(
             'DMNMultiInstance.bpmn', 'Process_1', 'test_integer_decision_multi.dmn')
         self.workflow = BpmnWorkflow(self.spec)
+        self.script_engine = PythonScriptEngine(environment=BoxedTaskDataEnvironment())
+        self.workflow.script_engine = self.script_engine
 
     def testConstructor(self):
         pass  # this is accomplished through setup.
 
     def testDmnHappy(self):
-        self.workflow = BpmnWorkflow(self.spec)
         self.workflow.do_engine_steps()
         self.workflow.complete_next()
         self.workflow.do_engine_steps()
@@ -25,16 +28,19 @@ class MultiInstanceDMNTest(BaseTestCase):
 
 
     def testDmnSaveRestore(self):
-        self.workflow = BpmnWorkflow(self.spec)
         self.save_restore()
+        self.workflow.script_engine = self.script_engine
         self.workflow.do_engine_steps()
         self.workflow.complete_next()
         self.save_restore()
+        self.workflow.script_engine = self.script_engine
         self.workflow.do_engine_steps()
         self.workflow.complete_next()
         self.save_restore()
+        self.workflow.script_engine = self.script_engine
         self.workflow.do_engine_steps()
         self.save_restore()
+        self.workflow.script_engine = self.script_engine
         self.assertEqual(self.workflow.data['stuff']['E']['y'], 'D')
 
 

--- a/tests/SpiffWorkflow/dmn/DecisionRunner.py
+++ b/tests/SpiffWorkflow/dmn/DecisionRunner.py
@@ -2,7 +2,7 @@ import os
 
 from lxml import etree
 
-from SpiffWorkflow.bpmn.PythonScriptEngine import Box
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import Box
 from SpiffWorkflow.dmn.engine.DMNEngine import DMNEngine
 from SpiffWorkflow.dmn.parser.DMNParser import DMNParser, get_dmn_ns
 

--- a/tests/SpiffWorkflow/dmn/feel_engine/FeelDictDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/feel_engine/FeelDictDecisionTest.py
@@ -1,6 +1,6 @@
 import unittest
 
-from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import Box
 
 from .FeelDecisionRunner import FeelDecisionRunner
 
@@ -19,7 +19,7 @@ class FeelDictDecisionTestClass(unittest.TestCase):
                 "PEANUTS": {"delicious": True},
                 "SPAM": {"delicious": False}
                 }}
-        PythonScriptEngine.convert_to_box(PythonScriptEngine(), data)
+        Box.convert_to_box(data)
         res = self.runner.decide(data)
         self.assertEqual(res.description, 'They are allergic to peanuts')
 

--- a/tests/SpiffWorkflow/dmn/feel_engine/FeelDictDotNotationDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/feel_engine/FeelDictDotNotationDecisionTest.py
@@ -1,6 +1,6 @@
 import unittest
 
-from SpiffWorkflow.bpmn.PythonScriptEngine import Box
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import Box
 
 from .FeelDecisionRunner import FeelDecisionRunner
 

--- a/tests/SpiffWorkflow/dmn/python_engine/DictDotNotationDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/python_engine/DictDotNotationDecisionTest.py
@@ -1,6 +1,6 @@
 import unittest
 
-from SpiffWorkflow.bpmn.PythonScriptEngine import Box
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import Box
 
 from .PythonDecisionRunner import PythonDecisionRunner
 

--- a/tests/SpiffWorkflow/dmn/python_engine/DictDotNotationDecisionWeirdCharactersTest.py
+++ b/tests/SpiffWorkflow/dmn/python_engine/DictDotNotationDecisionWeirdCharactersTest.py
@@ -1,6 +1,6 @@
 import unittest
 
-from SpiffWorkflow.bpmn.PythonScriptEngine import Box
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import Box
 
 from .PythonDecisionRunner import PythonDecisionRunner
 

--- a/tests/SpiffWorkflow/dmn/python_engine/PythonDecisionRunner.py
+++ b/tests/SpiffWorkflow/dmn/python_engine/PythonDecisionRunner.py
@@ -2,11 +2,12 @@ import datetime
 from decimal import Decimal
 
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
+from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import TaskDataEnvironment
 
 from ..DecisionRunner import DecisionRunner
 
 class PythonDecisionRunner(DecisionRunner):
 
     def __init__(self, filename):
-        scripting_additions={'Decimal': Decimal, 'datetime': datetime}
-        super().__init__(PythonScriptEngine(scripting_additions=scripting_additions), filename, 'python_engine')
+        environment = TaskDataEnvironment({'Decimal': Decimal, 'datetime': datetime})
+        super().__init__(PythonScriptEngine(environment=environment), filename, 'python_engine')


### PR DESCRIPTION
~Opening this as a draft while I test more and work on back end integration to start to gather feedback on the approach. Names and new public apis might be tweaked along the way.~ Edit: ready for review.

The current usage of task data to track the environment for the PythonScriptEngine is convenient but does lend itself to growing task data as the environment is copied from task to task. Larger workflows can run into issues with their task data size. This change provides a way for applications utilizing SpiffWorkflow to provide their own mechanism for tracking the state of the PythonScriptEngine between executions. If nothing is done the library works as it currently does.

Box was moved from the PythonScriptEngine proper to the PythonScriptEngineEnvrionment since custom environments may or may not want to Box.

If a custom environment is provided the application needs to properly restore it like it would for a PythonScriptEngine instance.