### PR TITLE
serialization fix

### DIFF
--- a/SpiffWorkflow/bpmn/serializer/helpers/dictionary.py
+++ b/SpiffWorkflow/bpmn/serializer/helpers/dictionary.py
@@ -15,11 +15,11 @@ class DictionaryConverter:
     by the converter.
 
     The (unqualified) class name will be used as the `typename` if one is not supplied.
-    You can optionally supply our own names (you'll need to do this if you use identically 
+    You can optionally supply our own names (you'll need to do this if you use identically
     named classes in multiple packages).
 
     When a dictionary is passed into `restore`, it will be checked for a `typename` key.
-    If a registered `typename` is found, the supplied `from_dict` function will be 
+    If a registered `typename` is found, the supplied `from_dict` function will be
     called.  Unrecognized objects will be returned as-is.
 
     For a simple example of how to use this class, see the `BpmnDataConverter` in
@@ -67,7 +67,7 @@ class DictionaryConverter:
         :param obj: the object to be converter
 
         Returns:
-            the dictionary representation for registered objects or the original
+            the dictionary representation for registered objects or an empty dictionary
             for unregistered objects
         """
         typename = self.typenames.get(obj.__class__)
@@ -79,7 +79,7 @@ class DictionaryConverter:
         elif isinstance(obj, (list, tuple, set)):
             return obj.__class__([ self.convert(item) for item in obj ])
         else:
-            return obj
+            return {}
 
     def restore(self, val):
         """


### PR DESCRIPTION
@essweine @danfunk
I am seeing below issue in serialization with unregistered objects.
- DictionaryConverter::convert() returns original spec object for un-registered specs.
- After above, BpmnProcessSpecConverter::to_dict() 
    ---> calls `self.convert_task_spec_extensions(self, task_spec, dct)` passing the spec object to `dct` and below code is
            throwing exception.
```
            if hasattr(task_spec, 'extensions'):
                dct.update({'extensions': task_spec.extensions})    # here dct is actually spec object.
```
```
  convert_task_spec_extensions
    dct.update({'extensions': task_spec.extensions})
AttributeError: 'BusinessRuleTask' object has no attribute 'update'
``` 

Also,  with below code in BpmnProcessSpecConverter::to_dict():
```
            dct['task_specs'][name] = task_dict ------->  Seeing below issue while printing the output.
```

 ```
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/__init__.py", line 234, in dumps
    return cls(
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/encoder.py", line 431, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/encoder.py", line 405, in _iterencode_dict
    yield from chunks
  [Previous line repeated 1 more time]
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/usr/local/Cellar/python@3.8/3.8.6/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type BusinessRuleTask is not JSON serializable
```

Solution:
- For unregistered spec objects, I am just returning an empty dict

