### PR TITLE
add checks for len == 0 when copying based on io spec

### DIFF
--- a/SpiffWorkflow/bpmn/specs/BpmnSpecMixin.py
+++ b/SpiffWorkflow/bpmn/specs/BpmnSpecMixin.py
@@ -77,7 +77,7 @@ class BpmnSpecMixin(TaskSpec):
             obj.get(my_task)
 
         # If an IO spec was given, require all inputs are present, and remove all other inputs.
-        if self.io_specification is not None:
+        if self.io_specification is not None and len(self.io_specification.data_inputs) > 0:
             data = {}
             for var in self.io_specification.data_inputs:
                 if var.name not in my_task.data:
@@ -89,7 +89,7 @@ class BpmnSpecMixin(TaskSpec):
 
     def _on_complete_hook(self, my_task):
 
-        if self.io_specification is not None:
+        if self.io_specification is not None and len(self.io_specification.data_outputs) > 0:
             data = {}
             for var in self.io_specification.data_outputs:
                 if var.name not in my_task.data:

--- a/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
+++ b/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
@@ -93,7 +93,7 @@ class CallActivity(SubWorkflowTask):
 
     def update_data(self, my_task, subworkflow):
 
-        if subworkflow.spec.io_specification is None:
+        if subworkflow.spec.io_specification is None or len(subworkflow.spec.io_specification.data_outputs) == 0:
             # Copy all workflow data if no outputs are specified
             my_task.data = deepcopy(subworkflow.last_task.data)
         else:


### PR DESCRIPTION
This adds checks on the input or output length when there is an io spec and copies all data in or out if input or output list is empty.

In my opinion, this is incorrect behavior.  However, since the editor can add empty ones without an author being aware of them, this is necessary, at least until we can get the editor working properly.