### PR TITLE
remove minidom and change method to take xml rather than a string

### DIFF
--- a/SpiffWorkflow/exceptions.py
+++ b/SpiffWorkflow/exceptions.py
@@ -124,8 +124,3 @@ class WorkflowTaskException(WorkflowException):
         # deeply nested in sub-workflows it is.  Takes the form of:
         # task-description (file-name)
         self.task_trace = self.get_task_trace(task)
-
-
-
-class StorageException(SpiffWorkflowException):
-    pass

--- a/SpiffWorkflow/specs/SubWorkflow.py
+++ b/SpiffWorkflow/specs/SubWorkflow.py
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
 import os
+from lxml import etree
 
 from .StartTask import StartTask
 from .base import TaskSpec
@@ -93,9 +94,8 @@ class SubWorkflow(TaskSpec):
         file_name = valueof(my_task, self.file)
         serializer = XmlSerializer()
         with open(file_name) as fp:
-            xml = fp.read()
-        wf_spec = WorkflowSpec.deserialize(
-            serializer, xml, filename=file_name)
+            xml = etree.parse(fp).getroot()
+        wf_spec = WorkflowSpec.deserialize(serializer, xml, filename=file_name)
         outer_workflow = my_task.workflow.outer_workflow
         return Workflow(wf_spec, parent=outer_workflow)
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,10 @@ setup(name='SpiffWorkflow',
       author_email='dan@sartography.com',
       license='lGPLv2',
       packages=find_packages(exclude=['tests', 'tests.*']),
-      package_data={'SpiffWorkflow.bpmn.parser.schema': ['*.xsd']},
+      package_data={
+          'SpiffWorkflow.bpmn.parser.schema': ['*.xsd'],
+          'SpiffWorkflow.dmn.parser.schema': ['*.xsd'],
+      },
       install_requires=['configparser', 'lxml', 'celery',
           # required for python 3.7 - https://stackoverflow.com/a/73932581
           'importlib-metadata<5.0; python_version <= "3.7"'],

--- a/tests/SpiffWorkflow/PatternTest.py
+++ b/tests/SpiffWorkflow/PatternTest.py
@@ -8,6 +8,8 @@ from lxml import etree
 from SpiffWorkflow.specs.WorkflowSpec import WorkflowSpec
 from SpiffWorkflow.task import Task
 from SpiffWorkflow.serializer.prettyxml import XmlSerializer
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from tests.SpiffWorkflow.util import run_workflow
 
 

--- a/tests/SpiffWorkflow/PatternTest.py
+++ b/tests/SpiffWorkflow/PatternTest.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-
-from builtins import object
 import sys
 import unittest
 import os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from lxml import etree
 
 from SpiffWorkflow.specs.WorkflowSpec import WorkflowSpec
 from SpiffWorkflow.task import Task
@@ -64,10 +63,9 @@ class PatternTest(unittest.TestCase):
         # Test patterns that are defined in XML format.
         if filename.endswith('.xml'):
             with open(filename) as fp:
-                xml = fp.read()
+                xml = etree.parse(fp).getroot()
             serializer = XmlSerializer()
-            wf_spec = WorkflowSpec.deserialize(
-                serializer, xml, filename=filename)
+            wf_spec = WorkflowSpec.deserialize(serializer, xml, filename=filename)
 
         # Test patterns that are defined in Python.
         elif filename.endswith('.py'):

--- a/tests/SpiffWorkflow/WorkflowTest.py
+++ b/tests/SpiffWorkflow/WorkflowTest.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
-
-import sys
 import unittest
 import os
-data_dir = os.path.join(os.path.dirname(__file__), 'data')
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+from lxml import etree
 
 from SpiffWorkflow.workflow import Workflow
 from SpiffWorkflow.specs.Cancel import Cancel
@@ -13,6 +10,7 @@ from SpiffWorkflow.specs.WorkflowSpec import WorkflowSpec
 from SpiffWorkflow.task import TaskState
 from SpiffWorkflow.serializer.prettyxml import XmlSerializer
 
+data_dir = os.path.join(os.path.dirname(__file__), 'data')
 
 class WorkflowTest(unittest.TestCase):
 
@@ -27,7 +25,7 @@ class WorkflowTest(unittest.TestCase):
         """
         xml_file = os.path.join(data_dir, 'spiff', 'workflow1.xml')
         with open(xml_file) as fp:
-            xml = fp.read()
+            xml = etree.parse(fp).getroot()
         wf_spec = WorkflowSpec.deserialize(XmlSerializer(), xml)
         workflow = Workflow(wf_spec)
 

--- a/tests/SpiffWorkflow/serializer/baseTest.py
+++ b/tests/SpiffWorkflow/serializer/baseTest.py
@@ -1,13 +1,6 @@
 # -*- coding: utf-8 -*-
-
-from builtins import str
-import sys
 import unittest
-import os
 import warnings
-dirname = os.path.dirname(__file__)
-data_dir = os.path.join(dirname, '..', 'data')
-sys.path.insert(0, os.path.join(dirname, '..'))
 
 from PatternTest import run_workflow, PatternTest
 from SpiffWorkflow.serializer.base import Serializer
@@ -26,10 +19,7 @@ class SerializerTest(PatternTest):
     def _prepare_result(self, item):
         return item
 
-    def _compare_results(self, item1, item2, exclude_dynamic=False,
-                         exclude_items=None):
-        #with open('1.xml', 'w') as fp: fp.write(item1)
-        #with open('2.xml', 'w') as fp: fp.write(item2)
+    def _compare_results(self, item1, item2):
         self.assertEqual(item1.decode('utf8'), item2.decode('utf8'))
 
     def _test_roundtrip_serialization(self, obj):

--- a/tests/SpiffWorkflow/serializer/dictTest.py
+++ b/tests/SpiffWorkflow/serializer/dictTest.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-
-from builtins import str
-import sys
 import unittest
-import os
-dirname = os.path.dirname(__file__)
-sys.path.insert(0, os.path.join(dirname, '..', '..', '..'))
-
 import uuid
+
 from SpiffWorkflow.serializer.dict import DictionarySerializer
 from .baseTest import SerializerTest
 from SpiffWorkflow.workflow import Workflow

--- a/tests/SpiffWorkflow/serializer/jsonTest.py
+++ b/tests/SpiffWorkflow/serializer/jsonTest.py
@@ -1,12 +1,7 @@
 # -*- coding: utf-8 -*-
-
-import sys
 import unittest
-import os
-dirname = os.path.dirname(__file__)
-sys.path.insert(0, os.path.join(dirname, '..', '..', '..'))
-
 import json
+
 from SpiffWorkflow.serializer.json import JSONSerializer
 from .dictTest import DictionarySerializerTest
 

--- a/tests/SpiffWorkflow/serializer/prettyxmlTest.py
+++ b/tests/SpiffWorkflow/serializer/prettyxmlTest.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
-
-import sys
 import unittest
-import os
-dirname = os.path.dirname(__file__)
-data_dir = os.path.join(dirname, '..', 'data')
-sys.path.insert(0, os.path.join(dirname, '..', '..', '..'))
 
 from SpiffWorkflow.serializer.prettyxml import XmlSerializer
 from .baseTest import SerializerTest

--- a/tests/SpiffWorkflow/serializer/xmlTest.py
+++ b/tests/SpiffWorkflow/serializer/xmlTest.py
@@ -1,13 +1,7 @@
 # -*- coding: utf-8 -*-
-
-import sys
 import unittest
-import os
-dirname = os.path.dirname(__file__)
-sys.path.insert(0, os.path.join(dirname, '..'))
-sys.path.insert(0, os.path.join(dirname, '..', '..', '..'))
-
 from lxml import etree
+
 from SpiffWorkflow.serializer.xml import XmlSerializer
 from serializer.baseTest import SerializerTest
 

--- a/tests/SpiffWorkflow/specs/SubWorkflowTest.py
+++ b/tests/SpiffWorkflow/specs/SubWorkflowTest.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
-
-import sys
 import unittest
 import os
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+from lxml import etree
 
 from SpiffWorkflow.specs.WorkflowSpec import WorkflowSpec
 from SpiffWorkflow.specs.SubWorkflow import SubWorkflow
@@ -26,11 +23,10 @@ class TaskSpecTest(unittest.TestCase):
         pass  # FIXME
 
     def load_workflow_spec(self, folder, f):
-        file = os.path.join(
-            os.path.dirname(__file__), '..', 'data', 'spiff', folder, f)
+        file = os.path.join(os.path.dirname(__file__), '..', 'data', 'spiff', folder, f)
         serializer = XmlSerializer()
         with open(file) as fp:
-            xml = fp.read()
+            xml = etree.parse(fp).getroot()
         self.wf_spec = WorkflowSpec.deserialize(
             serializer, xml, filename=file)
         self.workflow = Workflow(self.wf_spec)

--- a/tests/SpiffWorkflow/specs/WorkflowSpecTest.py
+++ b/tests/SpiffWorkflow/specs/WorkflowSpecTest.py
@@ -1,24 +1,22 @@
 # -*- coding: utf-8 -*-
-
-from builtins import zip
-from builtins import range
 import os
-import sys
 import unittest
-data_dir = os.path.join(os.path.dirname(__file__), '..', 'data')
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-
 import pickle
 from random import randint
+
+from lxml import etree
+
 try:
     from util import track_workflow
 except ImportError as e:
     from tests.SpiffWorkflow.util import track_workflow
+
 from SpiffWorkflow.workflow import Workflow
 from SpiffWorkflow.specs.Join import Join
 from SpiffWorkflow.specs.WorkflowSpec import WorkflowSpec
 from SpiffWorkflow.serializer.prettyxml import XmlSerializer
 
+data_dir = os.path.join(os.path.dirname(__file__), '..', 'data')
 serializer = XmlSerializer()
 data_file = 'data.pkl'
 
@@ -71,7 +69,6 @@ class WorkflowSpecTest(unittest.TestCase):
         workflow.complete_all()
         after = workflow.get_dump()
         self.assertTrue(workflow.is_completed(), 'Workflow not complete:' + after)
-        # taken_path = '\n'.join(taken_path) + '\n'
         if taken_path != expected_path:
             for taken, expected in zip(taken_path, expected_path):
                 print("TAKEN:   ", taken)
@@ -82,7 +79,7 @@ class WorkflowSpecTest(unittest.TestCase):
         # Read a complete workflow spec.
         xml_file = os.path.join(data_dir, 'spiff', 'workflow1.xml')
         with open(xml_file) as fp:
-            xml = fp.read()
+            xml = etree.parse(fp).getroot()
         path_file = os.path.splitext(xml_file)[0] + '.path'
         with open(path_file) as fp:
             expected_path = fp.read().strip().split('\n')


### PR DESCRIPTION
This replaces minidom with lxml in the prettyxml "serializer" (it's really a parser) and changes the `deserialize_workflow_spec` method to accept XML rather than a string.  It also removes from python 2 related an miscellaneous cruft from tests whose failures I had to investigate.