### PR TITLE
remove minidom

### DIFF
--- a/SpiffWorkflow/specs/SubWorkflow.py
+++ b/SpiffWorkflow/specs/SubWorkflow.py
@@ -18,6 +18,8 @@
 # 02110-1301  USA
 import os
 
+from lxml import etree
+
 from .StartTask import StartTask
 from .base import TaskSpec
 from ..task import TaskState
@@ -93,9 +95,8 @@ class SubWorkflow(TaskSpec):
         file_name = valueof(my_task, self.file)
         serializer = XmlSerializer()
         with open(file_name) as fp:
-            xml = fp.read()
-        wf_spec = WorkflowSpec.deserialize(
-            serializer, xml, filename=file_name)
+            xml = etree.parse(fp).getroot()
+        wf_spec = WorkflowSpec.deserialize(serializer, xml, filename=file_name)
         outer_workflow = my_task.workflow.outer_workflow
         return Workflow(wf_spec, parent=outer_workflow)
 

--- a/tests/SpiffWorkflow/PatternTest.py
+++ b/tests/SpiffWorkflow/PatternTest.py
@@ -6,6 +6,8 @@ import unittest
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
+from lxml import etree
+
 from SpiffWorkflow.specs.WorkflowSpec import WorkflowSpec
 from SpiffWorkflow.task import Task
 from SpiffWorkflow.serializer.prettyxml import XmlSerializer
@@ -64,7 +66,7 @@ class PatternTest(unittest.TestCase):
         # Test patterns that are defined in XML format.
         if filename.endswith('.xml'):
             with open(filename) as fp:
-                xml = fp.read()
+                xml = etree.parse(fp).getroot()
             serializer = XmlSerializer()
             wf_spec = WorkflowSpec.deserialize(
                 serializer, xml, filename=filename)

--- a/tests/SpiffWorkflow/WorkflowTest.py
+++ b/tests/SpiffWorkflow/WorkflowTest.py
@@ -6,6 +6,8 @@ import os
 data_dir = os.path.join(os.path.dirname(__file__), 'data')
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
+from lxml import etree
+
 from SpiffWorkflow.workflow import Workflow
 from SpiffWorkflow.specs.Cancel import Cancel
 from SpiffWorkflow.specs.Simple import Simple
@@ -27,7 +29,7 @@ class WorkflowTest(unittest.TestCase):
         """
         xml_file = os.path.join(data_dir, 'spiff', 'workflow1.xml')
         with open(xml_file) as fp:
-            xml = fp.read()
+            xml = etree.parse(fp).getroot()
         wf_spec = WorkflowSpec.deserialize(XmlSerializer(), xml)
         workflow = Workflow(wf_spec)
 

--- a/tests/SpiffWorkflow/specs/SubWorkflowTest.py
+++ b/tests/SpiffWorkflow/specs/SubWorkflowTest.py
@@ -4,6 +4,8 @@ import sys
 import unittest
 import os
 
+from lxml import etree
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
 from SpiffWorkflow.specs.WorkflowSpec import WorkflowSpec
@@ -30,7 +32,7 @@ class TaskSpecTest(unittest.TestCase):
             os.path.dirname(__file__), '..', 'data', 'spiff', folder, f)
         serializer = XmlSerializer()
         with open(file) as fp:
-            xml = fp.read()
+            xml = etree.parse(fp).getroot()
         self.wf_spec = WorkflowSpec.deserialize(
             serializer, xml, filename=file)
         self.workflow = Workflow(self.wf_spec)

--- a/tests/SpiffWorkflow/specs/WorkflowSpecTest.py
+++ b/tests/SpiffWorkflow/specs/WorkflowSpecTest.py
@@ -8,6 +8,8 @@ import unittest
 data_dir = os.path.join(os.path.dirname(__file__), '..', 'data')
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
 
+from lxml import etree
+
 import pickle
 from random import randint
 try:
@@ -82,7 +84,7 @@ class WorkflowSpecTest(unittest.TestCase):
         # Read a complete workflow spec.
         xml_file = os.path.join(data_dir, 'spiff', 'workflow1.xml')
         with open(xml_file) as fp:
-            xml = fp.read()
+            xml = etree.parse(fp).getroot()
         path_file = os.path.splitext(xml_file)[0] + '.path'
         with open(path_file) as fp:
             expected_path = fp.read().strip().split('\n')


### PR DESCRIPTION
This replaces `minidom` with `lxml` in `prettyxmlserializer` (which is actually a parser rather than a serializer), so that the entire codebase uses the same parser, changes `deserialize_workflow_spec` to take xml rather than parsing a string.