### PR TITLE
Feature/standardize task execution

### DIFF
--- a/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
+++ b/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
@@ -47,8 +47,8 @@ class _EndJoin(UnstructuredJoin):
 
         return force or len(waiting_tasks) == 0, waiting_tasks
 
-    def _on_complete_hook(self, my_task):
-        super(_EndJoin, self)._on_complete_hook(my_task)
+    def _on_ready_hook(self, my_task):
+        super(_EndJoin, self)._on_ready_hook(my_task)
         my_task.workflow.data.update(my_task.data)
 
 

--- a/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
+++ b/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
@@ -47,8 +47,8 @@ class _EndJoin(UnstructuredJoin):
 
         return force or len(waiting_tasks) == 0, waiting_tasks
 
-    def _on_ready_hook(self, my_task):
-        super(_EndJoin, self)._on_ready_hook(my_task)
+    def _run_hook(self, my_task):
+        super(_EndJoin, self)._run_hook(my_task)
         my_task.workflow.data.update(my_task.data)
 
 

--- a/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
+++ b/SpiffWorkflow/bpmn/specs/BpmnProcessSpec.py
@@ -48,8 +48,9 @@ class _EndJoin(UnstructuredJoin):
         return force or len(waiting_tasks) == 0, waiting_tasks
 
     def _run_hook(self, my_task):
-        super(_EndJoin, self)._run_hook(my_task)
+        result = super(_EndJoin, self)._run_hook(my_task)
         my_task.workflow.data.update(my_task.data)
+        return result
 
 
 class BpmnProcessSpec(WorkflowSpec):

--- a/SpiffWorkflow/bpmn/specs/InclusiveGateway.py
+++ b/SpiffWorkflow/bpmn/specs/InclusiveGateway.py
@@ -110,7 +110,7 @@ class InclusiveGateway(MultiChoice, UnstructuredJoin):
 
         return complete, waiting_tasks
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
         outputs = self._get_matching_outputs(my_task)
         if len(outputs) == 0:
             raise WorkflowTaskException(f'No conditions satisfied on gateway', task=my_task)

--- a/SpiffWorkflow/bpmn/specs/InclusiveGateway.py
+++ b/SpiffWorkflow/bpmn/specs/InclusiveGateway.py
@@ -110,7 +110,7 @@ class InclusiveGateway(MultiChoice, UnstructuredJoin):
 
         return complete, waiting_tasks
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         outputs = self._get_matching_outputs(my_task)
         if len(outputs) == 0:
             raise WorkflowTaskException(f'No conditions satisfied on gateway', task=my_task)

--- a/SpiffWorkflow/bpmn/specs/InclusiveGateway.py
+++ b/SpiffWorkflow/bpmn/specs/InclusiveGateway.py
@@ -115,6 +115,7 @@ class InclusiveGateway(MultiChoice, UnstructuredJoin):
         if len(outputs) == 0:
             raise WorkflowTaskException(f'No conditions satisfied on gateway', task=my_task)
         my_task._sync_children(outputs, TaskState.FUTURE)
+        return True
 
     @property
     def spec_type(self):

--- a/SpiffWorkflow/bpmn/specs/ScriptTask.py
+++ b/SpiffWorkflow/bpmn/specs/ScriptTask.py
@@ -29,10 +29,10 @@ class ScriptEngineTask(Simple, BpmnSpecMixin):
         """Please override for specific Implementations, see ScriptTask below for an example"""
         pass
 
-    def _on_ready_hook(self, task):
+    def _run_hook(self, task):
         try:
             self._execute(task)
-            super(ScriptEngineTask, self)._on_ready_hook(task)
+            super(ScriptEngineTask, self)._run_hook(task)
         except Exception as exc:
             task._set_state(TaskState.WAITING)
             raise exc

--- a/SpiffWorkflow/bpmn/specs/ScriptTask.py
+++ b/SpiffWorkflow/bpmn/specs/ScriptTask.py
@@ -36,7 +36,7 @@ class ScriptEngineTask(Simple, BpmnSpecMixin):
         except Exception as exc:
             task._set_state(TaskState.WAITING)
             raise exc
-
+        return True
 
 class ScriptTask(ScriptEngineTask):
 

--- a/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
+++ b/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
@@ -25,8 +25,8 @@ class SubWorkflowTask(BpmnSpecMixin):
     def spec_type(self):
         return 'Subprocess'
 
-    def _on_ready_hook(self, my_task):
-        super()._on_ready_hook(my_task)
+    def _run_hook(self, my_task):
+        super()._run_hook(my_task)
 
     def _on_subworkflow_completed(self, subworkflow, my_task):
         self.update_data(my_task, subworkflow)

--- a/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
+++ b/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
@@ -25,9 +25,6 @@ class SubWorkflowTask(BpmnSpecMixin):
     def spec_type(self):
         return 'Subprocess'
 
-    def _run_hook(self, my_task):
-        super()._run_hook(my_task)
-
     def _on_subworkflow_completed(self, subworkflow, my_task):
         self.update_data(my_task, subworkflow)
         my_task._set_state(TaskState.READY)

--- a/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
@@ -18,7 +18,6 @@
 # 02110-1301  USA
 
 from .event_types import ThrowingEvent, CatchingEvent
-from .event_definitions import CycleTimerEventDefinition
 from ..BpmnSpecMixin import BpmnSpecMixin
 from ....specs.Simple import Simple
 from ....task import TaskState
@@ -123,7 +122,7 @@ class BoundaryEvent(CatchingEvent):
         super(BoundaryEvent, self).catch(my_task, event_definition)
         # Would love to get rid of this statement and manage in the workflow
         # However, it is not really compatible with how boundary events work.
-        my_task.complete()
+        my_task.run()
 
 
 class EventBasedGateway(CatchingEvent):

--- a/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
@@ -66,7 +66,7 @@ class _BoundaryEventParent(Simple, BpmnSpecMixin):
     def spec_type(self):
         return 'Boundary Event Parent'
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
 
         # Clear any events that our children might have received and
         # wait for new events

--- a/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
@@ -73,6 +73,7 @@ class _BoundaryEventParent(Simple, BpmnSpecMixin):
         for child in my_task.children:
             if isinstance(child.task_spec, BoundaryEvent):
                 child.task_spec.event_definition.reset(child)
+                child._set_state(TaskState.WAITING)
 
     def _child_complete_hook(self, child_task):
 

--- a/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
@@ -74,6 +74,7 @@ class _BoundaryEventParent(Simple, BpmnSpecMixin):
             if isinstance(child.task_spec, BoundaryEvent):
                 child.task_spec.event_definition.reset(child)
                 child._set_state(TaskState.WAITING)
+        return True
 
     def _child_complete_hook(self, child_task):
 

--- a/SpiffWorkflow/bpmn/specs/events/event_types.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_types.py
@@ -67,12 +67,12 @@ class CatchingEvent(Simple, BpmnSpecMixin):
         elif my_task.state != TaskState.WAITING:
             my_task._set_state(TaskState.WAITING)
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
 
         if isinstance(self.event_definition, MessageEventDefinition):
             self.event_definition.update_task_data(my_task)
         self.event_definition.reset(my_task)
-        super(CatchingEvent, self)._on_ready_hook(my_task)
+        super(CatchingEvent, self)._run_hook(my_task)
 
     # This fixes the problem of boundary events remaining cancelled if the task is reused.
     # It pains me to add these methods, but unless we can get rid of the loop reset task we're stuck
@@ -96,6 +96,6 @@ class ThrowingEvent(Simple, BpmnSpecMixin):
         super(ThrowingEvent, self).__init__(wf_spec, name, **kwargs)
         self.event_definition = event_definition
 
-    def _on_ready_hook(self, my_task):
-        super(ThrowingEvent, self)._on_ready_hook(my_task)
+    def _run_hook(self, my_task):
+        super(ThrowingEvent, self)._run_hook(my_task)
         self.event_definition.throw(my_task)

--- a/SpiffWorkflow/bpmn/specs/events/event_types.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_types.py
@@ -72,7 +72,7 @@ class CatchingEvent(Simple, BpmnSpecMixin):
         if isinstance(self.event_definition, MessageEventDefinition):
             self.event_definition.update_task_data(my_task)
         self.event_definition.reset(my_task)
-        super(CatchingEvent, self)._run_hook(my_task)
+        return super(CatchingEvent, self)._run_hook(my_task)
 
     # This fixes the problem of boundary events remaining cancelled if the task is reused.
     # It pains me to add these methods, but unless we can get rid of the loop reset task we're stuck
@@ -99,3 +99,4 @@ class ThrowingEvent(Simple, BpmnSpecMixin):
     def _run_hook(self, my_task):
         super(ThrowingEvent, self)._run_hook(my_task)
         self.event_definition.throw(my_task)
+        return True

--- a/SpiffWorkflow/bpmn/workflow.py
+++ b/SpiffWorkflow/bpmn/workflow.py
@@ -251,7 +251,7 @@ class BpmnWorkflow(Workflow):
             for task in engine_steps:
                 if will_complete_task is not None:
                     will_complete_task(task)
-                task.complete()
+                task.run()
                 if did_complete_task is not None:
                     did_complete_task(task)
                 if task.task_spec.name == exit_at:

--- a/SpiffWorkflow/dmn/specs/BusinessRuleTask.py
+++ b/SpiffWorkflow/dmn/specs/BusinessRuleTask.py
@@ -23,10 +23,10 @@ class BusinessRuleTask(Simple, BpmnSpecMixin):
     def spec_class(self):
         return 'Business Rule Task'
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         try:
             my_task.data = DeepMerge.merge(my_task.data, self.dmnEngine.result(my_task))
-            super(BusinessRuleTask, self)._on_ready_hook(my_task)
+            super(BusinessRuleTask, self)._run_hook(my_task)
         except SpiffWorkflowException as we:
             we.add_note(f"Business Rule Task '{my_task.task_spec.description}'.")
             raise we

--- a/SpiffWorkflow/dmn/specs/BusinessRuleTask.py
+++ b/SpiffWorkflow/dmn/specs/BusinessRuleTask.py
@@ -34,4 +34,4 @@ class BusinessRuleTask(Simple, BpmnSpecMixin):
             error = WorkflowTaskException(str(e), task=my_task)
             error.add_note(f"Business Rule Task '{my_task.task_spec.description}'.")
             raise error
-
+        return True

--- a/SpiffWorkflow/specs/Cancel.py
+++ b/SpiffWorkflow/specs/Cancel.py
@@ -55,9 +55,8 @@ class Cancel(TaskSpec):
         if len(self.outputs) > 0:
             raise WorkflowException('Cancel with an output.', task_spec=self)
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
         my_task.workflow.cancel(self.cancel_successfully)
-        TaskSpec._on_complete_hook(self, my_task)
 
     def serialize(self, serializer):
         return serializer.serialize_cancel(self)

--- a/SpiffWorkflow/specs/Cancel.py
+++ b/SpiffWorkflow/specs/Cancel.py
@@ -57,6 +57,7 @@ class Cancel(TaskSpec):
 
     def _run_hook(self, my_task):
         my_task.workflow.cancel(self.cancel_successfully)
+        return True
 
     def serialize(self, serializer):
         return serializer.serialize_cancel(self)

--- a/SpiffWorkflow/specs/Cancel.py
+++ b/SpiffWorkflow/specs/Cancel.py
@@ -55,7 +55,7 @@ class Cancel(TaskSpec):
         if len(self.outputs) > 0:
             raise WorkflowException('Cancel with an output.', task_spec=self)
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         my_task.workflow.cancel(self.cancel_successfully)
 
     def serialize(self, serializer):

--- a/SpiffWorkflow/specs/CancelTask.py
+++ b/SpiffWorkflow/specs/CancelTask.py
@@ -34,6 +34,7 @@ class CancelTask(Trigger):
             cancel_tasks = my_task.workflow.get_task_spec_from_name(task_name)
             for cancel_task in my_task._get_root()._find_any(cancel_tasks):
                 cancel_task.cancel()
+        return True
 
     def serialize(self, serializer):
         return serializer.serialize_cancel_task(self)

--- a/SpiffWorkflow/specs/CancelTask.py
+++ b/SpiffWorkflow/specs/CancelTask.py
@@ -16,7 +16,6 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
-from .base import TaskSpec
 from .Trigger import Trigger
 
 
@@ -30,12 +29,11 @@ class CancelTask(Trigger):
     parallel split.
     """
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
         for task_name in self.context:
             cancel_tasks = my_task.workflow.get_task_spec_from_name(task_name)
             for cancel_task in my_task._get_root()._find_any(cancel_tasks):
                 cancel_task.cancel()
-        TaskSpec._on_complete_hook(self, my_task)
 
     def serialize(self, serializer):
         return serializer.serialize_cancel_task(self)

--- a/SpiffWorkflow/specs/CancelTask.py
+++ b/SpiffWorkflow/specs/CancelTask.py
@@ -29,7 +29,7 @@ class CancelTask(Trigger):
     parallel split.
     """
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         for task_name in self.context:
             cancel_tasks = my_task.workflow.get_task_spec_from_name(task_name)
             for cancel_task in my_task._get_root()._find_any(cancel_tasks):

--- a/SpiffWorkflow/specs/Choose.py
+++ b/SpiffWorkflow/specs/Choose.py
@@ -55,7 +55,7 @@ class Choose(Trigger):
         self.context = context
         self.choice = choice is not None and choice or []
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         context = my_task.workflow.get_task_spec_from_name(self.context)
         triggered = []
         for task in my_task.workflow.task_tree:

--- a/SpiffWorkflow/specs/Choose.py
+++ b/SpiffWorkflow/specs/Choose.py
@@ -55,7 +55,7 @@ class Choose(Trigger):
         self.context = context
         self.choice = choice is not None and choice or []
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
         context = my_task.workflow.get_task_spec_from_name(self.context)
         triggered = []
         for task in my_task.workflow.task_tree:
@@ -66,7 +66,6 @@ class Choose(Trigger):
                 triggered.append(task)
         for task in triggered:
             context._predict(task)
-        TaskSpec._on_complete_hook(self, my_task)
 
     def serialize(self, serializer):
         return serializer.serialize_choose(self)

--- a/SpiffWorkflow/specs/Choose.py
+++ b/SpiffWorkflow/specs/Choose.py
@@ -66,6 +66,7 @@ class Choose(Trigger):
                 triggered.append(task)
         for task in triggered:
             context._predict(task)
+        return True
 
     def serialize(self, serializer):
         return serializer.serialize_choose(self)

--- a/SpiffWorkflow/specs/ExclusiveChoice.py
+++ b/SpiffWorkflow/specs/ExclusiveChoice.py
@@ -70,7 +70,7 @@ class ExclusiveChoice(MultiChoice):
         spec = self._wf_spec.get_task_spec_from_name(self.default_task_spec)
         my_task._set_likely_task(spec)
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
 
         output = self._wf_spec.get_task_spec_from_name(self.default_task_spec)
         for condition, spec_name in self.cond_task_specs:

--- a/SpiffWorkflow/specs/ExclusiveChoice.py
+++ b/SpiffWorkflow/specs/ExclusiveChoice.py
@@ -75,6 +75,8 @@ class ExclusiveChoice(MultiChoice):
         my_task._sync_children([output], TaskState.FUTURE)
         for child in my_task.children:
             child.task_spec._predict(child, mask=TaskState.FUTURE|TaskState.PREDICTED_MASK)
+        
+        return True
 
     def serialize(self, serializer):
         return serializer.serialize_exclusive_choice(self)

--- a/SpiffWorkflow/specs/ExclusiveChoice.py
+++ b/SpiffWorkflow/specs/ExclusiveChoice.py
@@ -61,7 +61,7 @@ class ExclusiveChoice(MultiChoice):
         if self.default_task_spec is None:
             raise WorkflowException('A default output is required.', task_spec=self)
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
 
         output = self._wf_spec.get_task_spec_from_name(self.default_task_spec)
         for condition, spec_name in self.cond_task_specs:

--- a/SpiffWorkflow/specs/ExclusiveChoice.py
+++ b/SpiffWorkflow/specs/ExclusiveChoice.py
@@ -61,15 +61,6 @@ class ExclusiveChoice(MultiChoice):
         if self.default_task_spec is None:
             raise WorkflowException('A default output is required.', task_spec=self)
 
-    def _predict_hook(self, my_task):
-        # If the task's status is not predicted, we default to MAYBE
-        # for all it's outputs except the default choice, which is
-        # LIKELY.
-        # Otherwise, copy my own state to the children.
-        my_task._sync_children(self.outputs)
-        spec = self._wf_spec.get_task_spec_from_name(self.default_task_spec)
-        my_task._set_likely_task(spec)
-
     def _on_ready_hook(self, my_task):
 
         output = self._wf_spec.get_task_spec_from_name(self.default_task_spec)
@@ -82,6 +73,8 @@ class ExclusiveChoice(MultiChoice):
             raise WorkflowException(f'No conditions satisfied for {my_task.task_spec.name}', task_spec=self)
 
         my_task._sync_children([output], TaskState.FUTURE)
+        for child in my_task.children:
+            child.task_spec._predict(child, mask=TaskState.FUTURE|TaskState.PREDICTED_MASK)
 
     def serialize(self, serializer):
         return serializer.serialize_exclusive_choice(self)

--- a/SpiffWorkflow/specs/Join.py
+++ b/SpiffWorkflow/specs/Join.py
@@ -120,8 +120,7 @@ class Join(TaskSpec):
             # If the task is predicted with less outputs than he has
             # children, that means the prediction may be incomplete (for
             # example, because a prediction is not yet possible at this time).
-            if not child._is_definite() \
-                    and len(child.task_spec.outputs) > len(child.children):
+            if child._is_predicted() and len(child.task_spec.outputs) > len(child.children):
                 return True
         return False
 

--- a/SpiffWorkflow/specs/MultiChoice.py
+++ b/SpiffWorkflow/specs/MultiChoice.py
@@ -125,7 +125,7 @@ class MultiChoice(TaskSpec):
                 outputs.append(self._wf_spec.get_task_spec_from_name(output))
         return outputs
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
         """
         Runs the task. Should not be called directly.
         Returns True if completed, False otherwise.

--- a/SpiffWorkflow/specs/MultiChoice.py
+++ b/SpiffWorkflow/specs/MultiChoice.py
@@ -111,7 +111,7 @@ class MultiChoice(TaskSpec):
                 outputs.append(self._wf_spec.get_task_spec_from_name(output))
         return outputs
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         """Runs the task. Should not be called directly."""
         my_task._sync_children(self._get_matching_outputs(my_task), TaskState.FUTURE)
         for child in my_task.children:

--- a/SpiffWorkflow/specs/MultiChoice.py
+++ b/SpiffWorkflow/specs/MultiChoice.py
@@ -116,6 +116,7 @@ class MultiChoice(TaskSpec):
         my_task._sync_children(self._get_matching_outputs(my_task), TaskState.FUTURE)
         for child in my_task.children:
             child.task_spec._predict(child, mask=TaskState.FUTURE|TaskState.PREDICTED_MASK)
+        return True
 
     def serialize(self, serializer):
         return serializer.serialize_multi_choice(self)

--- a/SpiffWorkflow/specs/MultiInstance.py
+++ b/SpiffWorkflow/specs/MultiInstance.py
@@ -87,7 +87,7 @@ class MultiInstance(TaskSpec):
         else:
             my_task._sync_children(outputs, TaskState.LIKELY)
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         outputs = self._get_predicted_outputs(my_task)
         my_task._sync_children(outputs, TaskState.FUTURE)
         self._predict(my_task, mask=TaskState.FUTURE|TaskState.PREDICTED_MASK)

--- a/SpiffWorkflow/specs/MultiInstance.py
+++ b/SpiffWorkflow/specs/MultiInstance.py
@@ -99,7 +99,7 @@ class MultiInstance(TaskSpec):
         else:
             my_task._sync_children(outputs, TaskState.LIKELY)
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
         outputs = self._get_predicted_outputs(my_task)
         my_task._sync_children(outputs, TaskState.FUTURE)
 

--- a/SpiffWorkflow/specs/MultiInstance.py
+++ b/SpiffWorkflow/specs/MultiInstance.py
@@ -91,6 +91,7 @@ class MultiInstance(TaskSpec):
         outputs = self._get_predicted_outputs(my_task)
         my_task._sync_children(outputs, TaskState.FUTURE)
         self._predict(my_task, mask=TaskState.FUTURE|TaskState.PREDICTED_MASK)
+        return True
 
     def serialize(self, serializer):
         return serializer.serialize_multi_instance(self)

--- a/SpiffWorkflow/specs/ReleaseMutex.py
+++ b/SpiffWorkflow/specs/ReleaseMutex.py
@@ -47,10 +47,9 @@ class ReleaseMutex(TaskSpec):
         TaskSpec.__init__(self, wf_spec, name, **kwargs)
         self.mutex = mutex
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
         mutex = my_task.workflow._get_mutex(self.mutex)
         mutex.unlock()
-        TaskSpec._on_complete_hook(self, my_task)
 
     def serialize(self, serializer):
         return serializer.serialize_release_mutex(self)

--- a/SpiffWorkflow/specs/ReleaseMutex.py
+++ b/SpiffWorkflow/specs/ReleaseMutex.py
@@ -50,6 +50,7 @@ class ReleaseMutex(TaskSpec):
     def _run_hook(self, my_task):
         mutex = my_task.workflow._get_mutex(self.mutex)
         mutex.unlock()
+        return True
 
     def serialize(self, serializer):
         return serializer.serialize_release_mutex(self)

--- a/SpiffWorkflow/specs/ReleaseMutex.py
+++ b/SpiffWorkflow/specs/ReleaseMutex.py
@@ -47,7 +47,7 @@ class ReleaseMutex(TaskSpec):
         TaskSpec.__init__(self, wf_spec, name, **kwargs)
         self.mutex = mutex
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         mutex = my_task.workflow._get_mutex(self.mutex)
         mutex.unlock()
 

--- a/SpiffWorkflow/specs/SubWorkflow.py
+++ b/SpiffWorkflow/specs/SubWorkflow.py
@@ -115,6 +115,7 @@ class SubWorkflow(TaskSpec):
             for assignment in self.in_assign:
                 assignment.assign(my_task, child)
             child.task_spec._update(child)
+        return True
 
     def _update_hook(self, my_task):
         super()._update_hook(my_task)

--- a/SpiffWorkflow/specs/SubWorkflow.py
+++ b/SpiffWorkflow/specs/SubWorkflow.py
@@ -108,7 +108,7 @@ class SubWorkflow(TaskSpec):
         my_task._set_internal_data(subworkflow=subworkflow)
         my_task._set_state(TaskState.WAITING)
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         # Assign variables, if so requested.
         subworkflow = my_task._get_internal_data('subworkflow')
         for child in subworkflow.task_tree.children:

--- a/SpiffWorkflow/specs/ThreadMerge.py
+++ b/SpiffWorkflow/specs/ThreadMerge.py
@@ -62,8 +62,7 @@ class ThreadMerge(Join):
         # task that did the conditional parallel split.
         split_task = my_task._find_ancestor_from_name(self.split_task)
         if split_task is None:
-            msg = 'Join with %s, which was not reached' % self.split_task
-            raise WorkflowException(msg, task_spec=self)
+            raise WorkflowException(f'Join with %s, which was not reached {self.split_task}', task_spec=self)
         tasks = split_task.task_spec._get_activated_threads(split_task)
 
         # The default threshold is the number of threads that were started.
@@ -105,8 +104,7 @@ class ThreadMerge(Join):
             my_task._set_state(TaskState.WAITING)
             return
 
-        split_task_spec = my_task.workflow.get_task_spec_from_name(
-            self.split_task)
+        split_task_spec = my_task.workflow.get_task_spec_from_name(self.split_task)
         split_task = my_task._find_ancestor(split_task_spec)
 
         # Find the inbound task that was completed last.

--- a/SpiffWorkflow/specs/ThreadSplit.py
+++ b/SpiffWorkflow/specs/ThreadSplit.py
@@ -122,7 +122,7 @@ class ThreadSplit(TaskSpec):
         else:
             my_task._sync_children(outputs, TaskState.LIKELY)
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         outputs = self._get_predicted_outputs(my_task)
         my_task._sync_children(outputs, TaskState.FUTURE)
 

--- a/SpiffWorkflow/specs/ThreadSplit.py
+++ b/SpiffWorkflow/specs/ThreadSplit.py
@@ -124,7 +124,7 @@ class ThreadSplit(TaskSpec):
         else:
             my_task._sync_children(outputs, TaskState.LIKELY)
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
         # Split, and remember the number of splits in the context data.
         split_n = int(valueof(my_task, self.times))
 

--- a/SpiffWorkflow/specs/ThreadSplit.py
+++ b/SpiffWorkflow/specs/ThreadSplit.py
@@ -125,6 +125,7 @@ class ThreadSplit(TaskSpec):
     def _run_hook(self, my_task):
         outputs = self._get_predicted_outputs(my_task)
         my_task._sync_children(outputs, TaskState.FUTURE)
+        return True
 
     def serialize(self, serializer):
         return serializer.serialize_thread_split(self)

--- a/SpiffWorkflow/specs/ThreadStart.py
+++ b/SpiffWorkflow/specs/ThreadStart.py
@@ -46,6 +46,7 @@ class ThreadStart(TaskSpec):
     def _run_hook(self, my_task):
         my_task._assign_new_thread_id()
         my_task._sync_children(self.outputs, TaskState.READY)
+        return True
 
     def serialize(self, serializer):
         return serializer.serialize_thread_start(self)

--- a/SpiffWorkflow/specs/ThreadStart.py
+++ b/SpiffWorkflow/specs/ThreadStart.py
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
 from .base import TaskSpec
+from SpiffWorkflow.task import TaskState
 
 
 class ThreadStart(TaskSpec):
@@ -44,6 +45,7 @@ class ThreadStart(TaskSpec):
 
     def _on_ready_hook(self, my_task):
         my_task._assign_new_thread_id()
+        my_task._sync_children(self.outputs, TaskState.READY)
 
     def serialize(self, serializer):
         return serializer.serialize_thread_start(self)

--- a/SpiffWorkflow/specs/ThreadStart.py
+++ b/SpiffWorkflow/specs/ThreadStart.py
@@ -43,7 +43,7 @@ class ThreadStart(TaskSpec):
         TaskSpec.__init__(self, wf_spec, name, **kwargs)
         self.internal = True
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         my_task._assign_new_thread_id()
         my_task._sync_children(self.outputs, TaskState.READY)
 

--- a/SpiffWorkflow/specs/ThreadStart.py
+++ b/SpiffWorkflow/specs/ThreadStart.py
@@ -42,9 +42,8 @@ class ThreadStart(TaskSpec):
         TaskSpec.__init__(self, wf_spec, name, **kwargs)
         self.internal = True
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
         my_task._assign_new_thread_id()
-        TaskSpec._on_complete_hook(self, my_task)
 
     def serialize(self, serializer):
         return serializer.serialize_thread_start(self)

--- a/SpiffWorkflow/specs/Trigger.py
+++ b/SpiffWorkflow/specs/Trigger.py
@@ -71,7 +71,7 @@ class Trigger(TaskSpec):
                 task._set_state(TaskState.FUTURE)
                 task._ready()
 
-    def _on_ready_hook(self, my_task):
+    def _run_hook(self, my_task):
         """
         A hook into _on_complete() that does the task specific work.
 

--- a/SpiffWorkflow/specs/Trigger.py
+++ b/SpiffWorkflow/specs/Trigger.py
@@ -73,7 +73,7 @@ class Trigger(TaskSpec):
                 thetask._set_state(TaskState.FUTURE)
                 thetask._ready()
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
         """
         A hook into _on_complete() that does the task specific work.
 

--- a/SpiffWorkflow/specs/Trigger.py
+++ b/SpiffWorkflow/specs/Trigger.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from builtins import range
 # Copyright (C) 2007 Samuel Abels
 #
 # This library is free software; you can redistribute it and/or
@@ -65,13 +64,12 @@ class Trigger(TaskSpec):
         self.queued += 1
         # All tasks that have already completed need to be put back to
         # READY.
-        for thetask in my_task.workflow.task_tree:
-            if thetask.thread_id != my_task.thread_id:
+        for task in my_task.workflow.task_tree:
+            if task.thread_id != my_task.thread_id:
                 continue
-            if (thetask.task_spec == self and
-                    thetask._has_state(TaskState.COMPLETED)):
-                thetask._set_state(TaskState.FUTURE)
-                thetask._ready()
+            if task.task_spec == self and task._has_state(TaskState.COMPLETED):
+                task._set_state(TaskState.FUTURE)
+                task._ready()
 
     def _on_ready_hook(self, my_task):
         """

--- a/SpiffWorkflow/specs/Trigger.py
+++ b/SpiffWorkflow/specs/Trigger.py
@@ -86,6 +86,7 @@ class Trigger(TaskSpec):
                 task_spec = my_task.workflow.get_task_spec_from_name(task_name)
                 task_spec._on_trigger(my_task)
         self.queued = 0
+        return True
 
     def serialize(self, serializer):
         return serializer.serialize_trigger(self)

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -253,8 +253,8 @@ class TaskSpec(object):
         """
         if my_task._is_predicted():
             self._predict(my_task)
-        self.entered_event.emit(my_task.workflow, my_task)
         if self._update_hook(my_task):
+            self.entered_event.emit(my_task.workflow, my_task)
             my_task._ready()
 
     def _update_hook(self, my_task):
@@ -276,23 +276,6 @@ class TaskSpec(object):
         assert my_task is not None
         self.test()
 
-        # Assign variables, if so requested.
-        for assignment in self.pre_assign:
-            assignment.assign(my_task, my_task)
-
-        # Run task-specific code.
-        self._on_ready_before_hook(my_task)
-        self.reached_event.emit(my_task.workflow, my_task)
-        self._on_ready_hook(my_task)
-
-        # Run user code, if any.
-        if self.ready_event.emit(my_task.workflow, my_task):
-            # Assign variables, if so requested.
-            for assignment in self.post_assign:
-                assignment.assign(my_task, my_task)
-
-        self.finished_event.emit(my_task.workflow, my_task)
-
     def _on_ready_before_hook(self, my_task):
         """
         A hook into _on_ready() that does the task specific work.
@@ -310,6 +293,26 @@ class TaskSpec(object):
         :param my_task: The associated task in the task tree.
         """
         pass
+
+    def _run(self, my_task):
+
+        # Assign variables, if so requested.
+        for assignment in self.pre_assign:
+            assignment.assign(my_task, my_task)
+
+        # Run task-specific code.
+        self._on_ready_before_hook(my_task)
+        self.reached_event.emit(my_task.workflow, my_task)
+        self._on_ready_hook(my_task)
+
+        # Run user code, if any.
+        if self.ready_event.emit(my_task.workflow, my_task):
+            # Assign variables, if so requested.
+            for assignment in self.post_assign:
+                assignment.assign(my_task, my_task)
+
+        self.finished_event.emit(my_task.workflow, my_task)
+        return True
 
     def _on_cancel(self, my_task):
         """
@@ -355,7 +358,7 @@ class TaskSpec(object):
         my_task.workflow._task_completed_notify(my_task)
 
         self.completed_event.emit(my_task.workflow, my_task)
-        return True
+
 
     def _on_complete_hook(self, my_task):
         """

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -252,8 +252,8 @@ class TaskSpec(object):
         """
         if my_task._is_predicted():
             self._predict(my_task)
+        self.entered_event.emit(my_task.workflow, my_task)
         if self._update_hook(my_task):
-            self.entered_event.emit(my_task.workflow, my_task)
             my_task._ready()
 
     def _update_hook(self, my_task):

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -275,14 +275,13 @@ class TaskSpec(object):
         assert my_task is not None
         self.test()
 
-    def _on_ready_before_hook(self, my_task):
-        """
-        A hook into _on_ready() that does the task specific work.
+        # Assign variables, if so requested.
+        for assignment in self.pre_assign:
+            assignment.assign(my_task, my_task)
 
-        :type  my_task: Task
-        :param my_task: The associated task in the task tree.
-        """
-        pass
+        # Run task-specific code.
+        self._on_ready_hook(my_task)
+        self.reached_event.emit(my_task.workflow, my_task)
 
     def _on_ready_hook(self, my_task):
         """
@@ -295,14 +294,7 @@ class TaskSpec(object):
 
     def _run(self, my_task):
 
-        # Assign variables, if so requested.
-        for assignment in self.pre_assign:
-            assignment.assign(my_task, my_task)
-
-        # Run task-specific code.
-        self._on_ready_before_hook(my_task)
-        self.reached_event.emit(my_task.workflow, my_task)
-        self._on_ready_hook(my_task)
+        self._run_hook(my_task)
 
         # Run user code, if any.
         if self.ready_event.emit(my_task.workflow, my_task):
@@ -312,6 +304,15 @@ class TaskSpec(object):
 
         self.finished_event.emit(my_task.workflow, my_task)
         return True
+
+    def _run_hook(self, my_task):
+        """
+        A hook into _run() that does the task specific work.
+
+        :type  my_task: Task
+        :param my_task: The associated task in the task tree.
+        """
+        pass
 
     def _on_cancel(self, my_task):
         """

--- a/SpiffWorkflow/workflow.py
+++ b/SpiffWorkflow/workflow.py
@@ -73,7 +73,7 @@ class Workflow(object):
 
         start = self.task_tree._add_child(self.spec.start, state=TaskState.FUTURE)
 
-        self.spec.start._predict(start)
+        self.spec.start._predict(start, mask=TaskState.FUTURE|TaskState.PREDICTED_MASK)
         if 'parent' not in kwargs:
             start.task_spec._update(start)
 

--- a/SpiffWorkflow/workflow.py
+++ b/SpiffWorkflow/workflow.py
@@ -248,7 +248,7 @@ class Workflow(object):
         msg = 'A task with the given task_id (%s) was not found' % task_id
         raise WorkflowException(msg, task_spec=self.spec)
 
-    def complete_task_from_id(self, task_id):
+    def run_task_from_id(self, task_id):
         """
         Runs the task with the given id.
 
@@ -256,7 +256,7 @@ class Workflow(object):
         :param task_id: The id of the Task object.
         """
         task = self.get_task_from_id(task_id)
-        return task.complete()
+        return task.run()
 
     def reset_task_from_id(self, task_id):
         """
@@ -274,7 +274,7 @@ class Workflow(object):
         task = self.get_task_from_id(task_id)
         return task.reset_token(data)
 
-    def complete_next(self, pick_up=True, halt_on_manual=True):
+    def run_next(self, pick_up=True, halt_on_manual=True):
         """
         Runs the next task.
         Returns True if completed, False otherwise.
@@ -302,7 +302,7 @@ class Workflow(object):
             self.last_task = None
             if task is not None:
                 if not (halt_on_manual and task.task_spec.manual):
-                    if task.complete():
+                    if task.run():
                         self.last_task = task
                         return True
                 blacklist.append(task)
@@ -313,7 +313,7 @@ class Workflow(object):
                 if task._is_descendant_of(blacklisted_task):
                     continue
             if not (halt_on_manual and task.task_spec.manual):
-                if task.complete():
+                if task.run():
                     self.last_task = task
                     return True
             blacklist.append(task)
@@ -326,7 +326,7 @@ class Workflow(object):
                 return True
         return False
 
-    def complete_all(self, pick_up=True, halt_on_manual=True):
+    def run_all(self, pick_up=True, halt_on_manual=True):
         """
         Runs all branches until completion. This is a convenience wrapper
         around :meth:`complete_next`, and the pick_up argument is passed
@@ -339,7 +339,7 @@ class Workflow(object):
                         complete any tasks that have manual=True.
                         See :meth:`SpiffWorkflow.specs.TaskSpec.__init__`
         """
-        while self.complete_next(pick_up, halt_on_manual):
+        while self.run_next(pick_up, halt_on_manual):
             pass
 
     def get_dump(self):

--- a/doc/non-bpmn/tutorial/start.py
+++ b/doc/non-bpmn/tutorial/start.py
@@ -19,7 +19,7 @@ workflow = Workflow(spec)
 # Execute until all tasks are done or require manual intervention.
 # For the sake of this tutorial, we ignore the "manual" flag on the
 # tasks. In practice, you probably don't want to do that.
-workflow.complete_all(halt_on_manual=False)
+workflow.run_all(halt_on_manual=False)
 
 # Alternatively, this is what a UI would do for a manual task.
 #workflow.complete_task_from_id(...)

--- a/tests/SpiffWorkflow/bpmn/BpmnLoaderForTests.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnLoaderForTests.py
@@ -34,7 +34,7 @@ class TestUserTask(UserTask):
 
     def do_choice(self, task, choice):
         task.set_data(choice=choice)
-        task.complete()
+        task.run()
 
 
 class TestExclusiveGatewayParser(ConditionalGatewayParser):

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
@@ -116,7 +116,7 @@ class BpmnWorkflowTestCase(unittest.TestCase):
 
         if set_attribs:
             tasks[0].set_data(**set_attribs)
-        tasks[0].complete()
+        tasks[0].run()
 
     def save_restore(self):
 

--- a/tests/SpiffWorkflow/bpmn/CollaborationTest.py
+++ b/tests/SpiffWorkflow/bpmn/CollaborationTest.py
@@ -82,7 +82,7 @@ class CollaborationTest(BpmnWorkflowTestCase):
         workflow.do_engine_steps()
         for idx, task in enumerate(workflow.get_ready_user_tasks()):
             task.data['task_num'] = idx
-            task.complete()
+            task.run()
         workflow.do_engine_steps()
         ready_tasks = workflow.get_ready_user_tasks()
         waiting = workflow.get_tasks_from_spec_name('get_response')
@@ -94,7 +94,7 @@ class CollaborationTest(BpmnWorkflowTestCase):
         # Now copy the task_num that was sent into a new variable
         for task in ready_tasks:
             task.data.update(init_id=task.data['task_num'])
-            task.complete()
+            task.run()
         workflow.do_engine_steps()
         # If the messages were routed properly, the id should match
         for task in workflow.get_tasks_from_spec_name('subprocess_end'):
@@ -108,7 +108,7 @@ class CollaborationTest(BpmnWorkflowTestCase):
         workflow.do_engine_steps()
         for idx, task in enumerate(workflow.get_ready_user_tasks()):
             task.data['task_num'] = idx
-            task.complete()
+            task.run()
         workflow.do_engine_steps()
 
         # Two processes should have been started and two corresponding catch events should be waiting
@@ -121,12 +121,12 @@ class CollaborationTest(BpmnWorkflowTestCase):
         # Now copy the task_num that was sent into a new variable
         for task in ready_tasks:
             task.data.update(init_id=task.data['task_num'])
-            task.complete()
+            task.run()
         workflow.do_engine_steps()
 
         # Complete dummy tasks
         for task in workflow.get_ready_user_tasks():
-            task.complete()
+            task.run()
         workflow.do_engine_steps()
 
         # Repeat for the other process, using a different mapped name
@@ -136,7 +136,7 @@ class CollaborationTest(BpmnWorkflowTestCase):
         self.assertEqual(len(waiting), 2)
         for task in ready_tasks:
             task.data.update(subprocess=task.data['task_num'])
-            task.complete()
+            task.run()
         workflow.do_engine_steps()
 
         # If the messages were routed properly, the id should match

--- a/tests/SpiffWorkflow/bpmn/DataObjectReferenceTest.py
+++ b/tests/SpiffWorkflow/bpmn/DataObjectReferenceTest.py
@@ -22,13 +22,13 @@ class DataObjectReferenceTest(BpmnWorkflowTestCase):
         # Add the data so that we can advance the workflow
         ready_tasks = self.workflow.get_ready_user_tasks()
         ready_tasks[0].data = { 'obj_1': 'hello' }
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
 
         # Remove the data before advancing
         ready_tasks = self.workflow.get_ready_user_tasks()
         self.workflow.data.pop('obj_1')
         with self.assertRaises(WorkflowDataException) as exc:
-            ready_tasks[0].complete()
+            ready_tasks[0].run()
             self.assertEqual(exc.data_output.name, 'obj_1')
 
     def testMissingDataOutput(self):
@@ -37,7 +37,7 @@ class DataObjectReferenceTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
         ready_tasks = self.workflow.get_ready_user_tasks()
         with self.assertRaises(WorkflowDataException) as exc:
-            ready_tasks[0].complete()
+            ready_tasks[0].run()
             self.assertEqual(exc.data_output.name, 'obj_1')
 
     def actual_test(self, save_restore):
@@ -48,7 +48,7 @@ class DataObjectReferenceTest(BpmnWorkflowTestCase):
         # Set up the data
         ready_tasks = self.workflow.get_ready_user_tasks()
         ready_tasks[0].data = { 'obj_1': 'hello' }
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         # After task completion, obj_1 should be copied out of the task into the workflow
         self.assertNotIn('obj_1', ready_tasks[0].data)
         self.assertIn('obj_1', self.workflow.data)
@@ -59,14 +59,14 @@ class DataObjectReferenceTest(BpmnWorkflowTestCase):
         # Set a value for obj_1 in the task data again
         ready_tasks = self.workflow.get_ready_user_tasks()
         ready_tasks[0].data = { 'obj_1': 'hello again' }
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
 
         # Check to make sure we use the workflow value instead of the value we set
         ready_tasks = self.workflow.get_ready_user_tasks()
         self.assertEqual(ready_tasks[0].data['obj_1'], 'hello')
         # Modify the value in the task
         ready_tasks[0].data = { 'obj_1': 'hello again' }
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         # We did not set an output data reference so obj_1 should remain unchanged in the workflow data
         # and be removed from the task data
         self.assertNotIn('obj_1', ready_tasks[0].data)
@@ -77,7 +77,7 @@ class DataObjectReferenceTest(BpmnWorkflowTestCase):
         ready_tasks = self.workflow.get_ready_user_tasks()
         self.assertEqual(ready_tasks[0].data['obj_1'], 'hello')
         ready_tasks[0].data['obj_1'] = 'hello again'
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
         sp = self.workflow.get_tasks_from_spec_name('subprocess')[0]
         # It was copied out

--- a/tests/SpiffWorkflow/bpmn/IOSpecTest.py
+++ b/tests/SpiffWorkflow/bpmn/IOSpecTest.py
@@ -76,7 +76,7 @@ class CallActivityDataTest(BpmnWorkflowTestCase):
         waiting = self.workflow.get_tasks(TaskState.WAITING)
         while len(waiting) == 0:
             next_task = self.workflow.get_tasks(TaskState.READY)[0]
-            next_task.complete()
+            next_task.run()
             waiting = self.workflow.get_tasks(TaskState.WAITING)
 
     def complete_subprocess(self):
@@ -84,7 +84,7 @@ class CallActivityDataTest(BpmnWorkflowTestCase):
         waiting = self.workflow.get_tasks(TaskState.WAITING)
         while len(waiting) > 0:
             next_task = self.workflow.get_tasks(TaskState.READY)[0]
-            next_task.complete()
+            next_task.run()
             waiting = self.workflow.get_tasks(TaskState.WAITING)
 
 
@@ -113,7 +113,7 @@ class IOSpecOnTaskTest(BpmnWorkflowTestCase):
         task = self.workflow.get_tasks_from_spec_name('any_task')[0]
         task.data.update({'out_1': 1})
         with self.assertRaises(WorkflowDataException) as exc:
-            task.complete()
+            task.run()
         self.assertEqual(exc.exception.data_output.name, 'out_2')
 
     def actual_test(self, save_restore=False):
@@ -124,6 +124,6 @@ class IOSpecOnTaskTest(BpmnWorkflowTestCase):
         task = self.workflow.get_tasks_from_spec_name('any_task')[0]
         self.assertDictEqual(task.data, {'in_1': 1, 'in_2': 'hello world'})
         task.data.update({'out_1': 1, 'out_2': 'bye', 'extra': True})
-        task.complete()
+        task.run()
         self.workflow.do_engine_steps()
         self.assertDictEqual(self.workflow.last_task.data, {'out_1': 1, 'out_2': 'bye'})

--- a/tests/SpiffWorkflow/bpmn/InclusiveGatewayTest.py
+++ b/tests/SpiffWorkflow/bpmn/InclusiveGatewayTest.py
@@ -36,4 +36,4 @@ class InclusiveGatewayTest(BpmnWorkflowTestCase):
     def set_data(self, value):
         task = self.workflow.get_ready_user_tasks()[0]
         task.data = value
-        task.complete()
+        task.run()

--- a/tests/SpiffWorkflow/bpmn/ParallelMultiInstanceTest.py
+++ b/tests/SpiffWorkflow/bpmn/ParallelMultiInstanceTest.py
@@ -26,7 +26,7 @@ class BaseTestCase(BpmnWorkflowTestCase):
             self.assertEqual(task.task_spec.name, 'any_task [child]')
             self.assertIn('input_item', task.data)
             task.data['output_item'] = task.data['input_item'] * 2
-            task.complete()
+            task.run()
             if save_restore:
                 self.save_restore()
             ready_tasks = self.workflow.get_ready_user_tasks()
@@ -47,7 +47,7 @@ class BaseTestCase(BpmnWorkflowTestCase):
         self.assertEqual(len(ready_tasks), 3)
         task = [t for t in ready_tasks if t.data['input_item'] == 2][0]
         task.data['output_item'] = task.data['input_item'] * 2
-        task.complete()
+        task.run()
         self.workflow.do_engine_steps()
         self.workflow.refresh_waiting_tasks()
         

--- a/tests/SpiffWorkflow/bpmn/ParallelThroughSameTaskTest.py
+++ b/tests/SpiffWorkflow/bpmn/ParallelThroughSameTaskTest.py
@@ -51,7 +51,7 @@ class ParallelThroughSameTaskTest(BpmnWorkflowTestCase):
         self.assertEqual(2, len(ready_tasks))
         self.assertEqual(
             'Repeated Task', ready_tasks[0].task_spec.description)
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
         # The inclusive gateway allows us through here, because there is no route for the other thread
         # that doesn't use the same sequence flow
@@ -82,7 +82,7 @@ class ParallelThroughSameTaskTest(BpmnWorkflowTestCase):
         self.assertEqual(2, len(ready_tasks))
         self.assertEqual(
             'Repeated Task', ready_tasks[0].task_spec.description)
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
         self.save_restore()
         # The inclusive gateway allows us through here, because there is no route for the other thread

--- a/tests/SpiffWorkflow/bpmn/ResetSubProcessTest.py
+++ b/tests/SpiffWorkflow/bpmn/ResetSubProcessTest.py
@@ -35,7 +35,7 @@ class ResetSubProcessTest(BpmnWorkflowTestCase):
         
         self.workflow.do_engine_steps()
         top_level_task = self.workflow.get_ready_user_tasks()[0]
-        self.workflow.complete_task_from_id(top_level_task.id)
+        self.workflow.run_task_from_id(top_level_task.id)
         self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]
         self.save_restore()
@@ -50,11 +50,11 @@ class ResetSubProcessTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
         self.assertEqual(1, len(self.workflow.get_ready_user_tasks()))
         task = self.workflow.get_ready_user_tasks()[0]
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'SubTask2')
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         task = self.workflow.get_tasks_from_spec_name('Task1')[0]
         task.reset_token(self.workflow.last_task.data)
@@ -62,19 +62,19 @@ class ResetSubProcessTest(BpmnWorkflowTestCase):
         self.reload_save_restore()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'Task1')
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'Subtask2')
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'Subtask2A')
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'Task2')
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         self.assertTrue(self.workflow.is_completed())
 

--- a/tests/SpiffWorkflow/bpmn/SequentialMultiInstanceTest.py
+++ b/tests/SpiffWorkflow/bpmn/SequentialMultiInstanceTest.py
@@ -27,7 +27,7 @@ class BaseTestCase(BpmnWorkflowTestCase):
             self.assertEqual(task.task_spec.name, 'any_task [child]')
             self.assertIn('input_item', task.data)
             task.data['output_item'] = task.data['input_item'] * 2
-            task.complete()
+            task.run()
             if save_restore:
                 self.save_restore()
             ready_tasks = self.workflow.get_ready_user_tasks()
@@ -54,7 +54,7 @@ class BaseTestCase(BpmnWorkflowTestCase):
             self.assertEqual(ready.task_spec.name, 'any_task [child]')
             self.assertIn('input_item', ready.data)
             ready.data['output_item'] = ready.data['input_item'] * 2
-            ready.complete()
+            ready.run()
             self.workflow.do_engine_steps()
             self.workflow.refresh_waiting_tasks()
             ready_tasks = self.workflow.get_ready_user_tasks()

--- a/tests/SpiffWorkflow/bpmn/StandardLoopTest.py
+++ b/tests/SpiffWorkflow/bpmn/StandardLoopTest.py
@@ -21,7 +21,7 @@ class StandardLoopTest(BpmnWorkflowTestCase):
             ready_tasks = self.workflow.get_ready_user_tasks()
             self.assertEqual(len(ready_tasks), 1)
             ready_tasks[0].data[str(idx)] = True
-            ready_tasks[0].complete()
+            ready_tasks[0].run()
 
         self.workflow.do_engine_steps()
         self.assertTrue(self.workflow.is_completed())
@@ -36,7 +36,7 @@ class StandardLoopTest(BpmnWorkflowTestCase):
         ready_tasks = self.workflow.get_ready_user_tasks()
         self.assertEqual(len(ready_tasks), 1)
         ready_tasks[0].data['done'] = True
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
 
         self.workflow.do_engine_steps()
         self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/SwimLaneTest.py
+++ b/tests/SpiffWorkflow/bpmn/SwimLaneTest.py
@@ -35,7 +35,7 @@ class SwimLaneTest(BpmnWorkflowTestCase):
         self.assertEqual(0, len(btasks))
         task = atasks[0]
         self.assertEqual('Activity_A1', task.task_spec.name)
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         atasks = self.workflow.get_ready_user_tasks(lane="A")
         btasks = self.workflow.get_ready_user_tasks(lane="B")
@@ -44,10 +44,10 @@ class SwimLaneTest(BpmnWorkflowTestCase):
 
         # Complete the gateway and the two tasks in B Lane
         btasks[0].data = {'NeedClarification': False}
-        self.workflow.complete_task_from_id(btasks[0].id)
+        self.workflow.run_task_from_id(btasks[0].id)
         self.workflow.do_engine_steps()
         btasks = self.workflow.get_ready_user_tasks(lane="B")
-        self.workflow.complete_task_from_id(btasks[0].id)
+        self.workflow.run_task_from_id(btasks[0].id)
         self.workflow.do_engine_steps()
 
         # Assert we are in lane C
@@ -56,7 +56,7 @@ class SwimLaneTest(BpmnWorkflowTestCase):
         self.assertEqual(tasks[0].task_spec.lane, "C")
 
         # Step into the sub-process, assure that is also in lane C
-        self.workflow.complete_task_from_id(tasks[0].id)
+        self.workflow.run_task_from_id(tasks[0].id)
         self.workflow.do_engine_steps()
         tasks = self.workflow.get_ready_user_tasks()
         self.assertEqual("SubProcessTask", tasks[0].task_spec.description)

--- a/tests/SpiffWorkflow/bpmn/events/CallActivityEscalationTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/CallActivityEscalationTest.py
@@ -51,7 +51,7 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
             task.set_data(should_escalate=True)
         self.workflow.do_engine_steps()
         self.save_restore()
-        self.workflow.complete_all()
+        self.workflow.run_all()
         self.assertEqual(True, self.workflow.is_completed())
 
         self.assertEqual(True, 'EndEvent_specific1_noninterrupting_normal' in completed_set)
@@ -81,7 +81,7 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
             task.set_data(should_escalate=False)
         self.workflow.do_engine_steps()
         self.save_restore()
-        self.workflow.complete_all()
+        self.workflow.run_all()
         self.assertEqual(True, self.workflow.is_completed())
 
         self.assertEqual(True, 'EndEvent_specific1_noninterrupting_normal' in completed_set)
@@ -109,7 +109,7 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
         track_workflow(self.spec, completed_set)
         self.workflow.do_engine_steps()
         self.save_restore()
-        self.workflow.complete_all()
+        self.workflow.run_all()
         self.assertEqual(True, self.workflow.is_completed())
 
         self.assertEqual(True, 'EndEvent_specific1_noninterrupting_normal' in completed_set)

--- a/tests/SpiffWorkflow/bpmn/events/MultipleEventsTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MultipleEventsTest.py
@@ -33,7 +33,7 @@ class MultipleEventsTest(BpmnWorkflowTestCase):
         task = self.workflow.get_tasks(TaskState.READY)[0]
 
         # Move to User Task 1
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         task = self.workflow.get_tasks(TaskState.READY)[0]
         self.assertEqual('UserTaskOne', task.get_name())
@@ -52,10 +52,10 @@ class MultipleEventsTest(BpmnWorkflowTestCase):
         task = self.workflow.get_tasks(TaskState.READY)[0]
 
         # Move to User Task 2
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         task = self.workflow.get_tasks(TaskState.READY)[0]
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         task = self.workflow.get_tasks(TaskState.READY)[0]
         self.assertEqual('UserTaskTwo', task.get_name())

--- a/tests/SpiffWorkflow/bpmn/events/MultipleThrowEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MultipleThrowEventTest.py
@@ -42,6 +42,6 @@ class MultipleThrowEventStartsEventTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
         ready_tasks = self.workflow.get_ready_user_tasks()
         self.assertEqual(len(ready_tasks), 1)
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
         self.assertEqual(self.workflow.is_completed(), True)

--- a/tests/SpiffWorkflow/bpmn/events/NITimerDurationBoundaryTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/NITimerDurationBoundaryTest.py
@@ -62,7 +62,7 @@ class NITimerDurationTest(BpmnWorkflowTestCase):
                 task.data['delay_reason'] = 'Just Because'
             elif task.task_spec.name == 'Activity_Work':
                 task.data['work_done'] = 'Yes'
-            task.complete()
+            task.run()
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
         self.assertEqual(self.workflow.is_completed(),True)

--- a/tests/SpiffWorkflow/bpmn/events/TimerCycleTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerCycleTest.py
@@ -55,11 +55,11 @@ class TimerCycleTest(BpmnWorkflowTestCase):
             time.sleep(0.05)
             self.workflow.refresh_waiting_tasks()
             events = self.workflow.waiting_events()
-            if loopcount == 0:
-                # Wait time is 0.1s, so the first time through, there should still be a waiting event
+            if loopcount < 2:
+                # Wait time is 0.1s, two child tasks are created
                 self.assertEqual(len(events), 1)
             else:
-                # By the second iteration, both should be complete
+                # By the third iteration, the event should no longer be waiting
                 self.assertEqual(len(events), 0)
 
         # Get coffee still ready

--- a/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryOnTaskTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryOnTaskTest.py
@@ -39,7 +39,7 @@ class TimerDurationTest(BpmnWorkflowTestCase):
 
         # Make sure the task can still be called.
         task = self.workflow.get_ready_user_tasks()[0]
-        task.complete()
+        task.run()
         self.workflow.do_engine_steps()
         self.assertTrue(self.workflow.is_completed())
 

--- a/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryTest.py
@@ -24,7 +24,7 @@ class TimerDurationTest(BpmnWorkflowTestCase):
     def actual_test(self,save_restore = False):
         self.workflow.do_engine_steps()
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
 
         loopcount = 0
@@ -43,7 +43,7 @@ class TimerDurationTest(BpmnWorkflowTestCase):
         self.assertEqual(subworkflow.state, TaskState.CANCELLED)
         ready_tasks = self.workflow.get_ready_user_tasks()
         while len(ready_tasks) > 0:
-            ready_tasks[0].complete()
+            ready_tasks[0].run()
             ready_tasks = self.workflow.get_ready_user_tasks()
             self.workflow.do_engine_steps()
         self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/events/TransactionSubprocssTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TransactionSubprocssTest.py
@@ -19,11 +19,11 @@ class TransactionSubprocessTest(BpmnWorkflowTestCase):
 
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         ready_tasks[0].update_data({'value': 'asdf'})
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         ready_tasks[0].update_data({'quantity': 2})
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
         self.assertIn('value', self.workflow.last_task.data)
 
@@ -48,7 +48,7 @@ class TransactionSubprocessTest(BpmnWorkflowTestCase):
 
         # If value == '', we cancel
         ready_tasks[0].update_data({'value': ''})
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
 
         # If the subprocess gets cancelled, verify that data set there does not persist
@@ -72,13 +72,13 @@ class TransactionSubprocessTest(BpmnWorkflowTestCase):
 
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         ready_tasks[0].update_data({'value': 'asdf'})
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
 
         # If quantity == 0, we throw an error with no error code
         ready_tasks[0].update_data({'quantity': 0})
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
 
         # We formerly checked that subprocess data does not persist, but I think it should persist
@@ -103,13 +103,13 @@ class TransactionSubprocessTest(BpmnWorkflowTestCase):
 
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         ready_tasks[0].update_data({'value': 'asdf'})
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
 
         # If quantity < 0, we throw 'Error 1'
         ready_tasks[0].update_data({'quantity': -1})
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
 
         # The cancel boundary event should be cancelled

--- a/tests/SpiffWorkflow/bpmn/serializer/BpmnWorkflowSerializerTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/BpmnWorkflowSerializerTest.py
@@ -142,7 +142,7 @@ class BpmnWorkflowSerializerTest(BaseTestCase):
     def test_serialize_workflow_where_script_task_includes_function(self):
         self.workflow.do_engine_steps()
         ready_tasks = self.workflow.get_ready_user_tasks()
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.workflow.do_engine_steps()
         results = self.serializer.serialize_json(self.workflow)
         assert self.workflow.is_completed()

--- a/tests/SpiffWorkflow/bpmn/serializer/VersionMigrationTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/VersionMigrationTest.py
@@ -21,7 +21,7 @@ class Version_1_0_Test(BaseTestCase):
         # We should be able to finish the workflow from this point
         ready_tasks = wf.get_tasks(TaskState.READY)
         self.assertEqual('Action3', ready_tasks[0].task_spec.description)
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         wf.do_engine_steps()
         self.assertEqual(True, wf.is_completed())
 
@@ -50,7 +50,7 @@ class Version_1_1_Test(BaseTestCase):
         self.assertEqual(len(task.task_spec.cond_task_specs), 2)
         ready_task = wf.get_ready_user_tasks()[0]
         ready_task.data['NeedClarification'] = 'Yes'
-        ready_task.complete()
+        ready_task.run()
         wf.do_engine_steps()
         ready_task = wf.get_ready_user_tasks()[0]
         self.assertEqual(ready_task.task_spec.name, 'Activity_A2')

--- a/tests/SpiffWorkflow/camunda/CallActivityMessageTest.py
+++ b/tests/SpiffWorkflow/camunda/CallActivityMessageTest.py
@@ -39,7 +39,7 @@ class CallActivityMessageTest(BaseTestCase):
             current_task = ready_tasks[0]
             self.assertEqual(current_task.task_spec.name,step[0])
             current_task.update_data(step[1])
-            current_task.complete()
+            current_task.run()
             self.workflow.do_engine_steps()
             self.workflow.refresh_waiting_tasks()
             if save_restore: self.save_restore()

--- a/tests/SpiffWorkflow/camunda/ClashingNameTest.py
+++ b/tests/SpiffWorkflow/camunda/ClashingNameTest.py
@@ -52,7 +52,7 @@ class ClashingNameTest(BaseTestCase):
                 firsttaskid = task.id
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 
@@ -68,7 +68,7 @@ class ClashingNameTest(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 

--- a/tests/SpiffWorkflow/camunda/DMNCustomScriptTest.py
+++ b/tests/SpiffWorkflow/camunda/DMNCustomScriptTest.py
@@ -29,7 +29,7 @@ class DMNCustomScriptTest(BaseTestCase):
 
     def complete_manual_task(self):
         manual_task = self.workflow.get_tasks_from_spec_name('manual_task')[0]
-        self.workflow.complete_task_from_id(manual_task.id)
+        self.workflow.run_task_from_id(manual_task.id)
         self.workflow.do_engine_steps()
 
     def testDmnHappy(self):

--- a/tests/SpiffWorkflow/camunda/DMNDictTest.py
+++ b/tests/SpiffWorkflow/camunda/DMNDictTest.py
@@ -16,7 +16,7 @@ class DMNDictTest(BaseTestCase):
         self.workflow = BpmnWorkflow(self.spec)
         self.workflow.do_engine_steps()
         x = self.workflow.get_ready_user_tasks()
-        self.workflow.complete_task_from_id(x[0].id)
+        self.workflow.run_task_from_id(x[0].id)
         self.workflow.do_engine_steps()
         self.assertDictEqual(self.workflow.last_task.data, self.expectedResult)
 
@@ -25,7 +25,7 @@ class DMNDictTest(BaseTestCase):
         self.workflow.do_engine_steps()
         self.save_restore()
         x = self.workflow.get_ready_user_tasks()
-        self.workflow.complete_task_from_id(x[0].id)
+        self.workflow.run_task_from_id(x[0].id)
         self.workflow.do_engine_steps()
         self.save_restore()
         self.assertDictEqual(self.workflow.last_task.data, self.expectedResult)

--- a/tests/SpiffWorkflow/camunda/ExternalMessageBoundaryEventTest.py
+++ b/tests/SpiffWorkflow/camunda/ExternalMessageBoundaryEventTest.py
@@ -41,7 +41,7 @@ class ExternalMessageBoundaryTest(BaseTestCase):
         self.assertEqual(True, ready_tasks[1].data['caughtinterrupt'])
         self.assertEqual('Meaningless User Task',ready_tasks[0].task_spec.description)
         self.assertEqual(False, ready_tasks[0].data['caughtinterrupt'])
-        ready_tasks[1].complete()
+        ready_tasks[1].run()
         self.workflow.do_engine_steps()
         # what I think is going on here is that when we hit the reset, it is updating the
         # last_task and appending the data to whatever happened there, so it would make sense that
@@ -52,7 +52,7 @@ class ExternalMessageBoundaryTest(BaseTestCase):
         # The user activity was cancelled and we should continue from the boundary event
         self.assertEqual(1, len(ready_tasks),'Expected to have two ready tasks')
         event = self.workflow.get_tasks_from_spec_name('Event_19detfv')[0]
-        event.complete()
+        event.run()
         self.assertEqual('SomethingDrastic', event.data['reset_var'])
         self.assertEqual(False, event.data['caughtinterrupt'])
 

--- a/tests/SpiffWorkflow/camunda/MessageBoundaryEventTest.py
+++ b/tests/SpiffWorkflow/camunda/MessageBoundaryEventTest.py
@@ -41,7 +41,7 @@ class MessageBoundaryTest(BaseTestCase):
                 if task.task_spec.name == step[0]:
                     task.update_data(step[1])
 
-                self.workflow.complete_task_from_id(task.id)
+                self.workflow.run_task_from_id(task.id)
                 self.workflow.do_engine_steps()
                 time.sleep(.01)
                 self.workflow.refresh_waiting_tasks()

--- a/tests/SpiffWorkflow/camunda/MultiInstanceDMNTest.py
+++ b/tests/SpiffWorkflow/camunda/MultiInstanceDMNTest.py
@@ -23,10 +23,10 @@ class MultiInstanceDMNTest(BaseTestCase):
         
         self.save_restore()
         self.workflow.do_engine_steps()
-        self.workflow.complete_next()
+        self.workflow.run_next()
         self.save_restore()
         self.workflow.do_engine_steps()
-        self.workflow.complete_next()
+        self.workflow.run_next()
         self.save_restore()
         self.workflow.do_engine_steps()
         self.save_restore()

--- a/tests/SpiffWorkflow/camunda/NIMessageBoundaryTest.py
+++ b/tests/SpiffWorkflow/camunda/NIMessageBoundaryTest.py
@@ -29,7 +29,7 @@ class NIMessageBoundaryTest(BaseTestCase):
 
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         self.assertEqual(1, len(ready_tasks))
-        self.workflow.complete_task_from_id(ready_tasks[0].id)
+        self.workflow.run_task_from_id(ready_tasks[0].id)
         self.workflow.do_engine_steps()
 
         # first we run through a couple of steps where we answer No to each
@@ -45,7 +45,7 @@ class NIMessageBoundaryTest(BaseTestCase):
                                  'We got a ready task that we did not expect - %s'%(
                                  task.task_spec.name))
                 task.data[response[0]] = response[1]
-                self.workflow.complete_task_from_id(task.id)
+                self.workflow.run_task_from_id(task.id)
                 self.workflow.do_engine_steps()
             # if we have a list of tasks - that list becomes invalid
             # after we do a save restore, so I'm completing the list
@@ -66,7 +66,7 @@ class NIMessageBoundaryTest(BaseTestCase):
                                  'We got a ready task that we did not expect - %s'%(
                                  task.task_spec.name))
                 task.data[response[0]] = response[1]
-                self.workflow.complete_task_from_id(task.id)
+                self.workflow.run_task_from_id(task.id)
                 self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 
@@ -75,14 +75,14 @@ class NIMessageBoundaryTest(BaseTestCase):
         task = ready_tasks[0]
         self.assertEqual(task.task_spec.name,'Activity_DoWork')
         task.data['work_done'] = 'Yes'
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         self.assertEqual(len(ready_tasks), 1)
         task = ready_tasks[0]
         self.assertEqual(task.task_spec.name, 'Activity_WorkCompleted')
         task.data['work_completed'] = 'Lots of Stuff'
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
         self.assertEqual(self.workflow.is_completed(),True)
         self.assertEqual(self.workflow.last_task.data,{'Event_InterruptBoundary_Response': 'Youre late!',

--- a/tests/SpiffWorkflow/camunda/ParseMultiInstanceTest.py
+++ b/tests/SpiffWorkflow/camunda/ParseMultiInstanceTest.py
@@ -32,7 +32,7 @@ class ParseMultiInstanceTest(BaseTestCase):
         self.assertEqual(len(ready_tasks), 3)
         for task in ready_tasks:
             task.data['output_item'] = task.data['output_item'] * 2
-            task.complete()
+            task.run()
 
         self.workflow.do_engine_steps()
         self.assertTrue(self.workflow.is_completed())
@@ -58,7 +58,7 @@ class ParseMultiInstanceTest(BaseTestCase):
         self.assertEqual(len(ready_tasks), 3)
         for task in ready_tasks:
             task.data['output_item'] = task.data['output_item'] * 2
-            task.complete()
+            task.run()
 
         self.workflow.do_engine_steps()
         self.assertTrue(self.workflow.is_completed())
@@ -84,7 +84,7 @@ class ParseMultiInstanceTest(BaseTestCase):
         self.assertEqual(len(ready_tasks), 3)
         for task in ready_tasks:
             task.data['input_item'] = task.data['input_item'] * 2
-            task.complete()
+            task.run()
 
         self.workflow.do_engine_steps()
         self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/camunda/ResetTokenNestedParallelTest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenNestedParallelTest.py
@@ -73,7 +73,7 @@ class ResetTokenTestNestedParallel(BaseTestCase):
                 firsttaskid = task.id
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
         self.workflow.reset_task_from_id(firsttaskid)
@@ -91,7 +91,7 @@ class ResetTokenTestNestedParallel(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
         notworking = self.workflow.get_ready_user_tasks()
@@ -148,7 +148,7 @@ class ResetTokenTestNestedParallel(BaseTestCase):
                 firsttaskid = task.id
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 
@@ -182,7 +182,7 @@ class ResetTokenTestNestedParallel(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 

--- a/tests/SpiffWorkflow/camunda/ResetTokenParallelMatrixTest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenParallelMatrixTest.py
@@ -76,7 +76,7 @@ class ResetTokenTestParallelMatrix(BaseTestCase):
                 firsttaskid = task.id
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 
@@ -96,7 +96,7 @@ class ResetTokenTestParallelMatrix(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 
@@ -154,7 +154,7 @@ class ResetTokenTestParallelMatrix(BaseTestCase):
                 firsttaskid = task.id
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 
@@ -190,7 +190,7 @@ class ResetTokenTestParallelMatrix(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 

--- a/tests/SpiffWorkflow/camunda/ResetTokenParallelTaskCountTest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenParallelTaskCountTest.py
@@ -36,7 +36,7 @@ class ResetTokenParallelTaskCountTest(BaseTestCase):
         data = {'skipParallel': True}
         task = self.workflow.get_ready_user_tasks()[0]
         task.data = data
-        self.workflow.complete_task_from_id(task.id)
+        self.workflow.run_task_from_id(task.id)
         self.assertEquals(total, len(self.workflow.get_tasks()))
 
         # Reset the token to the first user task.

--- a/tests/SpiffWorkflow/camunda/ResetTokenSubWorkflowTest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenSubWorkflowTest.py
@@ -51,7 +51,7 @@ class ResetTokenTestSubProcess(BaseTestCase):
                 firsttaskid = task.id
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore:
                 self.save_restore()
@@ -75,7 +75,7 @@ class ResetTokenTestSubProcess(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore:
                 self.save_restore()
@@ -128,7 +128,7 @@ class ResetTokenTestSubProcess(BaseTestCase):
                 firsttaskid = task.id
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 
@@ -164,7 +164,7 @@ class ResetTokenTestSubProcess(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 

--- a/tests/SpiffWorkflow/camunda/ResetTokenTest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenTest.py
@@ -54,7 +54,7 @@ class ResetTokenTest(BaseTestCase):
                 firsttaskid = task.id
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 
@@ -70,7 +70,7 @@ class ResetTokenTest(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 

--- a/tests/SpiffWorkflow/camunda/StartMessageEventTest.py
+++ b/tests/SpiffWorkflow/camunda/StartMessageEventTest.py
@@ -48,7 +48,7 @@ class StartMessageTest(BaseTestCase):
             current_task = ready_tasks[0]
             self.assertEqual(current_task.task_spec.name,step[0])
             current_task.update_data(step[1])
-            current_task.complete()
+            current_task.run()
             self.workflow.do_engine_steps()
             self.workflow.refresh_waiting_tasks()
             if save_restore:

--- a/tests/SpiffWorkflow/camunda/SubWorkflowTest.py
+++ b/tests/SpiffWorkflow/camunda/SubWorkflowTest.py
@@ -31,7 +31,7 @@ class SubWorkflowTest(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual("Activity_"+answer, task.task_spec.name)
             task.update_data({"Field"+answer: answer})
-            self.workflow.complete_task_from_id(task.id)
+            self.workflow.run_task_from_id(task.id)
             self.workflow.do_engine_steps()
             if save_restore: self.save_restore()
 

--- a/tests/SpiffWorkflow/core/ControlFlowPatternTest.py
+++ b/tests/SpiffWorkflow/core/ControlFlowPatternTest.py
@@ -158,6 +158,16 @@ class RecursionTest(TestCase, WorkflowPatternTestCase):
     def setUp(self):
         self.load_from_xml('control-flow/recursion')
 
+    # I am disabling this test becuse I have wasted an entire day trying to make it pass
+    # The workflow completes and the task tree is as expected, but the subworkflow tasks
+    # no longer appear in the taken path.  This is because they are connected to the subworkflow 
+    # in on_reached_cb, which now occurs after they are executed.
+    # Moving subworkflow creation to predict would likely fix the problem, but there are problems
+    # with prediction that also need to be fixed as well.
+
+    def test_run_workflow(self):
+        pass
+
 class ImplicitTerminationTest(TestCase, WorkflowPatternTestCase):
     def setUp(self):
         self.load_from_xml('control-flow/implicit_termination')

--- a/tests/SpiffWorkflow/core/ControlFlowPatternTest.py
+++ b/tests/SpiffWorkflow/core/ControlFlowPatternTest.py
@@ -165,8 +165,8 @@ class RecursionTest(TestCase, WorkflowPatternTestCase):
     # Moving subworkflow creation to predict would likely fix the problem, but there are problems
     # with prediction that also need to be fixed as well.
 
-    def test_run_workflow(self):
-        pass
+    #def test_run_workflow(self):
+    #    pass
 
 class ImplicitTerminationTest(TestCase, WorkflowPatternTestCase):
     def setUp(self):

--- a/tests/SpiffWorkflow/core/PersistSmallWorkflowTest.py
+++ b/tests/SpiffWorkflow/core/PersistSmallWorkflowTest.py
@@ -47,15 +47,15 @@ class PersistSmallWorkflowTest(unittest.TestCase):
 
         tasks = workflow.get_tasks(TaskState.READY)
         task_start = tasks[0]
-        workflow.complete_task_from_id(task_start.id)
+        workflow.run_task_from_id(task_start.id)
 
         tasks = workflow.get_tasks(TaskState.READY)
         multichoice = tasks[0]
-        workflow.complete_task_from_id(multichoice.id)
+        workflow.run_task_from_id(multichoice.id)
 
         tasks = workflow.get_tasks(TaskState.READY)
         task_a1 = tasks[0]
-        workflow.complete_task_from_id(task_a1.id)
+        workflow.run_task_from_id(task_a1.id)
         return workflow
 
     def testDictionarySerializer(self):
@@ -100,7 +100,7 @@ class PersistSmallWorkflowTest(unittest.TestCase):
         """
         old_workflow = self.workflow
 
-        old_workflow.complete_next()
+        old_workflow.run_next()
         self.assertEqual('task_a2', old_workflow.last_task.get_name())
         serializer = DictionarySerializer()
         serialized_workflow = old_workflow.serialize(serializer)
@@ -108,7 +108,7 @@ class PersistSmallWorkflowTest(unittest.TestCase):
         serializer = DictionarySerializer()
         new_workflow = Workflow.deserialize(serializer, serialized_workflow)
         self.assertEqual('task_a2', old_workflow.last_task.get_name())
-        new_workflow.complete_all()
+        new_workflow.run_all()
         self.assertEqual('task_a2', old_workflow.last_task.get_name())
 
 

--- a/tests/SpiffWorkflow/core/WorkflowTest.py
+++ b/tests/SpiffWorkflow/core/WorkflowTest.py
@@ -34,7 +34,7 @@ class WorkflowTest(unittest.TestCase):
         tasks = workflow.get_tasks(TaskState.READY)
         self.assertEqual(len(tasks), 1)
         self.assertEqual(tasks[0].task_spec.name, 'Start')
-        workflow.complete_task_from_id(tasks[0].id)
+        workflow.run_task_from_id(tasks[0].id)
         self.assertEqual(tasks[0].state, TaskState.COMPLETED)
 
         tasks = workflow.get_tasks(TaskState.READY)
@@ -45,7 +45,7 @@ class WorkflowTest(unittest.TestCase):
         self.assertEqual(task_a1.task_spec.name, 'task_a1')
         self.assertEqual(task_b1.task_spec.__class__, Simple)
         self.assertEqual(task_b1.task_spec.name, 'task_b1')
-        workflow.complete_task_from_id(task_a1.id)
+        workflow.run_task_from_id(task_a1.id)
         self.assertEqual(task_a1.state, TaskState.COMPLETED)
 
         tasks = workflow.get_tasks(TaskState.READY)
@@ -54,16 +54,16 @@ class WorkflowTest(unittest.TestCase):
         task_a2 = tasks[0]
         self.assertEqual(task_a2.task_spec.__class__, Simple)
         self.assertEqual(task_a2.task_spec.name, 'task_a2')
-        workflow.complete_task_from_id(task_a2.id)
+        workflow.run_task_from_id(task_a2.id)
 
         tasks = workflow.get_tasks(TaskState.READY)
         self.assertEqual(len(tasks), 1)
         self.assertTrue(task_b1 in tasks)
 
-        workflow.complete_task_from_id(task_b1.id)
+        workflow.run_task_from_id(task_b1.id)
         tasks = workflow.get_tasks(TaskState.READY)
         self.assertEqual(len(tasks), 1)
-        workflow.complete_task_from_id(tasks[0].id)
+        workflow.run_task_from_id(tasks[0].id)
 
         tasks = workflow.get_tasks(TaskState.READY)
         self.assertEqual(len(tasks), 1)

--- a/tests/SpiffWorkflow/core/pattern_base.py
+++ b/tests/SpiffWorkflow/core/pattern_base.py
@@ -71,7 +71,7 @@ class WorkflowPatternTestCase:
     def run_workflow(self):
         # We allow the workflow to require a maximum of 5 seconds to complete, to allow for testing long running tasks.
         for i in range(10):
-            self.workflow.complete_all(False)
+            self.workflow.run_all(False)
             if self.workflow.is_completed():
                 break
             time.sleep(0.5)

--- a/tests/SpiffWorkflow/core/specs/MergeTest.py
+++ b/tests/SpiffWorkflow/core/specs/MergeTest.py
@@ -56,7 +56,7 @@ class MergeTest(JoinTest):
         workflow.task_tree.set_data(everywhere=1)
         for task in workflow.get_tasks():
             task.set_data(**{'name': task.get_name(), task.get_name(): 1})
-        workflow.complete_all()
+        workflow.run_all()
         self.assertTrue(workflow.is_completed())
         found = {}
         for task in workflow.get_tasks():

--- a/tests/SpiffWorkflow/core/specs/SubWorkflowTest.py
+++ b/tests/SpiffWorkflow/core/specs/SubWorkflowTest.py
@@ -42,17 +42,16 @@ class TaskSpecTest(unittest.TestCase):
         self.assertEqual(1, len(ready_tasks))
         task = ready_tasks[0]
         self.assertEqual(name, task.task_spec.name)
-        task.complete()
+        task.run()
 
     def do_next_named_step(self, name, other_ready_tasks):
         # This method completes a single task from the specified set of ready
         # tasks
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         all_tasks = sorted([name] + other_ready_tasks)
-        self.assertEqual(
-            all_tasks, sorted([t.task_spec.name for t in ready_tasks]))
+        self.assertEqual(all_tasks, sorted([t.task_spec.name for t in ready_tasks]))
         task = list([t for t in ready_tasks if t.task_spec.name == name])[0]
-        task.complete()
+        task.run()
 
     def test_block_to_subworkflow(self):
         self.load_workflow_spec('data', 'block_to_subworkflow.xml')

--- a/tests/SpiffWorkflow/core/specs/WorkflowSpecTest.py
+++ b/tests/SpiffWorkflow/core/specs/WorkflowSpecTest.py
@@ -43,7 +43,7 @@ class WorkflowSpecTest(unittest.TestCase):
 
         # Execute a random number of steps.
         for i in range(randint(0, len(workflow.spec.task_specs))):
-            workflow.complete_next()
+            workflow.run_next()
 
         # Store the workflow instance in a file.
         with open(data_file, 'wb') as fp:
@@ -64,14 +64,9 @@ class WorkflowSpecTest(unittest.TestCase):
         taken_path = track_workflow(workflow.spec, taken_path)
 
         # Run the rest of the workflow.
-        workflow.complete_all()
+        workflow.run_all()
         after = workflow.get_dump()
         self.assertTrue(workflow.is_completed(), 'Workflow not complete:' + after)
-        # taken_path = '\n'.join(taken_path) + '\n'
-        if taken_path != expected_path:
-            for taken, expected in zip(taken_path, expected_path):
-                print("TAKEN:   ", taken)
-                print("EXPECTED:", expected)
         self.assertEqual(expected_path, taken_path)
 
     def testSerialize(self):

--- a/tests/SpiffWorkflow/core/util.py
+++ b/tests/SpiffWorkflow/core/util.py
@@ -37,7 +37,6 @@ def on_reached_cb(workflow, task, taken_path):
     old = task.get_data('data', '')
     data = task.get_name() + ': ' + atts + '/' + props + '\n'
     task.set_data(data=old + data)
-
     # In workflows that load a subworkflow, the newly loaded children
     # will not have on_reached_cb() assigned. By using this function, we
     # re-assign the function in every step, thus making sure that new
@@ -46,15 +45,15 @@ def on_reached_cb(workflow, task, taken_path):
         track_task(child.task_spec, taken_path)
     return True
 
-
 def on_complete_cb(workflow, task, taken_path):
     # Record the path.
     indent = '  ' * (task._get_depth() - 1)
     taken_path.append('%s%s' % (indent, task.get_name()))
     return True
 
-
 def track_task(task_spec, taken_path):
+    # Disconnecting and reconnecting makes absolutely no sense but inexplicably these tests break
+    # if just connected based on a check that they're not
     if task_spec.reached_event.is_connected(on_reached_cb):
         task_spec.reached_event.disconnect(on_reached_cb)
     task_spec.reached_event.connect(on_reached_cb, taken_path)
@@ -62,14 +61,12 @@ def track_task(task_spec, taken_path):
         task_spec.completed_event.disconnect(on_complete_cb)
     task_spec.completed_event.connect(on_complete_cb, taken_path)
 
-
 def track_workflow(wf_spec, taken_path=None):
     if taken_path is None:
         taken_path = []
     for name in wf_spec.task_specs:
         track_task(wf_spec.task_specs[name], taken_path)
     return taken_path
-
 
 def run_workflow(test, wf_spec, expected_path, expected_data, workflow=None):
     # Execute all tasks within the Workflow.
@@ -84,7 +81,7 @@ def run_workflow(test, wf_spec, expected_path, expected_data, workflow=None):
         # We allow the workflow to require a maximum of 5 seconds to
         # complete, to allow for testing long running tasks.
         for i in range(10):
-            workflow.complete_all(False)
+            workflow.run_all(False)
             if workflow.is_completed():
                 break
             time.sleep(0.5)

--- a/tests/SpiffWorkflow/spiff/CorrelationTest.py
+++ b/tests/SpiffWorkflow/spiff/CorrelationTest.py
@@ -23,14 +23,14 @@ class CorrelationTest(BaseTestCase):
             task.data['task_num'] = idx
             task.data['task_name'] = f'subprocess {idx}'
             task.data['extra_data'] = f'unused data'
-            task.complete()
+            task.run()
         self.workflow.do_engine_steps()
         ready_tasks = self.workflow.get_ready_user_tasks()
         for task in ready_tasks:
             self.assertEqual(task.task_spec.name, 'prepare_response')
             response = 'OK' if task.data['source_task']['num'] else 'No'
             task.data.update(response=response)
-            task.complete()
+            task.run()
         self.workflow.do_engine_steps()
         # If the messages were routed properly, the task number should match the response id
         for task in self.workflow.get_tasks_from_spec_name('subprocess_end'):

--- a/tests/SpiffWorkflow/spiff/MultiInstanceTaskTest.py
+++ b/tests/SpiffWorkflow/spiff/MultiInstanceTaskTest.py
@@ -19,7 +19,7 @@ class MultiInstanceTaskTest(BaseTestCase):
         ready_tasks = self.workflow.get_ready_user_tasks()
         for task in ready_tasks:
             task.data['output_item'] = task.data['input_item'] * 2
-            task.complete()
+            task.run()
             self.workflow.do_engine_steps()
 
         self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
+++ b/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
@@ -27,7 +27,7 @@ class PrescriptPostsciptTest(BaseTestCase):
         self.set_process_data({'b': 2})
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         # This execute the same script as task_test
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         # a should be removed, b should be unchanged, and c and z should be present (but not x & y)
         self.assertDictEqual({'b': 2, 'c': 12, 'z': 6}, ready_tasks[0].data)
 
@@ -43,7 +43,7 @@ class PrescriptPostsciptTest(BaseTestCase):
         # The prescript sets x, y = a * 2, b * 2 and creates the variable z = x + y
         # The postscript sets c = z * 2 and deletes x and y
         # a and b should remain unchanged, and c and z should be added
-        ready_tasks[0].complete()
+        ready_tasks[0].run()
         self.assertDictEqual({'a': 1, 'b': 2, 'c': 12, 'z': 6}, ready_tasks[0].data)
 
     def test_for_error(self, save_restore=False):


### PR DESCRIPTION
This PR creates a new `_run` method on task specs that runs the tasks.  This method should return `True` if execution was successful, `False` if unsuccessful (success and failure are still currently conflated in the `COMPLETED` task state, but in the future we can differentiate them) or `None` if the task is not complete, in which case the state will be changed to `WAITING`

This will allow a custom script engine to execute scripts or service tasks to immediately return `None` while the task executes without holding up the rest of the workflow.  The behavior of the default script engine executes scripts synchronously and returns True on successful completion.  This preserves the current behavior.

The old `_on_ready_hook` method can be used to execute code when the task becomes `READY` but before it is run; this makes `on_ready_before` redundant so I've removed it.

I've also changed the prediction model so that (1) we no longer always re-predict definite tasks and (2) the states actually change when `sync_children` is called.  Definite tasks can still be re-predicted by providing an optional mask to `_predict`.