### PR TITLE
Bugfix/execute event gateways on ready

### DIFF
--- a/SpiffWorkflow/bpmn/serializer/workflow.py
+++ b/SpiffWorkflow/bpmn/serializer/workflow.py
@@ -246,7 +246,7 @@ class BpmnWorkflowSerializer:
 
         if isinstance(task_spec, SubWorkflowTask) and task_id in top_dct.get('subprocesses', {}):
             subprocess_spec = top.subprocess_specs[task_spec.spec]
-            subprocess = self.wf_class(subprocess_spec, {}, name=task_spec.name, parent=process)
+            subprocess = self.wf_class(subprocess_spec, {}, name=task_spec.name, parent=process, deserializing=True)
             subprocess_dct = top_dct['subprocesses'].get(task_id, {})
             subprocess.data = self.data_converter.restore(subprocess_dct.pop('data'))
             subprocess.success = subprocess_dct.pop('success')

--- a/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
@@ -139,5 +139,5 @@ class EventBasedGateway(CatchingEvent):
     def _on_ready_hook(self, my_task):
         seen_events =  my_task.internal_data.get('seen_events', [])
         for child in my_task.children:
-            if not child.task_spec.event_definition in seen_events:
+            if child.task_spec.event_definition not in seen_events:
                 child.cancel()

--- a/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
@@ -136,8 +136,8 @@ class EventBasedGateway(CatchingEvent):
     def _predict_hook(self, my_task):
         my_task._sync_children(self.outputs, state=TaskState.MAYBE)
 
-    def _on_complete_hook(self, my_task):
+    def _on_ready_hook(self, my_task):
+        seen_events =  my_task.internal_data.get('seen_events', [])
         for child in my_task.children:
-            if not child.task_spec.event_definition.has_fired(child):
+            if not child.task_spec.event_definition in seen_events:
                 child.cancel()
-        return super()._on_complete_hook(my_task)

--- a/SpiffWorkflow/bpmn/specs/events/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/events/event_definitions.py
@@ -501,11 +501,10 @@ class MultipleEventDefinition(EventDefinition):
 
         seen_events = my_task.internal_data.get('seen_events', [])
         for event in self.event_definitions:
-            if isinstance(event, (TimerEventDefinition, CycleTimerEventDefinition)):
+            if isinstance(event, TimerEventDefinition):
                 child = [c for c in my_task.children if c.task_spec.event_definition == event]
                 child[0].task_spec._update_hook(child[0])
-                child[0]._set_state(TaskState.MAYBE)
-                if event.has_fired(my_task):
+                if event.has_fired(child[0]):
                     seen_events.append(event)
 
         if self.parallel:

--- a/SpiffWorkflow/bpmn/workflow.py
+++ b/SpiffWorkflow/bpmn/workflow.py
@@ -271,7 +271,10 @@ class BpmnWorkflow(Workflow):
         for my_task in self.get_tasks(TaskState.WAITING):
             if will_refresh_task is not None:
                 will_refresh_task(my_task)
-            my_task.task_spec._update(my_task)
+            # This seems redundant, but the state could have been updated by another waiting task and no longer be waiting.
+            # Someday, I would like to get rid of this method, and also do_engine_steps
+            if my_task.state == TaskState.WAITING:
+                my_task.task_spec._update(my_task)
             if did_refresh_task is not None:
                 did_refresh_task(my_task)
 

--- a/tests/SpiffWorkflow/bpmn/events/EventBasedGatewayTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/EventBasedGatewayTest.py
@@ -28,7 +28,7 @@ class EventBasedGatewayTest(BpmnWorkflowTestCase):
         if save_restore:
             self.save_restore()
             self.workflow.script_engine = self.script_engine
-        self.assertEqual(len(waiting_tasks), 1)
+        self.assertEqual(len(waiting_tasks), 2)
         self.workflow.catch(MessageEventDefinition('message_1'))
         self.workflow.do_engine_steps()
         self.workflow.refresh_waiting_tasks()
@@ -41,7 +41,7 @@ class EventBasedGatewayTest(BpmnWorkflowTestCase):
 
         self.workflow.do_engine_steps()
         waiting_tasks = self.workflow.get_waiting_tasks()
-        self.assertEqual(len(waiting_tasks), 1)
+        self.assertEqual(len(waiting_tasks), 2)
         timer_event = waiting_tasks[0].task_spec.event_definition.event_definitions[-1]
         self.workflow.catch(timer_event)
         self.workflow.refresh_waiting_tasks()


### PR DESCRIPTION
This PR
- executes event based gateways before task completion (I missed this in my last PR)
- does not change the state of children of event based gateways back to `MAYBE` from `WAITING`
- adds a method on `Workflow` that can be used to repredict unfinished tasks
- skips task prediction during deserialization