### PR TITLE
do not execute boundary events in catch

### DIFF
--- a/SpiffWorkflow/bpmn/specs/BpmnSpecMixin.py
+++ b/SpiffWorkflow/bpmn/specs/BpmnSpecMixin.py
@@ -89,6 +89,9 @@ class BpmnSpecMixin(TaskSpec):
 
     def _on_complete_hook(self, my_task):
 
+        if isinstance(my_task.parent.task_spec, BpmnSpecMixin):
+            my_task.parent.task_spec._child_complete_hook(my_task)
+
         if self.io_specification is not None and len(self.io_specification.data_outputs) > 0:
             data = {}
             for var in self.io_specification.data_outputs:
@@ -105,8 +108,6 @@ class BpmnSpecMixin(TaskSpec):
             my_task.data.pop(obj.name, None)
 
         super(BpmnSpecMixin, self)._on_complete_hook(my_task)
-        if isinstance(my_task.parent.task_spec, BpmnSpecMixin):
-            my_task.parent.task_spec._child_complete_hook(my_task)
 
     def _child_complete_hook(self, child_task):
         pass

--- a/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
+++ b/SpiffWorkflow/bpmn/specs/SubWorkflowTask.py
@@ -27,15 +27,17 @@ class SubWorkflowTask(BpmnSpecMixin):
 
     def _on_subworkflow_completed(self, subworkflow, my_task):
         self.update_data(my_task, subworkflow)
-        my_task._set_state(TaskState.READY)
 
     def _update_hook(self, my_task):
         wf = my_task.workflow._get_outermost_workflow(my_task)
-        if my_task.id not in wf.subprocesses:
+        subprocess = wf.subprocesses.get(my_task.id)
+        if subprocess is None:
             super()._update_hook(my_task)
             self.create_workflow(my_task)
             self.start_workflow(my_task)
             my_task._set_state(TaskState.WAITING)
+        else:
+            return subprocess.is_completed()
 
     def _on_cancel(self, my_task):
         subworkflow = my_task.workflow.get_subprocess(my_task)

--- a/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
+++ b/SpiffWorkflow/bpmn/specs/events/IntermediateEvent.py
@@ -67,9 +67,7 @@ class _BoundaryEventParent(Simple, BpmnSpecMixin):
         return 'Boundary Event Parent'
 
     def _run_hook(self, my_task):
-
-        # Clear any events that our children might have received and
-        # wait for new events
+        # Clear any events that our children might have received and wait for new events
         for child in my_task.children:
             if isinstance(child.task_spec, BoundaryEvent):
                 child.task_spec.event_definition.reset(child)
@@ -77,7 +75,6 @@ class _BoundaryEventParent(Simple, BpmnSpecMixin):
         return True
 
     def _child_complete_hook(self, child_task):
-
         # If the main child completes, or a cancelling event occurs, cancel any unfinished children
         if child_task.task_spec == self.main_child_task_spec or child_task.task_spec.cancel_activity:
             for sibling in child_task.parent.children:
@@ -85,11 +82,8 @@ class _BoundaryEventParent(Simple, BpmnSpecMixin):
                     continue
                 if sibling.task_spec == self.main_child_task_spec or not sibling._is_finished():
                     sibling.cancel()
-            for t in child_task.workflow._get_waiting_tasks():
-                t.task_spec._update(t)
 
     def _predict_hook(self, my_task):
-
         # Events attached to the main task might occur
         my_task._sync_children(self.outputs, state=TaskState.MAYBE)
         # The main child's state is based on this task's state
@@ -119,12 +113,6 @@ class BoundaryEvent(CatchingEvent):
     def catches(self, my_task, event_definition, correlations=None):
         # Boundary events should only be caught while waiting
         return super(BoundaryEvent, self).catches(my_task, event_definition, correlations) and my_task.state == TaskState.WAITING
-
-    def catch(self, my_task, event_definition):
-        super(BoundaryEvent, self).catch(my_task, event_definition)
-        # Would love to get rid of this statement and manage in the workflow
-        # However, it is not really compatible with how boundary events work.
-        my_task.run()
 
 
 class EventBasedGateway(CatchingEvent):

--- a/SpiffWorkflow/spiff/specs/subworkflow_task.py
+++ b/SpiffWorkflow/spiff/specs/subworkflow_task.py
@@ -22,11 +22,14 @@ class SubWorkflowTask(DefaultSubWorkflow, SpiffBpmnTask):
     def _update_hook(self, my_task):
         # Don't really like duplicating this, but we need to run SpiffBpmn update rather than the default
         wf = my_task.workflow._get_outermost_workflow(my_task)
-        if my_task.id not in wf.subprocesses:
-            SpiffBpmnTask._update_hook(self, my_task)
+        subprocess = wf.subprocesses.get(my_task.id)
+        if subprocess is None:
+            super()._update_hook(my_task)
             self.create_workflow(my_task)
             self.start_workflow(my_task)
             my_task._set_state(TaskState.WAITING)
+        else:
+            return subprocess.is_completed()
 
     def _on_complete_hook(self, my_task):
         SpiffBpmnTask._on_complete_hook(self, my_task)

--- a/tests/SpiffWorkflow/bpmn/ApprovalsTest.py
+++ b/tests/SpiffWorkflow/bpmn/ApprovalsTest.py
@@ -46,6 +46,8 @@ class ApprovalsTest(BpmnWorkflowTestCase):
     def testRunThroughHappy(self):
 
         self.do_next_named_step('First_Approval_Wins.Manager_Approval')
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.First_Approval_Wins_Done')
 
         self.do_next_named_step('Approvals.Manager_Approval__P_')
@@ -55,11 +57,15 @@ class ApprovalsTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Parallel_Approvals_SP.Step1')
         self.do_next_named_step('Parallel_Approvals_SP.Manager_Approval')
         self.do_next_named_step('Parallel_Approvals_SP.Supervisor_Approval')
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.Parallel_SP_Done')
 
     def testRunThroughHappyOtherOrders(self):
 
         self.do_next_named_step('First_Approval_Wins.Supervisor_Approval')
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.First_Approval_Wins_Done')
 
         self.do_next_named_step('Approvals.Supervisor_Approval__P_')
@@ -69,11 +75,15 @@ class ApprovalsTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Parallel_Approvals_SP.Manager_Approval')
         self.do_next_named_step('Parallel_Approvals_SP.Step1')
         self.do_next_named_step('Parallel_Approvals_SP.Supervisor_Approval')
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.Parallel_SP_Done')
 
     def testSaveRestore(self):
 
         self.do_next_named_step('First_Approval_Wins.Manager_Approval')
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         self.save_restore()
         self.do_next_exclusive_step('Approvals.First_Approval_Wins_Done')
 
@@ -86,12 +96,16 @@ class ApprovalsTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Parallel_Approvals_SP.Manager_Approval')
         self.do_next_exclusive_step('Parallel_Approvals_SP.Step1')
         self.do_next_exclusive_step('Parallel_Approvals_SP.Supervisor_Approval')
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.Parallel_SP_Done')
 
     def testSaveRestoreWaiting(self):
 
         self.do_next_named_step('First_Approval_Wins.Manager_Approval')
         self.save_restore()
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.First_Approval_Wins_Done')
 
         self.save_restore()
@@ -108,6 +122,8 @@ class ApprovalsTest(BpmnWorkflowTestCase):
         self.save_restore()
         self.do_next_exclusive_step('Parallel_Approvals_SP.Supervisor_Approval')
         self.save_restore()
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.Parallel_SP_Done')
 
 

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
@@ -118,6 +118,13 @@ class BpmnWorkflowTestCase(unittest.TestCase):
             tasks[0].set_data(**set_attribs)
         tasks[0].run()
 
+    def complete_subworkflow(self):
+        # A side effect of finer grained contol over task execution is that tasks require more explicit intervention
+        # to change states.  Subworkflows tasks no longer go directly to ready when the subworkflow completes.
+        # So they may need to explicitly refreshed to become ready, and then run.
+        self.workflow.refresh_waiting_tasks()
+        self.workflow.do_engine_steps()
+
     def save_restore(self):
 
         script_engine = self.workflow.script_engine

--- a/tests/SpiffWorkflow/bpmn/CallActivityEndEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivityEndEventTest.py
@@ -34,13 +34,12 @@ class CallActivityTest(BpmnWorkflowTestCase):
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses,
                                      script_engine=CustomScriptEngine())
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.assertTrue(self.workflow.is_completed())
         self.assertIsInstance(self.workflow.script_engine, CustomScriptEngine)
 
         if save_restore:
             self.save_restore()
-            # We have to reset the script engine after deserialize.
-            self.workflow.script_engine = CustomScriptEngine()
 
         # Get the subworkflow
         sub_task = self.workflow.get_tasks_from_spec_name('Sub_Bpmn_Task')[0]
@@ -54,6 +53,7 @@ class CallActivityTest(BpmnWorkflowTestCase):
         # data should be removed in the final output as well.
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses)
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.assertTrue(self.workflow.is_completed())
         self.assertNotIn('remove_this_var', self.workflow.last_task.data.keys())
 

--- a/tests/SpiffWorkflow/bpmn/CallActivitySubProcessPropTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivitySubProcessPropTest.py
@@ -27,6 +27,8 @@ class CallActivitySubProcessPropTest(BpmnWorkflowTestCase):
 
     def actualTest(self, save_restore=False):
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         if save_restore:
             self.save_restore()
         self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
+++ b/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
@@ -38,6 +38,8 @@ class CustomInlineScriptTest(BpmnWorkflowTestCase):
     def actual_test(self, save_restore):
         if save_restore: self.save_restore()
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         if save_restore: self.save_restore()
         data = self.workflow.last_task.data
         self.assertEqual(data['c1'], 'HELLO')

--- a/tests/SpiffWorkflow/bpmn/IOSpecTest.py
+++ b/tests/SpiffWorkflow/bpmn/IOSpecTest.py
@@ -62,6 +62,8 @@ class CallActivityDataTest(BpmnWorkflowTestCase):
         self.assertNotIn('unused', task.data)
 
         self.complete_subprocess()
+        # Refreshing causes the subprocess to become ready
+        self.workflow.refresh_waiting_tasks()
         task = self.workflow.get_tasks(TaskState.READY)[0]
         # Originals should not change
         self.assertEqual(task.data['in_1'], 1)
@@ -80,13 +82,11 @@ class CallActivityDataTest(BpmnWorkflowTestCase):
             waiting = self.workflow.get_tasks(TaskState.WAITING)
 
     def complete_subprocess(self):
-        # When we complete, the subworkflow task will move from WAITING to READY
-        waiting = self.workflow.get_tasks(TaskState.WAITING)
-        while len(waiting) > 0:
-            next_task = self.workflow.get_tasks(TaskState.READY)[0]
-            next_task.run()
-            waiting = self.workflow.get_tasks(TaskState.WAITING)
-
+        # Complete the ready tasks in the subprocess
+        ready = self.workflow.get_tasks(TaskState.READY)
+        while len(ready) > 0:
+            ready[0].run()
+            ready = self.workflow.get_tasks(TaskState.READY)
 
 class IOSpecOnTaskTest(BpmnWorkflowTestCase):
 

--- a/tests/SpiffWorkflow/bpmn/NestedProcessesTest.py
+++ b/tests/SpiffWorkflow/bpmn/NestedProcessesTest.py
@@ -25,9 +25,11 @@ class NestedProcessesTest(BpmnWorkflowTestCase):
         self.assertEqual(1, len(self.workflow.get_tasks(TaskState.READY)))
         self.do_next_named_step('Action3')
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
+        self.complete_subworkflow()
+        self.complete_subworkflow()
         self.save_restore()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
 
 def suite():

--- a/tests/SpiffWorkflow/bpmn/ParallelMultipleSplitsTest.py
+++ b/tests/SpiffWorkflow/bpmn/ParallelMultipleSplitsTest.py
@@ -32,6 +32,7 @@ class ParallelMultipleSplitsTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
         self.do_next_named_step('SP 3 - Yes Task')
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
 
         self.do_next_named_step('Done')
         self.workflow.do_engine_steps()

--- a/tests/SpiffWorkflow/bpmn/ResetSubProcessTest.py
+++ b/tests/SpiffWorkflow/bpmn/ResetSubProcessTest.py
@@ -35,7 +35,7 @@ class ResetSubProcessTest(BpmnWorkflowTestCase):
         
         self.workflow.do_engine_steps()
         top_level_task = self.workflow.get_ready_user_tasks()[0]
-        self.workflow.run_task_from_id(top_level_task.id)
+        top_level_task.run()
         self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]
         self.save_restore()
@@ -50,11 +50,11 @@ class ResetSubProcessTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
         self.assertEqual(1, len(self.workflow.get_ready_user_tasks()))
         task = self.workflow.get_ready_user_tasks()[0]
-        self.workflow.run_task_from_id(task.id)
+        task.run()
         self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'SubTask2')
-        self.workflow.run_task_from_id(task.id)
+        task.run()
         self.workflow.do_engine_steps()
         task = self.workflow.get_tasks_from_spec_name('Task1')[0]
         task.reset_token(self.workflow.last_task.data)
@@ -62,19 +62,20 @@ class ResetSubProcessTest(BpmnWorkflowTestCase):
         self.reload_save_restore()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'Task1')
-        self.workflow.run_task_from_id(task.id)
+        task.run()
         self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'Subtask2')
-        self.workflow.run_task_from_id(task.id)
+        task.run()
         self.workflow.do_engine_steps()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'Subtask2A')
-        self.workflow.run_task_from_id(task.id)
+        task.run()
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'Task2')
-        self.workflow.run_task_from_id(task.id)
+        task.run()
         self.workflow.do_engine_steps()
         self.assertTrue(self.workflow.is_completed())
 

--- a/tests/SpiffWorkflow/bpmn/events/ActionManagementTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/ActionManagementTest.py
@@ -50,6 +50,7 @@ class ActionManagementTest(BpmnWorkflowTestCase):
 
         self.do_next_named_step("Complete Work", choice="Done")
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
 
         self.assertTrue(self.workflow.is_completed())
 
@@ -91,6 +92,7 @@ class ActionManagementTest(BpmnWorkflowTestCase):
 
         self.do_next_named_step("Complete Work", choice="Done")
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
 
         self.assertTrue(self.workflow.is_completed())
 

--- a/tests/SpiffWorkflow/bpmn/events/CallActivityEscalationTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/CallActivityEscalationTest.py
@@ -80,6 +80,7 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
         for task in self.workflow.get_tasks(TaskState.READY):
             task.set_data(should_escalate=False)
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.save_restore()
         self.workflow.run_all()
         self.assertEqual(True, self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/events/MessageInterruptsSpTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageInterruptsSpTest.py
@@ -28,6 +28,7 @@ class MessageInterruptsSpTest(BpmnWorkflowTestCase):
 
         self.do_next_exclusive_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.save_restore()
 
         self.do_next_exclusive_step('Ack Subprocess Done')
@@ -35,8 +36,7 @@ class MessageInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughInterruptSaveAndRestore(self):
 
@@ -58,8 +58,7 @@ class MessageInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
 
 def suite():

--- a/tests/SpiffWorkflow/bpmn/events/MessageInterruptsTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageInterruptsTest.py
@@ -30,13 +30,13 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.WAITING)))
 
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageInterruptSaveAndRestore(self):
 
@@ -61,9 +61,9 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.save_restore()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughHappy(self):
 
@@ -77,11 +77,11 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.do_next_exclusive_step('Do Something That Takes A Long Time')
 
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.WAITING)))
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageInterrupt(self):
 
@@ -101,8 +101,8 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.do_next_exclusive_step('Acknowledge Interrupt Message')
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.complete_subworkflow()
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
 
 def suite():

--- a/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptTest.py
@@ -31,13 +31,13 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.WAITING)))
 
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageInterruptSaveAndRestore(self):
 
@@ -71,8 +71,8 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.complete_subworkflow()
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughHappy(self):
 
@@ -87,11 +87,11 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.do_next_exclusive_step('Do Something That Takes A Long Time')
 
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.WAITING)))
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageInterrupt(self):
 
@@ -118,8 +118,8 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Do Something That Takes A Long Time')
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.complete_subworkflow()
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageInterruptOtherOrder(self):
 
@@ -145,8 +145,8 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Acknowledge Non-Interrupt Message')
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.complete_subworkflow()
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageInterruptOtherOrderSaveAndRestore(self):
 
@@ -177,8 +177,8 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.complete_subworkflow()
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
 
 def suite():

--- a/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptsSpTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptsSpTest.py
@@ -28,6 +28,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
 
         self.do_next_exclusive_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.save_restore()
 
         self.do_next_exclusive_step('Ack Subprocess Done')
@@ -35,8 +36,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageSaveAndRestore(self):
 
@@ -53,6 +53,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
 
         self.do_next_named_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.save_restore()
 
         self.do_next_named_step('Ack Subprocess Done')
@@ -64,8 +65,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageOrder2SaveAndRestore(self):
 
@@ -81,6 +81,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.workflow.catch(MessageEventDefinition('Test Message'))
         self.do_next_named_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.save_restore()
 
         self.do_next_named_step('Acknowledge SP Parallel Message')
@@ -92,8 +93,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageOrder3SaveAndRestore(self):
 
@@ -114,6 +114,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
 
         self.do_next_named_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.save_restore()
 
         self.do_next_named_step('Ack Subprocess Done')
@@ -121,8 +122,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
 
 def suite():

--- a/tests/SpiffWorkflow/bpmn/events/MessagesTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessagesTest.py
@@ -27,12 +27,11 @@ class MessagesTest(BpmnWorkflowTestCase):
         self.workflow.catch(MessageEventDefinition('Test Message'))
         self.assertEqual(1, len(self.workflow.get_tasks(TaskState.READY)))
 
-        self.assertEqual(
-            'Test Message', self.workflow.get_tasks(TaskState.READY)[0].task_spec.description)
+        self.assertEqual('Test Message', self.workflow.get_tasks(TaskState.READY)[0].task_spec.description)
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.complete_subworkflow()
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughSaveAndRestore(self):
 
@@ -52,8 +51,8 @@ class MessagesTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(
-            0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        self.complete_subworkflow()
+        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
 
 def suite():

--- a/tests/SpiffWorkflow/bpmn/events/MultipleThrowEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MultipleThrowEventTest.py
@@ -19,6 +19,7 @@ class MultipleThrowEventIntermediateCatchTest(BpmnWorkflowTestCase):
         if save_restore:
             self.save_restore()
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.assertEqual(len(self.workflow.get_waiting_tasks()), 0)
         self.assertEqual(self.workflow.is_completed(), True)
 
@@ -44,4 +45,5 @@ class MultipleThrowEventStartsEventTest(BpmnWorkflowTestCase):
         self.assertEqual(len(ready_tasks), 1)
         ready_tasks[0].run()
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.assertEqual(self.workflow.is_completed(), True)

--- a/tests/SpiffWorkflow/bpmn/events/NITimerDurationBoundaryTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/NITimerDurationBoundaryTest.py
@@ -65,7 +65,9 @@ class NITimerDurationTest(BpmnWorkflowTestCase):
             task.run()
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
-        self.assertEqual(self.workflow.is_completed(),True)
+        self.workflow.do_engine_steps()
+        self.complete_subworkflow()
+        self.assertEqual(self.workflow.is_completed(), True)
         self.assertEqual(self.workflow.last_task.data, {'work_done': 'Yes', 'delay_reason': 'Just Because'})
 
 

--- a/tests/SpiffWorkflow/bpmn/events/TransactionSubprocssTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TransactionSubprocssTest.py
@@ -25,6 +25,7 @@ class TransactionSubprocessTest(BpmnWorkflowTestCase):
         ready_tasks[0].update_data({'quantity': 2})
         ready_tasks[0].run()
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.assertIn('value', self.workflow.last_task.data)
 
         # Check that workflow and next task completed

--- a/tests/SpiffWorkflow/bpmn/serializer/VersionMigrationTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/VersionMigrationTest.py
@@ -23,6 +23,10 @@ class Version_1_0_Test(BaseTestCase):
         self.assertEqual('Action3', ready_tasks[0].task_spec.description)
         ready_tasks[0].run()
         wf.do_engine_steps()
+        wf.refresh_waiting_tasks()
+        wf.do_engine_steps()
+        wf.refresh_waiting_tasks()
+        wf.do_engine_steps()
         self.assertEqual(True, wf.is_completed())
 
 
@@ -34,11 +38,15 @@ class Version_1_1_Test(BaseTestCase):
         wf.script_engine = PythonScriptEngine(environment=TaskDataEnvironment({"time": time}))
         wf.refresh_waiting_tasks()
         wf.do_engine_steps()
+        wf.refresh_waiting_tasks()
+        wf.do_engine_steps()
         self.assertTrue(wf.is_completed())
 
     def test_convert_data_specs(self):
         fn = os.path.join(self.DATA_DIR, 'serialization', 'v1.1-data.json')
         wf = self.serializer.deserialize_json(open(fn).read())
+        wf.do_engine_steps()
+        wf.refresh_waiting_tasks()
         wf.do_engine_steps()
         self.assertTrue(wf.is_completed())
 

--- a/tests/SpiffWorkflow/camunda/CallActivityMessageTest.py
+++ b/tests/SpiffWorkflow/camunda/CallActivityMessageTest.py
@@ -41,7 +41,7 @@ class CallActivityMessageTest(BaseTestCase):
             current_task.update_data(step[1])
             current_task.run()
             self.workflow.do_engine_steps()
-            self.workflow.refresh_waiting_tasks()
+            self.complete_subworkflow()
             if save_restore: self.save_restore()
             ready_tasks = self.workflow.get_tasks(TaskState.READY)
         self.assertEqual(self.workflow.is_completed(),True,'Expected the workflow to be complete at this point')

--- a/tests/SpiffWorkflow/camunda/ExternalMessageBoundaryEventTest.py
+++ b/tests/SpiffWorkflow/camunda/ExternalMessageBoundaryEventTest.py
@@ -50,7 +50,7 @@ class ExternalMessageBoundaryTest(BaseTestCase):
         self.workflow.catch(MessageEventDefinition('reset', payload='SomethingDrastic', result_var='reset_var'))
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         # The user activity was cancelled and we should continue from the boundary event
-        self.assertEqual(1, len(ready_tasks),'Expected to have two ready tasks')
+        self.assertEqual(2, len(ready_tasks), 'Expected to have two ready tasks')
         event = self.workflow.get_tasks_from_spec_name('Event_19detfv')[0]
         event.run()
         self.assertEqual('SomethingDrastic', event.data['reset_var'])

--- a/tests/SpiffWorkflow/camunda/NIMessageBoundaryTest.py
+++ b/tests/SpiffWorkflow/camunda/NIMessageBoundaryTest.py
@@ -84,6 +84,7 @@ class NIMessageBoundaryTest(BaseTestCase):
         task.data['work_completed'] = 'Lots of Stuff'
         self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()
         self.assertEqual(self.workflow.is_completed(),True)
         self.assertEqual(self.workflow.last_task.data,{'Event_InterruptBoundary_Response': 'Youre late!',
                                                        'flag_task': 'Yes',

--- a/tests/SpiffWorkflow/camunda/ResetTokenSubWorkflowTest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenSubWorkflowTest.py
@@ -51,7 +51,7 @@ class ResetTokenTestSubProcess(BaseTestCase):
                 firsttaskid = task.id
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.run_task_from_id(task.id)
+            task.run()
             self.workflow.do_engine_steps()
             if save_restore:
                 self.save_restore()
@@ -75,8 +75,9 @@ class ResetTokenTestSubProcess(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual(step['taskname'], task.task_spec.name)
             task.update_data({step['formvar']: step['answer']})
-            self.workflow.run_task_from_id(task.id)
+            task.run()
             self.workflow.do_engine_steps()
+            self.complete_subworkflow()
             if save_restore:
                 self.save_restore()
 

--- a/tests/SpiffWorkflow/camunda/SubWorkflowTest.py
+++ b/tests/SpiffWorkflow/camunda/SubWorkflowTest.py
@@ -31,8 +31,9 @@ class SubWorkflowTest(BaseTestCase):
             task = self.workflow.get_ready_user_tasks()[0]
             self.assertEqual("Activity_"+answer, task.task_spec.name)
             task.update_data({"Field"+answer: answer})
-            self.workflow.run_task_from_id(task.id)
+            task.run()
             self.workflow.do_engine_steps()
+            self.complete_subworkflow()
             if save_restore: self.save_restore()
 
         self.assertEqual(self.workflow.last_task.data,{'FieldA': 'A',

--- a/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
+++ b/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
@@ -82,3 +82,4 @@ class PrescriptPostsciptTest(BaseTestCase):
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         ready_tasks[0].set_data(**data)
         self.workflow.do_engine_steps()
+        self.complete_subworkflow()


### PR DESCRIPTION
This is a fairly minor change, but required lots of test updates.

Boundary events were formerly being run from catch; ideally tasks should only run through an explicit call.  To fix boundary events, I had to also update subworkflow tasks not to immediately move to ready when the subworkflow completes (also a net positive since it removes a special case transition).

However, this means that they need to be updated before they become ready, and then they need to be run, which required lots of updates to our tests.