### PR TITLE
Feature/new task states

### DIFF
--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -71,7 +71,7 @@ class PythonScriptEngine(object):
     def execute(self, task, script, external_methods=None):
         """Execute the script, within the context of the specified task."""
         try:
-            self._execute(script, task.data, external_methods or {})
+            return self._execute(script, task.data, external_methods or {})
         except Exception as err:
             wte = self.create_task_exec_exception(task, script, err)
             raise wte
@@ -114,4 +114,4 @@ class PythonScriptEngine(object):
         return self.environment.evaluate(expression, context, external_methods)
 
     def _execute(self, script, context, external_methods=None):
-        self.environment.execute(script, context, external_methods)
+        return self.environment.execute(script, context, external_methods)

--- a/SpiffWorkflow/bpmn/PythonScriptEngine.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngine.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 import ast
-import copy
 import sys
 import traceback
 import warnings
 
 from .PythonScriptEngineEnvironment import TaskDataEnvironment
 from ..exceptions import SpiffWorkflowException, WorkflowTaskException
-from ..operators import Operator
 
 
 # Copyright (C) 2020 Kelly McDonald
@@ -40,10 +38,12 @@ class PythonScriptEngine(object):
     """
 
     def __init__(self, default_globals=None, scripting_additions=None, environment=None):
+
         if default_globals is not None or scripting_additions is not None:
             warnings.warn(f'default_globals and scripting_additions are deprecated.  '
                           f'Please provide an environment such as TaskDataEnvrionment',
                           DeprecationWarning, stacklevel=2)
+
         if environment is None:
             environment_globals = {}
             environment_globals.update(default_globals or {})
@@ -51,7 +51,6 @@ class PythonScriptEngine(object):
             self.environment = TaskDataEnvironment(environment_globals)
         else:
             self.environment = environment
-        self.error_tasks = {}
 
     def validate(self, expression):
         ast.parse(expression)
@@ -62,12 +61,7 @@ class PythonScriptEngine(object):
         return the result.
         """
         try:
-            if isinstance(expression, Operator):
-                # I am assuming that this takes care of some kind of XML
-                # expression judging from the contents of operators.py
-                return expression._matches(task)
-            else:
-                return self._evaluate(expression, task.data, external_methods)
+            return self._evaluate(expression, task.data, external_methods)
         except SpiffWorkflowException as se:
             se.add_note(f"Error evaluating expression '{expression}'")
             raise se
@@ -75,15 +69,11 @@ class PythonScriptEngine(object):
             raise WorkflowTaskException(f"Error evaluating expression '{expression}'", task=task, exception=e)
 
     def execute(self, task, script, external_methods=None):
-        """
-        Execute the script, within the context of the specified task
-        """
+        """Execute the script, within the context of the specified task."""
         try:
-            self.check_for_overwrite(task, external_methods or {})
             self._execute(script, task.data, external_methods or {})
         except Exception as err:
             wte = self.create_task_exec_exception(task, script, err)
-            self.error_tasks[task.id] = wte
             raise wte
 
     def call_service(self, operation_name, operation_params, task_data):
@@ -119,19 +109,6 @@ class PythonScriptEngine(object):
         if line_number > 0:
             error_line = script.splitlines()[line_number - 1]
         return line_number, error_line
-
-    def check_for_overwrite(self, task, external_methods):
-        """It's possible that someone will define a variable with the
-        same name as a pre-defined script, rending the script un-callable.
-        This results in a nearly indecipherable error.  Better to fail
-        fast with a sensible error message."""
-        func_overwrites = set(self.environment.globals).intersection(task.data)
-        func_overwrites.update(set(external_methods).intersection(task.data))
-        if len(func_overwrites) > 0:
-            msg = f"You have task data that overwrites a predefined " \
-                  f"function(s). Please change the following variable or " \
-                  f"field name(s) to something else: {func_overwrites}"
-            raise WorkflowTaskException(msg, task=task)
 
     def _evaluate(self, expression, context, external_methods=None):
         return self.environment.evaluate(expression, context, external_methods)

--- a/SpiffWorkflow/bpmn/PythonScriptEngineEnvironment.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngineEnvironment.py
@@ -49,7 +49,7 @@ class TaskDataEnvironment(BasePythonScriptEngineEnvironment):
 
     def check_for_overwrite(self, context, external_methods):
         """It's possible that someone will define a variable with the
-        same name as a pre-defined script, rending the script un-callable.
+        same name as a pre-defined script, rendering the script un-callable.
         This results in a nearly indecipherable error.  Better to fail
         fast with a sensible error message."""
         func_overwrites = set(self.globals).intersection(context)

--- a/SpiffWorkflow/bpmn/PythonScriptEngineEnvironment.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngineEnvironment.py
@@ -1,6 +1,7 @@
 import copy
 import warnings
 
+
 class BasePythonScriptEngineEnvironment:
     def __init__(self, environment_globals=None):
         self.globals = environment_globals or {}
@@ -11,7 +12,9 @@ class BasePythonScriptEngineEnvironment:
     def execute(self, script, context, external_methods=None):
         raise NotImplementedError("Subclass must implement this method")
 
+
 class TaskDataEnvironment(BasePythonScriptEngineEnvironment):
+
     def evaluate(self, expression, context, external_methods=None):
         my_globals = copy.copy(self.globals)  # else we pollute all later evals.
         self._prepare_context(context)
@@ -20,6 +23,7 @@ class TaskDataEnvironment(BasePythonScriptEngineEnvironment):
         return eval(expression, my_globals)
 
     def execute(self, script, context, external_methods=None):
+        self.check_for_overwrite(context, external_methods or {})
         my_globals = copy.copy(self.globals)
         self._prepare_context(context)
         my_globals.update(external_methods or {})
@@ -32,8 +36,7 @@ class TaskDataEnvironment(BasePythonScriptEngineEnvironment):
     def _prepare_context(self, context):
         pass
 
-    def _remove_globals_and_functions_from_context(self, context,
-                                                  external_methods=None):
+    def _remove_globals_and_functions_from_context(self, context, external_methods=None):
         """When executing a script, don't leave the globals, functions
         and external methods in the context that we have modified."""
         for k in list(context):
@@ -42,6 +45,20 @@ class TaskDataEnvironment(BasePythonScriptEngineEnvironment):
                     k in self.globals or \
                     external_methods and k in external_methods:
                 context.pop(k)
+
+    def check_for_overwrite(self, context, external_methods):
+        """It's possible that someone will define a variable with the
+        same name as a pre-defined script, rending the script un-callable.
+        This results in a nearly indecipherable error.  Better to fail
+        fast with a sensible error message."""
+        func_overwrites = set(self.globals).intersection(context)
+        func_overwrites.update(set(external_methods).intersection(context))
+        if len(func_overwrites) > 0:
+            msg = f"You have task data that overwrites a predefined " \
+                  f"function(s). Please change the following variable or " \
+                  f"field name(s) to something else: {func_overwrites}"
+            raise ValueError(msg)
+
 
 class Box(dict):
     """

--- a/SpiffWorkflow/bpmn/PythonScriptEngineEnvironment.py
+++ b/SpiffWorkflow/bpmn/PythonScriptEngineEnvironment.py
@@ -32,6 +32,7 @@ class TaskDataEnvironment(BasePythonScriptEngineEnvironment):
             exec(script, context)
         finally:
             self._remove_globals_and_functions_from_context(context, external_methods)
+        return True
 
     def _prepare_context(self, context):
         pass

--- a/SpiffWorkflow/bpmn/serializer/migration/version_migration.py
+++ b/SpiffWorkflow/bpmn/serializer/migration/version_migration.py
@@ -7,6 +7,7 @@ from .version_1_2 import (
     create_data_objects_and_io_specs,
     check_multiinstance,
     remove_loop_reset,
+    update_task_states,
 )
 
 def from_version_1_1(old):
@@ -36,6 +37,7 @@ def from_version_1_1(old):
     create_data_objects_and_io_specs(new)
     check_multiinstance(new)
     remove_loop_reset(new)
+    update_task_states(new)
     new['VERSION'] = "1.2"
     return new
 
@@ -53,6 +55,7 @@ def from_version_1_0(old):
     attributes based on the task states.
     """
     new = deepcopy(old)
+    new['VERSION'] = "1.1"
     move_subprocesses_to_top(new)
     return from_version_1_1(new)
 

--- a/SpiffWorkflow/bpmn/specs/ScriptTask.py
+++ b/SpiffWorkflow/bpmn/specs/ScriptTask.py
@@ -18,7 +18,6 @@
 # 02110-1301  USA
 
 from .BpmnSpecMixin import BpmnSpecMixin
-from ...task import TaskState
 from ...specs.Simple import Simple
 
 
@@ -30,13 +29,8 @@ class ScriptEngineTask(Simple, BpmnSpecMixin):
         pass
 
     def _run_hook(self, task):
-        try:
-            self._execute(task)
-            super(ScriptEngineTask, self)._run_hook(task)
-        except Exception as exc:
-            task._set_state(TaskState.WAITING)
-            raise exc
-        return True
+        return self._execute(task)
+
 
 class ScriptTask(ScriptEngineTask):
 
@@ -54,5 +48,4 @@ class ScriptTask(ScriptEngineTask):
         return 'Script Task'
 
     def _execute(self, task):
-        task.workflow.script_engine.execute(task, self.script)
-
+        return task.workflow.script_engine.execute(task, self.script)

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -381,6 +381,7 @@ class TaskSpec(object):
         pass
 
     def _on_error(self, my_task):
+        """Can be overridden for task specific error handling"""
         self._on_error_hook(my_task)
     
     def _on_error_hook(self, my_task):

--- a/SpiffWorkflow/specs/base.py
+++ b/SpiffWorkflow/specs/base.py
@@ -381,10 +381,10 @@ class TaskSpec(object):
         pass
 
     def _on_error(self, my_task):
-        """Can be overridden for task specific error handling"""
         self._on_error_hook(my_task)
     
     def _on_error_hook(self, my_task):
+        """Can be overridden for task specific error handling"""
         pass
 
     @abstractmethod

--- a/SpiffWorkflow/spiff/specs/service_task.py
+++ b/SpiffWorkflow/spiff/specs/service_task.py
@@ -1,5 +1,6 @@
-from copy import deepcopy
 import json
+from copy import deepcopy
+
 from SpiffWorkflow.bpmn.specs.ServiceTask import ServiceTask
 from SpiffWorkflow.exceptions import WorkflowTaskException
 from SpiffWorkflow.spiff.specs.spiff_task import SpiffBpmnTask
@@ -42,3 +43,4 @@ class ServiceTask(SpiffBpmnTask, ServiceTask):
             raise wte
         parsed_result = json.loads(result)
         task.data[self._result_variable(task)] = parsed_result
+        return True

--- a/SpiffWorkflow/spiff/specs/spiff_task.py
+++ b/SpiffWorkflow/spiff/specs/spiff_task.py
@@ -22,7 +22,7 @@ class SpiffBpmnTask(BpmnSpecMixin):
         try:
             my_task.workflow.script_engine.execute(my_task, script)
         except Exception as exc:
-            my_task._set_state(TaskState.WAITING)
+            my_task._set_state(TaskState.ERROR)
             raise exc
 
     def get_payload(self, my_task, script, expr):

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -66,37 +66,41 @@ class TaskState:
     created to allow for visualizing the workflow at a time where
     the required decisions have not yet been made.
     """
-    # Note: The states in this list are ordered in the sequence in which
-    # they may appear. Do not change.
     MAYBE = 1
     LIKELY = 2
     FUTURE = 4
     WAITING = 8
     READY = 16
-    COMPLETED = 32
-    CANCELLED = 64
+    STARTED = 32
+    COMPLETED = 64
+    ERROR = 128
+    CANCELLED = 256
 
-    FINISHED_MASK = CANCELLED | COMPLETED
-    DEFINITE_MASK = FUTURE | WAITING | READY
+    FINISHED_MASK = CANCELLED | ERROR | COMPLETED
+    DEFINITE_MASK = FUTURE | WAITING | READY | STARTED
     PREDICTED_MASK = LIKELY | MAYBE
     NOT_FINISHED_MASK = PREDICTED_MASK | DEFINITE_MASK
     ANY_MASK = FINISHED_MASK | NOT_FINISHED_MASK
 
 
-TaskStateNames = {TaskState.FUTURE: 'FUTURE',
-                  TaskState.WAITING: 'WAITING',
-                  TaskState.READY: 'READY',
-                  TaskState.CANCELLED: 'CANCELLED',
-                  TaskState.COMPLETED: 'COMPLETED',
-                  TaskState.LIKELY: 'LIKELY',
-                  TaskState.MAYBE: 'MAYBE'}
+TaskStateNames = {
+    TaskState.FUTURE: 'FUTURE',
+    TaskState.WAITING: 'WAITING',
+    TaskState.READY: 'READY',
+    TaskState.STARTED: 'STARTED',
+    TaskState.CANCELLED: 'CANCELLED',
+    TaskState.COMPLETED: 'COMPLETED',
+    TaskState.ERROR: 'ERROR',
+    TaskState.LIKELY: 'LIKELY',
+    TaskState.MAYBE: 'MAYBE'
+}
 TaskStateMasks = {
-                  TaskState.FINISHED_MASK: 'FINISHED_MASK',
-                  TaskState.DEFINITE_MASK: 'DEFINITE_MASK',
-                  TaskState.PREDICTED_MASK: 'PREDICTED_MASK',
-                  TaskState.NOT_FINISHED_MASK: 'NOT_FINISHED_MASK',
-                  TaskState.ANY_MASK: 'ANY_MASK',
-                  }
+    TaskState.FINISHED_MASK: 'FINISHED_MASK',
+    TaskState.DEFINITE_MASK: 'DEFINITE_MASK',
+    TaskState.PREDICTED_MASK: 'PREDICTED_MASK',
+    TaskState.NOT_FINISHED_MASK: 'NOT_FINISHED_MASK',
+    TaskState.ANY_MASK: 'ANY_MASK',
+}
 
 
 class DeprecatedMetaTask(type):
@@ -629,10 +633,18 @@ class Task(object,  metaclass=DeprecatedMetaTask):
         })
         metrics.debug('', extra=extra)
         if retval is None:
-            self._set_state(TaskState.WAITING)
+            # This state is intended to indicate a task that is not finished, but can continue
+            # in the background without blocking other unrelated tasks (it on other branches)
+            # If a task is set to "started", it will have to be tracked indepentenly of the workflow
+            # and completed manually when it finishes for the time being (probably I'll add polling
+            # methods in the future, but I'm not exactly sure how they should work).
+            # I'm adding this state now, because I'm add an error state (which I think there is a
+            # need for and don't want to do throuh the hassle of updatin serialization of task states
+            # twice; doing this at all is going to be painful enough).
+            self._set_state(TaskState.STARTED)
+        elif retval is False:
+            self.error()
         else:
-            # If we add an error state, the we can move the task to COMPLETE or ERROR
-            # according to the return value.
             self.complete()
         return retval
 
@@ -651,6 +663,10 @@ class Task(object,  metaclass=DeprecatedMetaTask):
         self._set_state(TaskState.COMPLETED)
         self.task_spec._on_complete(self)
         self.workflow.last_task = self
+
+    def error(self):
+        self._set_state(TaskState.ERROR)
+        self.task_spec._on_error(self)
 
     def trigger(self, *args):
         """

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -635,12 +635,12 @@ class Task(object,  metaclass=DeprecatedMetaTask):
         if retval is None:
             # This state is intended to indicate a task that is not finished, but can continue
             # in the background without blocking other unrelated tasks (it on other branches)
-            # If a task is set to "started", it will have to be tracked indepentenly of the workflow
+            # If a task is set to "started", it will have to be tracked independently of the workflow
             # and completed manually when it finishes for the time being (probably I'll add polling
             # methods in the future, but I'm not exactly sure how they should work).
-            # I'm adding this state now, because I'm add an error state (which I think there is a
-            # need for and don't want to do throuh the hassle of updatin serialization of task states
-            # twice; doing this at all is going to be painful enough).
+            # I'm adding this state now because I'm adding an error state (which I think there is a
+            # need for) and don't want to go through the hassle of updating serialization of task states
+            # twice; doing this at all is going to be painful enough.
             self._set_state(TaskState.STARTED)
         elif retval is False:
             self.error()

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -633,11 +633,14 @@ class Task(object,  metaclass=DeprecatedMetaTask):
         })
         metrics.debug('', extra=extra)
         if retval is None:
-            # This state is intended to indicate a task that is not finished, but can continue
-            # in the background without blocking other unrelated tasks (it on other branches)
-            # If a task is set to "started", it will have to be tracked independently of the workflow
-            # and completed manually when it finishes for the time being (probably I'll add polling
-            # methods in the future, but I'm not exactly sure how they should work).
+            # This state is intended to indicate a task that is not finished, but will continue
+            # in the background without blocking other unrelated tasks (ie on other branches).
+            # It is a distinct state from "waiting" so that `update` does not have to distinguish
+            # between tasks that can be started and tasks that have already been started.  
+            # Spiff can manage deciding if a task can run, but if a task is set to "started", it will
+            # have to be tracked independently of the workflow and completed manually when it finishes 
+            # for the time being (probably I'll add polling methods in the future, but I'm not exactly 
+            # sure how they should work).
             # I'm adding this state now because I'm adding an error state (which I think there is a
             # need for) and don't want to go through the hassle of updating serialization of task states
             # twice; doing this at all is going to be painful enough.

--- a/tests/SpiffWorkflow/bpmn/CallActivityEndEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivityEndEventTest.py
@@ -6,6 +6,8 @@ from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
 
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from SpiffWorkflow.exceptions import WorkflowTaskException
+from SpiffWorkflow.task import TaskState
+
 from .BpmnWorkflowTestCase import BpmnWorkflowTestCase
 
 __author__ = 'kellym'
@@ -66,6 +68,8 @@ class CallActivityTest(BpmnWorkflowTestCase):
         self.assertEquals(2, len(context.exception.task_trace))
         self.assertRegexpMatches(context.exception.task_trace[0], 'Create Data \(.*?call_activity_call_activity.bpmn\)')
         self.assertRegexpMatches(context.exception.task_trace[1], 'Get Data Call Activity \(.*?call_activity_with_error.bpmn\)')
+        task = self.workflow.get_tasks_from_spec_name('Sub_Bpmn_Task')[0]
+        self.assertEqual(task.state, TaskState.ERROR)
 
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(CallActivityTest)

--- a/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
+++ b/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
@@ -51,7 +51,6 @@ class CustomInlineScriptTest(BpmnWorkflowTestCase):
         ready_task.data = {'custom_function': "bill"}
         with self.assertRaises(WorkflowTaskException) as e:
             self.workflow.do_engine_steps()
-        self.assertTrue('' in str(e.exception))
         self.assertTrue('custom_function' in str(e.exception))
 
 

--- a/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
+++ b/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
@@ -52,6 +52,8 @@ class CustomInlineScriptTest(BpmnWorkflowTestCase):
         with self.assertRaises(WorkflowTaskException) as e:
             self.workflow.do_engine_steps()
         self.assertTrue('custom_function' in str(e.exception))
+        task = self.workflow.get_tasks_from_spec_name('Activity_1y303ko')[0]
+        self.assertEqual(task.state, TaskState.ERROR)
 
 
 def suite():

--- a/tests/SpiffWorkflow/bpmn/ExclusiveGatewayNoDefaultTest.py
+++ b/tests/SpiffWorkflow/bpmn/ExclusiveGatewayNoDefaultTest.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
-
-
-
-import sys
-import os
 import unittest
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
-from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
 from SpiffWorkflow.exceptions import WorkflowException
+from SpiffWorkflow.task import TaskState
+
+from .BpmnWorkflowTestCase import BpmnWorkflowTestCase
 
 __author__ = 'essweine'
 
@@ -25,6 +22,8 @@ class ExclusiveGatewayNoDefaultTest(BpmnWorkflowTestCase):
         first = self.workflow.get_tasks_from_spec_name('StartEvent_1')[0]
         first.data = { 'x': 1 }
         self.assertRaises(WorkflowException, self.workflow.do_engine_steps)
+        task = self.workflow.get_tasks_from_spec_name('Gateway_CheckValue')[0]
+        self.assertEqual(task.state, TaskState.ERROR)
 
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(ExclusiveGatewayNoDefaultTest)

--- a/tests/SpiffWorkflow/bpmn/InclusiveGatewayTest.py
+++ b/tests/SpiffWorkflow/bpmn/InclusiveGatewayTest.py
@@ -1,5 +1,6 @@
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from SpiffWorkflow.exceptions import WorkflowTaskException
+from SpiffWorkflow.task import TaskState
 
 from .BpmnWorkflowTestCase import BpmnWorkflowTestCase
 
@@ -26,6 +27,8 @@ class InclusiveGatewayTest(BpmnWorkflowTestCase):
     def testNoPathFromSecondGateway(self):
         self.set_data({'v': 0, 'u': -1, 'w': -1})
         self.assertRaises(WorkflowTaskException, self.workflow.do_engine_steps)
+        task = self.workflow.get_tasks_from_spec_name('second')[0]
+        self.assertEqual(task.state, TaskState.ERROR)
 
     def testParallelCondition(self):
         self.set_data({'v': 0, 'u': 1, 'w': 1})

--- a/tests/SpiffWorkflow/bpmn/data/script-start.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/script-start.bpmn
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Process_cozt5fu" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1r4la8u</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1r4la8u" sourceRef="StartEvent_1" targetRef="Gateway_1b4ue4p" />
+    <bpmn:parallelGateway id="Gateway_1b4ue4p">
+      <bpmn:incoming>Flow_1r4la8u</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rx8ly6</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0m6kw0s</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0rx8ly6" sourceRef="Gateway_1b4ue4p" targetRef="script" />
+    <bpmn:sequenceFlow id="Flow_0m6kw0s" sourceRef="Gateway_1b4ue4p" targetRef="manual" />
+    <bpmn:scriptTask id="script" name="script">
+      <bpmn:incoming>Flow_0rx8ly6</bpmn:incoming>
+      <bpmn:outgoing>Flow_1wcrqdb</bpmn:outgoing>
+      <bpmn:script>x, y = 1, 2
+z = x + y</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:manualTask id="manual" name="manual">
+      <bpmn:incoming>Flow_0m6kw0s</bpmn:incoming>
+      <bpmn:outgoing>Flow_0npa1g8</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1wcrqdb" sourceRef="script" targetRef="Gateway_0lxkg29" />
+    <bpmn:sequenceFlow id="Flow_0npa1g8" sourceRef="manual" targetRef="Gateway_0lxkg29" />
+    <bpmn:parallelGateway id="Gateway_0lxkg29">
+      <bpmn:incoming>Flow_1wcrqdb</bpmn:incoming>
+      <bpmn:incoming>Flow_0npa1g8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vd5x0n</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="Event_05ezfux">
+      <bpmn:incoming>Flow_1vd5x0n</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1vd5x0n" sourceRef="Gateway_0lxkg29" targetRef="Event_05ezfux" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_cozt5fu">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0wzobnw_di" bpmnElement="Gateway_1b4ue4p">
+        <dc:Bounds x="265" y="152" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ufpwld_di" bpmnElement="script">
+        <dc:Bounds x="370" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0q6915b_di" bpmnElement="manual">
+        <dc:Bounds x="370" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1rol38p_di" bpmnElement="Gateway_0lxkg29">
+        <dc:Bounds x="535" y="265" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05ezfux_di" bpmnElement="Event_05ezfux">
+        <dc:Bounds x="632" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1r4la8u_di" bpmnElement="Flow_1r4la8u">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="265" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rx8ly6_di" bpmnElement="Flow_0rx8ly6">
+        <di:waypoint x="315" y="177" />
+        <di:waypoint x="370" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m6kw0s_di" bpmnElement="Flow_0m6kw0s">
+        <di:waypoint x="290" y="202" />
+        <di:waypoint x="290" y="290" />
+        <di:waypoint x="370" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wcrqdb_di" bpmnElement="Flow_1wcrqdb">
+        <di:waypoint x="470" y="177" />
+        <di:waypoint x="560" y="177" />
+        <di:waypoint x="560" y="265" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0npa1g8_di" bpmnElement="Flow_0npa1g8">
+        <di:waypoint x="470" y="290" />
+        <di:waypoint x="535" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vd5x0n_di" bpmnElement="Flow_1vd5x0n">
+        <di:waypoint x="585" y="290" />
+        <di:waypoint x="632" y="290" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/serialization/v1.1-task-states.json
+++ b/tests/SpiffWorkflow/bpmn/data/serialization/v1.1-task-states.json
@@ -1,0 +1,563 @@
+{
+  "serializer_version": "1.1",
+  "data": {}, 
+  "last_task": "3a4a6596-3b3d-4cd5-9724-cd1ccc263676", 
+  "success": true, 
+  "tasks": {
+    "d10fb568-6104-4a26-9081-e29c8eb42e70": {
+      "id": "d10fb568-6104-4a26-9081-e29c8eb42e70", 
+      "parent": null, 
+      "children": [
+        "f0a4e631-c30a-4444-b2b1-2cdc21179c65"
+      ], 
+      "last_state_change": 1681913960.451874, 
+      "state": 32, 
+      "task_spec": "Root", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "f0a4e631-c30a-4444-b2b1-2cdc21179c65": {
+      "id": "f0a4e631-c30a-4444-b2b1-2cdc21179c65", 
+      "parent": "d10fb568-6104-4a26-9081-e29c8eb42e70", 
+      "children": [
+        "3468f48a-c493-4731-9484-0821d046a0bc"
+      ], 
+      "last_state_change": 1681913960.4591289, 
+      "state": 32, 
+      "task_spec": "Start", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "3468f48a-c493-4731-9484-0821d046a0bc": {
+      "id": "3468f48a-c493-4731-9484-0821d046a0bc", 
+      "parent": "f0a4e631-c30a-4444-b2b1-2cdc21179c65", 
+      "children": [
+        "0366c1b3-d55e-42e4-a6fd-db2d6a1940eb"
+      ], 
+      "last_state_change": 1681913960.460862, 
+      "state": 32, 
+      "task_spec": "StartEvent_1", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {
+        "event_fired": true
+      }, 
+      "data": {}
+    }, 
+    "0366c1b3-d55e-42e4-a6fd-db2d6a1940eb": {
+      "id": "0366c1b3-d55e-42e4-a6fd-db2d6a1940eb", 
+      "parent": "3468f48a-c493-4731-9484-0821d046a0bc", 
+      "children": [
+        "afd334bf-f987-46b3-b6df-779562c4b4bf", 
+        "ad8b1640-55ac-4ff5-b07e-16c0b7c92976"
+      ], 
+      "last_state_change": 1681913960.4621637, 
+      "state": 32, 
+      "task_spec": "task_1.BoundaryEventParent", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "afd334bf-f987-46b3-b6df-779562c4b4bf": {
+      "id": "afd334bf-f987-46b3-b6df-779562c4b4bf", 
+      "parent": "0366c1b3-d55e-42e4-a6fd-db2d6a1940eb", 
+      "children": [
+        "3a4a6596-3b3d-4cd5-9724-cd1ccc263676"
+      ], 
+      "last_state_change": 1681913960.4634154, 
+      "state": 32, 
+      "task_spec": "task_1", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "3a4a6596-3b3d-4cd5-9724-cd1ccc263676": {
+      "id": "3a4a6596-3b3d-4cd5-9724-cd1ccc263676", 
+      "parent": "afd334bf-f987-46b3-b6df-779562c4b4bf", 
+      "children": [
+        "8ee8a04c-e784-4419-adb4-7c7f99f72bf6", 
+        "00c5b447-760e-47dc-a77b-cffbf893d098"
+      ], 
+      "last_state_change": 1681913960.4667528, 
+      "state": 32, 
+      "task_spec": "Gateway_1eg2w56", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "8ee8a04c-e784-4419-adb4-7c7f99f72bf6": {
+      "id": "8ee8a04c-e784-4419-adb4-7c7f99f72bf6", 
+      "parent": "3a4a6596-3b3d-4cd5-9724-cd1ccc263676", 
+      "children": [
+        "cee7ab8e-d50b-4681-94f2-51bbd8dd6df1"
+      ], 
+      "last_state_change": 1681913960.4669333, 
+      "state": 16, 
+      "task_spec": "task_2", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "cee7ab8e-d50b-4681-94f2-51bbd8dd6df1": {
+      "id": "cee7ab8e-d50b-4681-94f2-51bbd8dd6df1", 
+      "parent": "8ee8a04c-e784-4419-adb4-7c7f99f72bf6", 
+      "children": [
+        "4695356f-8db1-48f6-a8bb-d610b2da7a63"
+      ], 
+      "last_state_change": 1681913960.454116, 
+      "state": 4, 
+      "task_spec": "Gateway_1dpu3vt", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "4695356f-8db1-48f6-a8bb-d610b2da7a63": {
+      "id": "4695356f-8db1-48f6-a8bb-d610b2da7a63", 
+      "parent": "cee7ab8e-d50b-4681-94f2-51bbd8dd6df1", 
+      "children": [
+        "f4ab0e07-d985-412f-aca0-369bd29797e1"
+      ], 
+      "last_state_change": 1681913960.45428, 
+      "state": 4, 
+      "task_spec": "Event_1deqprp", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "f4ab0e07-d985-412f-aca0-369bd29797e1": {
+      "id": "f4ab0e07-d985-412f-aca0-369bd29797e1", 
+      "parent": "4695356f-8db1-48f6-a8bb-d610b2da7a63", 
+      "children": [
+        "e326e6ec-f20d-4171-8133-24b160ad3404"
+      ], 
+      "last_state_change": 1681913960.4544458, 
+      "state": 4, 
+      "task_spec": "main.EndJoin", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "e326e6ec-f20d-4171-8133-24b160ad3404": {
+      "id": "e326e6ec-f20d-4171-8133-24b160ad3404", 
+      "parent": "f4ab0e07-d985-412f-aca0-369bd29797e1", 
+      "children": [], 
+      "last_state_change": 1681913960.4546103, 
+      "state": 4, 
+      "task_spec": "End", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "00c5b447-760e-47dc-a77b-cffbf893d098": {
+      "id": "00c5b447-760e-47dc-a77b-cffbf893d098", 
+      "parent": "3a4a6596-3b3d-4cd5-9724-cd1ccc263676", 
+      "children": [
+        "c57e4be7-670c-41aa-9740-9fff831f6ccd"
+      ], 
+      "last_state_change": 1681913960.4671006, 
+      "state": 16, 
+      "task_spec": "task_3", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "c57e4be7-670c-41aa-9740-9fff831f6ccd": {
+      "id": "c57e4be7-670c-41aa-9740-9fff831f6ccd", 
+      "parent": "00c5b447-760e-47dc-a77b-cffbf893d098", 
+      "children": [
+        "ee2c8edc-5d5e-4fc2-ba4b-1801d000c6c3"
+      ], 
+      "last_state_change": 1681913960.454881, 
+      "state": 4, 
+      "task_spec": "Gateway_1dpu3vt", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "ee2c8edc-5d5e-4fc2-ba4b-1801d000c6c3": {
+      "id": "ee2c8edc-5d5e-4fc2-ba4b-1801d000c6c3", 
+      "parent": "c57e4be7-670c-41aa-9740-9fff831f6ccd", 
+      "children": [
+        "91a213bf-bef6-40fa-b0a4-7c7f58552184"
+      ], 
+      "last_state_change": 1681913960.4550629, 
+      "state": 4, 
+      "task_spec": "Event_1deqprp", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "91a213bf-bef6-40fa-b0a4-7c7f58552184": {
+      "id": "91a213bf-bef6-40fa-b0a4-7c7f58552184", 
+      "parent": "ee2c8edc-5d5e-4fc2-ba4b-1801d000c6c3", 
+      "children": [
+        "8166e255-1d17-4f94-8c0e-82cefe8500fd"
+      ], 
+      "last_state_change": 1681913960.4552596, 
+      "state": 4, 
+      "task_spec": "main.EndJoin", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "8166e255-1d17-4f94-8c0e-82cefe8500fd": {
+      "id": "8166e255-1d17-4f94-8c0e-82cefe8500fd", 
+      "parent": "91a213bf-bef6-40fa-b0a4-7c7f58552184", 
+      "children": [], 
+      "last_state_change": 1681913960.455456, 
+      "state": 4, 
+      "task_spec": "End", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {}, 
+      "data": {}
+    }, 
+    "ad8b1640-55ac-4ff5-b07e-16c0b7c92976": {
+      "id": "ad8b1640-55ac-4ff5-b07e-16c0b7c92976", 
+      "parent": "0366c1b3-d55e-42e4-a6fd-db2d6a1940eb", 
+      "children": [], 
+      "last_state_change": 1681913960.463645, 
+      "state": 64, 
+      "task_spec": "signal", 
+      "triggered": false, 
+      "workflow_name": "main", 
+      "internal_data": {
+        "event_fired": false
+      }, 
+      "data": {}
+    }
+  }, 
+  "root": "d10fb568-6104-4a26-9081-e29c8eb42e70", 
+  "spec": {
+    "name": "main", 
+    "description": "main", 
+    "file": "/home/essweine/work/sartography/code/SpiffWorkflow/tests/SpiffWorkflow/bpmn/data/diagram_1.bpmn", 
+    "task_specs": {
+      "Start": {
+        "id": "main_1", 
+        "name": "Start", 
+        "description": "", 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [], 
+        "outputs": [
+          "StartEvent_1"
+        ], 
+        "typename": "StartTask"
+      }, 
+      "main.EndJoin": {
+        "id": "main_2", 
+        "name": "main.EndJoin", 
+        "description": "", 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "Event_1deqprp"
+        ], 
+        "outputs": [
+          "End"
+        ], 
+        "typename": "_EndJoin"
+      }, 
+      "End": {
+        "id": "main_3", 
+        "name": "End", 
+        "description": "", 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "main.EndJoin"
+        ], 
+        "outputs": [], 
+        "typename": "Simple"
+      }, 
+      "StartEvent_1": {
+        "id": "main_4", 
+        "name": "StartEvent_1", 
+        "description": null, 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "Start"
+        ], 
+        "outputs": [
+          "task_1.BoundaryEventParent"
+        ], 
+        "lane": null, 
+        "documentation": null, 
+        "position": {
+          "x": 179.0, 
+          "y": 99.0
+        }, 
+        "data_input_associations": [], 
+        "data_output_associations": [], 
+        "io_specification": null, 
+        "event_definition": {
+          "internal": false, 
+          "external": false, 
+          "typename": "NoneEventDefinition"
+        }, 
+        "typename": "StartEvent", 
+        "extensions": {}
+      }, 
+      "task_1": {
+        "id": "main_5", 
+        "name": "task_1", 
+        "description": "Task 1", 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "task_1.BoundaryEventParent"
+        ], 
+        "outputs": [
+          "Gateway_1eg2w56"
+        ], 
+        "lane": null, 
+        "documentation": null, 
+        "position": {
+          "x": 270.0, 
+          "y": 77.0
+        }, 
+        "data_input_associations": [], 
+        "data_output_associations": [], 
+        "io_specification": null, 
+        "typename": "NoneTask", 
+        "extensions": {}
+      }, 
+      "task_1.BoundaryEventParent": {
+        "id": "main_6", 
+        "name": "task_1.BoundaryEventParent", 
+        "description": "", 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "StartEvent_1"
+        ], 
+        "outputs": [
+          "task_1", 
+          "signal"
+        ], 
+        "lane": null, 
+        "documentation": null, 
+        "position": {
+          "x": 0, 
+          "y": 0
+        }, 
+        "data_input_associations": [], 
+        "data_output_associations": [], 
+        "io_specification": null, 
+        "main_child_task_spec": "task_1", 
+        "typename": "_BoundaryEventParent"
+      }, 
+      "signal": {
+        "id": "main_7", 
+        "name": "signal", 
+        "description": "Signal Event", 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "task_1.BoundaryEventParent"
+        ], 
+        "outputs": [], 
+        "lane": null, 
+        "documentation": null, 
+        "position": {
+          "x": 302.0, 
+          "y": 139.0
+        }, 
+        "data_input_associations": [], 
+        "data_output_associations": [], 
+        "io_specification": null, 
+        "event_definition": {
+          "internal": true, 
+          "external": true, 
+          "name": "Signal_08n3u9r", 
+          "typename": "SignalEventDefinition"
+        }, 
+        "cancel_activity": true, 
+        "typename": "BoundaryEvent", 
+        "extensions": {}
+      }, 
+      "Gateway_1eg2w56": {
+        "id": "main_8", 
+        "name": "Gateway_1eg2w56", 
+        "description": null, 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "task_1"
+        ], 
+        "outputs": [
+          "task_2", 
+          "task_3"
+        ], 
+        "lane": null, 
+        "documentation": null, 
+        "position": {
+          "x": 425.0, 
+          "y": 92.0
+        }, 
+        "data_input_associations": [], 
+        "data_output_associations": [], 
+        "io_specification": null, 
+        "split_task": null, 
+        "threshold": null, 
+        "cancel": false, 
+        "typename": "ParallelGateway", 
+        "extensions": {}
+      }, 
+      "task_2": {
+        "id": "main_9", 
+        "name": "task_2", 
+        "description": "Task 2", 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "Gateway_1eg2w56"
+        ], 
+        "outputs": [
+          "Gateway_1dpu3vt"
+        ], 
+        "lane": null, 
+        "documentation": null, 
+        "position": {
+          "x": 530.0, 
+          "y": 77.0
+        }, 
+        "data_input_associations": [], 
+        "data_output_associations": [], 
+        "io_specification": null, 
+        "typename": "NoneTask", 
+        "extensions": {}
+      }, 
+      "Gateway_1dpu3vt": {
+        "id": "main_10", 
+        "name": "Gateway_1dpu3vt", 
+        "description": null, 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "task_2", 
+          "task_3"
+        ], 
+        "outputs": [
+          "Event_1deqprp"
+        ], 
+        "lane": null, 
+        "documentation": null, 
+        "position": {
+          "x": 685.0, 
+          "y": 92.0
+        }, 
+        "data_input_associations": [], 
+        "data_output_associations": [], 
+        "io_specification": null, 
+        "split_task": null, 
+        "threshold": null, 
+        "cancel": false, 
+        "typename": "ParallelGateway", 
+        "extensions": {}
+      }, 
+      "Event_1deqprp": {
+        "id": "main_11", 
+        "name": "Event_1deqprp", 
+        "description": null, 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "Gateway_1dpu3vt"
+        ], 
+        "outputs": [
+          "main.EndJoin"
+        ], 
+        "lane": null, 
+        "documentation": null, 
+        "position": {
+          "x": 792.0, 
+          "y": 99.0
+        }, 
+        "data_input_associations": [], 
+        "data_output_associations": [], 
+        "io_specification": null, 
+        "event_definition": {
+          "internal": false, 
+          "external": false, 
+          "typename": "NoneEventDefinition"
+        }, 
+        "typename": "EndEvent", 
+        "extensions": {}
+      }, 
+      "task_3": {
+        "id": "main_12", 
+        "name": "task_3", 
+        "description": "Task 3", 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [
+          "Gateway_1eg2w56"
+        ], 
+        "outputs": [
+          "Gateway_1dpu3vt"
+        ], 
+        "lane": null, 
+        "documentation": null, 
+        "position": {
+          "x": 530.0, 
+          "y": 190.0
+        }, 
+        "data_input_associations": [], 
+        "data_output_associations": [], 
+        "io_specification": null, 
+        "typename": "NoneTask", 
+        "extensions": {}
+      }, 
+      "Root": {
+        "id": "main_13", 
+        "name": "Root", 
+        "description": "", 
+        "manual": false, 
+        "internal": false, 
+        "lookahead": 2, 
+        "inputs": [], 
+        "outputs": [], 
+        "typename": "Simple"
+      }
+    }, 
+    "io_specification": null, 
+    "data_objects": {}, 
+    "correlation_keys": {}, 
+    "typename": "BpmnProcessSpec"
+  }, 
+  "subprocess_specs": {}, 
+  "subprocesses": {}, 
+  "bpmn_messages": [], 
+  "correlations": {}
+}

--- a/tests/SpiffWorkflow/bpmn/serializer/VersionMigrationTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/VersionMigrationTest.py
@@ -79,3 +79,16 @@ class Version_1_1_Test(BaseTestCase):
             wf.refresh_waiting_tasks()
         self.assertTrue(wf.is_completed())
         self.assertEqual(wf.last_task.data['counter'], 20)
+
+    def test_update_task_states(self):
+        fn = os.path.join(self.DATA_DIR, 'serialization', 'v1.1-task-states.json')
+        wf = self.serializer.deserialize_json(open(fn).read())
+        start = wf.get_tasks_from_spec_name('Start')[0]
+        self.assertEqual(start.state, TaskState.COMPLETED)
+        signal = wf.get_tasks_from_spec_name('signal')[0]
+        self.assertEqual(signal.state, TaskState.CANCELLED)
+        ready_tasks = wf.get_tasks(TaskState.READY)
+        while len(ready_tasks) > 0:
+            ready_tasks[0].run()
+            ready_tasks = wf.get_tasks(TaskState.READY)
+        self.assertTrue(wf.is_completed())

--- a/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
+++ b/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
@@ -58,6 +58,8 @@ class PrescriptPostsciptTest(BaseTestCase):
             self.workflow.do_engine_steps()
         ex = se.exception
         self.assertIn("Error occurred in the Pre-Script", str(ex))
+        task = self.workflow.get_tasks_from_spec_name('Activity_1iqs4li')[0]
+        self.assertEqual(task.state, TaskState.ERROR)
 
     def call_activity_test(self, save_restore=False):
 


### PR DESCRIPTION
This adds two new task states:
- An `ERROR` state
- A `STARTED` state that can be used to indicate task execution is being managed outside spiff

When a task is run, it should return `True` on successful completion, `False` if something went wrong but it was handled elsewhere,or `None` if it hasn't finished.  By default, `run` will return `True`, except in the case of script tasks, which will use the value returned by `_execute`.  Custom script engines will need to be updated to accommodate this.

This change is intended to make it easier to manage execution of scripts and service tasks outside of spiffworkflow
- tasks can be executed asynchronously more easily
- errors can be handled more gracefully

If an unhandled exception occurs during the execution of any task, the state will change to `ERROR` and the exception will be raised.