### PR TITLE
change the order of tasks when calling get_tasks()

### DIFF
--- a/SpiffWorkflow/bpmn/workflow.py
+++ b/SpiffWorkflow/bpmn/workflow.py
@@ -292,10 +292,10 @@ class BpmnWorkflow(Workflow):
         # almost surely be in a different state than the tasks we want
         for task in Workflow.get_tasks_iterator(wf):
             subprocess = top.subprocesses.get(task.id)
-            if subprocess is not None:
-                tasks.extend(subprocess.get_tasks(state, subprocess))
             if task._has_state(state):
                 tasks.append(task)
+            if subprocess is not None:
+                tasks.extend(subprocess.get_tasks(state, subprocess))
         return tasks
 
     def get_task_from_id(self, task_id, workflow=None):

--- a/tests/SpiffWorkflow/bpmn/CallActivityEndEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivityEndEventTest.py
@@ -71,6 +71,18 @@ class CallActivityTest(BpmnWorkflowTestCase):
         task = self.workflow.get_tasks_from_spec_name('Sub_Bpmn_Task')[0]
         self.assertEqual(task.state, TaskState.ERROR)
 
+    def test_order_of_tasks_in_get_task_is_call_acitivty_task_first_then_sub_tasks(self):
+        self.workflow = BpmnWorkflow(self.spec, self.subprocesses)
+        self.workflow.do_engine_steps()
+        tasks = self.workflow.get_tasks()
+        def index_of(name):
+            return [i for i, x in enumerate(tasks) if x.task_spec.name == name][0]
+
+        self.assertLess(index_of('Activity_Call_Activity'), index_of('Start_Called_Activity'))
+        self.assertLess(index_of('Activity_Call_Activity'), index_of('Sub_Bpmn_Task'))
+        self.assertLess(index_of('Activity_Call_Activity'), index_of('End_Called_Activity'))
+
+
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(CallActivityTest)
 if __name__ == '__main__':

--- a/tests/SpiffWorkflow/bpmn/data/call_activity_call_activity.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/call_activity_call_activity.bpmn
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_34b94b6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_34b94b6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
   <bpmn:process id="Call_Activity_Get_Data" name="Call Activity Get Data" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1">
+    <bpmn:startEvent id="Start_Called_Activity">
       <bpmn:outgoing>Flow_07uhaa7</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_07uhaa7" sourceRef="StartEvent_1" targetRef="Sub_Bpmn_Task" />
-    <bpmn:endEvent id="Event_1rokcus">
+    <bpmn:sequenceFlow id="Flow_07uhaa7" sourceRef="Start_Called_Activity" targetRef="Sub_Bpmn_Task" />
+    <bpmn:endEvent id="End_Called_Activity">
       <bpmn:documentation># Call Event
 &lt;div&gt;&lt;span&gt;Hello {{my_var}}&lt;/span&gt;&lt;/div&gt;</bpmn:documentation>
       <bpmn:incoming>Flow_0apfnjq</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_0apfnjq" sourceRef="Sub_Bpmn_Task" targetRef="Event_1rokcus" />
+    <bpmn:sequenceFlow id="Flow_0apfnjq" sourceRef="Sub_Bpmn_Task" targetRef="End_Called_Activity" />
     <bpmn:scriptTask id="Sub_Bpmn_Task" name="Create Data">
       <bpmn:incoming>Flow_07uhaa7</bpmn:incoming>
       <bpmn:outgoing>Flow_0apfnjq</bpmn:outgoing>
@@ -29,10 +29,10 @@ del(remove_this_var)</bpmn:script>
         <di:waypoint x="215" y="117" />
         <di:waypoint x="270" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="Start_Called_Activity">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1rokcus_di" bpmnElement="Event_1rokcus">
+      <bpmndi:BPMNShape id="Event_1rokcus_di" bpmnElement="End_Called_Activity">
         <dc:Bounds x="432" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0esr09m_di" bpmnElement="Sub_Bpmn_Task">

--- a/tests/SpiffWorkflow/bpmn/data/call_activity_end_event.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/call_activity_end_event.bpmn
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_f07329e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_f07329e" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0">
   <bpmn:process id="Process_8200379" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1g3dpd7</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_1g3dpd7" sourceRef="StartEvent_1" targetRef="Activity_0wppf2v" />
-    <bpmn:sequenceFlow id="Flow_0ovgj6c" sourceRef="Activity_0wppf2v" targetRef="Activity_12zat0d" />
-    <bpmn:callActivity id="Activity_12zat0d" name="Get Data Call Activity" calledElement="Call_Activity_Get_Data">
+    <bpmn:sequenceFlow id="Flow_1g3dpd7" sourceRef="StartEvent_1" targetRef="Pre_Data_Script" />
+    <bpmn:sequenceFlow id="Flow_0ovgj6c" sourceRef="Pre_Data_Script" targetRef="Activity_Call_Activity" />
+    <bpmn:callActivity id="Activity_Call_Activity" name="Get Data Call Activity" calledElement="Call_Activity_Get_Data">
       <bpmn:incoming>Flow_0ovgj6c</bpmn:incoming>
       <bpmn:outgoing>Flow_0qdgvah</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="Flow_0qdgvah" sourceRef="Activity_12zat0d" targetRef="Activity_1ta6769" />
+    <bpmn:sequenceFlow id="Flow_0qdgvah" sourceRef="Activity_Call_Activity" targetRef="Activity_Print_Data_Script" />
     <bpmn:endEvent id="Event_18dla68">
       <bpmn:documentation># Main Workflow
 Hello {{my_other_var}}
@@ -18,15 +18,15 @@ Hello {{my_other_var}}
 </bpmn:documentation>
       <bpmn:incoming>Flow_0izaz4f</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_0izaz4f" sourceRef="Activity_1ta6769" targetRef="Event_18dla68" />
-    <bpmn:scriptTask id="Activity_1ta6769" name="Print Data">
+    <bpmn:sequenceFlow id="Flow_0izaz4f" sourceRef="Activity_Print_Data_Script" targetRef="Event_18dla68" />
+    <bpmn:scriptTask id="Activity_Print_Data_Script" name="Print Data">
       <bpmn:incoming>Flow_0qdgvah</bpmn:incoming>
       <bpmn:outgoing>Flow_0izaz4f</bpmn:outgoing>
       <bpmn:script>print(pre_var)
 print(my_var)
 print(my_other_var)</bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:scriptTask id="Activity_0wppf2v" name="Pre Data">
+    <bpmn:scriptTask id="Pre_Data_Script" name="Pre Data">
       <bpmn:incoming>Flow_1g3dpd7</bpmn:incoming>
       <bpmn:outgoing>Flow_0ovgj6c</bpmn:outgoing>
       <bpmn:script>pre_var = 'some string'
@@ -54,16 +54,16 @@ remove_this_var = 'something else'</bpmn:script>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0mcej1g_di" bpmnElement="Activity_12zat0d">
+      <bpmndi:BPMNShape id="Activity_0mcej1g_di" bpmnElement="Activity_Call_Activity">
         <dc:Bounds x="430" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_18dla68_di" bpmnElement="Event_18dla68">
         <dc:Bounds x="752" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1v8hse1_di" bpmnElement="Activity_1ta6769">
+      <bpmndi:BPMNShape id="Activity_1v8hse1_di" bpmnElement="Activity_Print_Data_Script">
         <dc:Bounds x="590" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1mhwjko_di" bpmnElement="Activity_0wppf2v">
+      <bpmndi:BPMNShape id="Activity_1mhwjko_di" bpmnElement="Pre_Data_Script">
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>


### PR DESCRIPTION
By swapping the order of these lines, we can assure that a call activity is returned BEFORE the tasks that it contains, rather than after it.