### PR TITLE
Improvement/better subworkflow management

### DIFF
--- a/SpiffWorkflow/bpmn/exceptions.py
+++ b/SpiffWorkflow/bpmn/exceptions.py
@@ -63,15 +63,12 @@ class WorkflowTaskException(WorkflowException):
     @staticmethod
     def get_task_trace(task):
         task_trace = [f"{task.task_spec.bpmn_name} ({task.workflow.spec.file})"]
-        caller = task.workflow.spec.name
-        parent = task.workflow.parent
+        top = task.workflow.top_workflow
+        parent = None if task.workflow is top else task.workflow.parent_workflow
         while parent is not None:
-            for spec in parent.spec.task_specs.values():
-                if hasattr(spec, 'spec') and spec.spec == caller:
-                    task_trace.append(f"{spec.bpmn_name} ({parent.spec.file})")
-                    break
-            caller = parent.spec.name
-            parent = parent.parent
+            caller = parent.get_task_from_id(task.workflow.parent)
+            task_trace.append(f"{caller.task_spec.bpmn_name} ({parent.spec.file})")
+            parent = None if caller.workflow is top else caller.workflow.parent_workflow
         return task_trace
 
     @staticmethod

--- a/SpiffWorkflow/bpmn/exceptions.py
+++ b/SpiffWorkflow/bpmn/exceptions.py
@@ -63,11 +63,15 @@ class WorkflowTaskException(WorkflowException):
     @staticmethod
     def get_task_trace(task):
         task_trace = [f"{task.task_spec.bpmn_name} ({task.workflow.spec.file})"]
-        workflow = task.workflow
-        while workflow != workflow.outer_workflow:
-            caller = workflow.name
-            workflow = workflow.outer_workflow
-            task_trace.append(f"{workflow.spec.task_specs[caller].bpmn_name} ({workflow.spec.file})")
+        caller = task.workflow.spec.name
+        parent = task.workflow.parent
+        while parent is not None:
+            for spec in parent.spec.task_specs.values():
+                if hasattr(spec, 'spec') and spec.spec == caller:
+                    task_trace.append(f"{spec.bpmn_name} ({parent.spec.file})")
+                    break
+            caller = parent.spec.name
+            parent = parent.parent
         return task_trace
 
     @staticmethod

--- a/SpiffWorkflow/bpmn/exceptions.py
+++ b/SpiffWorkflow/bpmn/exceptions.py
@@ -66,7 +66,7 @@ class WorkflowTaskException(WorkflowException):
         top = task.workflow.top_workflow
         parent = None if task.workflow is top else task.workflow.parent_workflow
         while parent is not None:
-            caller = parent.get_task_from_id(task.workflow.parent)
+            caller = parent.get_task_from_id(task.workflow.parent_task_id)
             task_trace.append(f"{caller.task_spec.bpmn_name} ({parent.spec.file})")
             parent = None if caller.workflow is top else caller.workflow.parent_workflow
         return task_trace

--- a/SpiffWorkflow/bpmn/serializer/workflow.py
+++ b/SpiffWorkflow/bpmn/serializer/workflow.py
@@ -23,7 +23,7 @@ from copy import deepcopy
 from uuid import UUID
 
 from SpiffWorkflow.task import Task
-from SpiffWorkflow.bpmn.workflow import BpmnMessage, BpmnWorkflow
+from SpiffWorkflow.bpmn.workflow import BpmnMessage, BpmnWorkflow, BpmnSubWorkflow
 from SpiffWorkflow.bpmn.specs.mixins.subworkflow_task import SubWorkflowTask
 
 from .migration.version_migration import MIGRATIONS
@@ -104,13 +104,14 @@ class BpmnWorkflowSerializer:
             cls(spec_converter)
         return spec_converter
 
-    def __init__(self, spec_converter=None, data_converter=None, wf_class=None, version=VERSION,
+    def __init__(self, spec_converter=None, data_converter=None, wf_class=None, sub_wf_class=None, version=VERSION,
                  json_encoder_cls=DEFAULT_JSON_ENCODER_CLS, json_decoder_cls=DEFAULT_JSON_DECODER_CLS):
         """Intializes a Workflow Serializer with the given Workflow, Task and Data Converters.
 
         :param spec_converter: the workflow spec converter
         :param data_converter: the data converter
         :param wf_class: the workflow class
+        :param sub_wf_class: the subworkflow class
         :param json_encoder_cls: JSON encoder class to be used for dumps/dump operations
         :param json_decoder_cls: JSON decoder class to be used for loads/load operations
         """
@@ -118,6 +119,7 @@ class BpmnWorkflowSerializer:
         self.spec_converter = spec_converter if spec_converter is not None else self.configure_workflow_spec_converter()
         self.data_converter = data_converter if data_converter is not None else DefaultRegistry()
         self.wf_class = wf_class if wf_class is not None else BpmnWorkflow
+        self.sub_wf_class = sub_wf_class if sub_wf_class is not None else BpmnSubWorkflow
         self.json_encoder_cls = json_encoder_cls
         self.json_decoder_cls = json_decoder_cls
         self.VERSION = version
@@ -166,17 +168,14 @@ class BpmnWorkflowSerializer:
         """
         # These properties are applicable to top level & subprocesses
         dct = self.process_to_dict(workflow)
-        # These are only used at the top-level
-        dct['spec'] = self.spec_converter.convert(workflow.spec)
+        # These are only used at the top-level      
         dct['subprocess_specs'] = dict(
             (name, self.spec_converter.convert(spec)) for name, spec in workflow.subprocess_specs.items()
         )
         dct['subprocesses'] = dict(
-            (str(task_id), self.process_to_dict(sp)) for task_id, sp in workflow.subprocesses.items()
+            (str(task_id), self.subworkflow_to_dict(sp)) for task_id, sp in workflow.subprocesses.items()
         )
         dct['bpmn_messages'] = [self.message_to_dict(msg) for msg in workflow.bpmn_messages]
-
-        dct['correlations'] = workflow.correlations
         return dct
 
     def workflow_from_dict(self, dct):
@@ -215,6 +214,11 @@ class BpmnWorkflowSerializer:
         workflow.task_tree = self.task_tree_from_dict(dct_copy, dct_copy.pop('root'), None, workflow)
 
         return workflow
+
+    def subworkflow_to_dict(self, workflow):
+        dct = self.process_to_dict(workflow)
+        dct['parent'] = str(workflow.parent)
+        return dct
 
     def task_to_dict(self, task):
         return {
@@ -264,7 +268,7 @@ class BpmnWorkflowSerializer:
 
         if isinstance(task_spec, SubWorkflowTask) and task_id in top_dct.get('subprocesses', {}):
             subprocess_spec = top.subprocess_specs[task_spec.spec]
-            subprocess = self.wf_class(subprocess_spec, {}, parent=process, deserializing=True)
+            subprocess = self.sub_wf_class(subprocess_spec, task.id, top_level_workflow, deserializing=True)
             subprocess_dct = top_dct['subprocesses'].get(task_id, {})
             subprocess.spec.data_objects.update(process.spec.data_objects)
             if len(subprocess.spec.data_objects) > 0:
@@ -272,6 +276,7 @@ class BpmnWorkflowSerializer:
             else:
                 subprocess.data = self.data_converter.restore(subprocess_dct.pop('data'))
             subprocess.success = subprocess_dct.pop('success')
+            subprocess.correlations = subprocess_dct.pop('correlations', {})
             subprocess.task_tree = self.task_tree_from_dict(subprocess_dct, subprocess_dct.pop('root'), None, subprocess, top, top_dct)
             subprocess.completed_event.connect(task_spec._on_subworkflow_completed, task)
             top_level_workflow.subprocesses[task.id] = subprocess
@@ -287,7 +292,9 @@ class BpmnWorkflowSerializer:
 
     def process_to_dict(self, process):
         return {
+            'spec': self.spec_converter.convert(process.spec),
             'data': self.data_converter.convert(process.data),
+            'correlations': process.correlations,
             'last_task': str(process.last_task.id) if process.last_task is not None else None,
             'success': process.success,
             'tasks': self.task_tree_to_dict(process.task_tree),

--- a/SpiffWorkflow/bpmn/serializer/workflow.py
+++ b/SpiffWorkflow/bpmn/serializer/workflow.py
@@ -217,7 +217,7 @@ class BpmnWorkflowSerializer:
 
     def subworkflow_to_dict(self, workflow):
         dct = self.process_to_dict(workflow)
-        dct['parent'] = str(workflow.parent)
+        dct['parent_task_id'] = str(workflow.parent_task_id)
         return dct
 
     def task_to_dict(self, task):

--- a/SpiffWorkflow/bpmn/serializer/workflow.py
+++ b/SpiffWorkflow/bpmn/serializer/workflow.py
@@ -225,7 +225,6 @@ class BpmnWorkflowSerializer:
             'state': task.state,
             'task_spec': task.task_spec.name,
             'triggered': task.triggered,
-            'workflow_name': task.workflow.name,
             'internal_data': self.data_converter.convert(task.internal_data),
             'data': self.data_converter.convert(task.data),
         }
@@ -265,7 +264,7 @@ class BpmnWorkflowSerializer:
 
         if isinstance(task_spec, SubWorkflowTask) and task_id in top_dct.get('subprocesses', {}):
             subprocess_spec = top.subprocess_specs[task_spec.spec]
-            subprocess = self.wf_class(subprocess_spec, {}, name=task_spec.name, parent=process, deserializing=True)
+            subprocess = self.wf_class(subprocess_spec, {}, parent=process, deserializing=True)
             subprocess_dct = top_dct['subprocesses'].get(task_id, {})
             subprocess.spec.data_objects.update(process.spec.data_objects)
             if len(subprocess.spec.data_objects) > 0:

--- a/SpiffWorkflow/bpmn/specs/control.py
+++ b/SpiffWorkflow/bpmn/specs/control.py
@@ -42,10 +42,6 @@ class _BoundaryEventParent(BpmnTaskSpec):
         super(_BoundaryEventParent, self).__init__(wf_spec, name, **kwargs)
         self.main_child_task_spec = main_child_task_spec
 
-    @property
-    def spec_type(self):
-        return 'Boundary Event Parent'
-
     def _run_hook(self, my_task):
         # Clear any events that our children might have received and wait for new events
         for child in my_task.children:
@@ -89,10 +85,6 @@ class _EndJoin(UnstructuredJoin, BpmnTaskSpec):
             w = task.workflow
             if w == my_task.workflow:
                 is_mine = True
-            while w and w.parent is not None:
-                w = w.parent
-                if w == my_task.workflow:
-                    is_mine = True
             if is_mine:
                 waiting_tasks.append(task)
 

--- a/SpiffWorkflow/bpmn/specs/control.py
+++ b/SpiffWorkflow/bpmn/specs/control.py
@@ -89,8 +89,8 @@ class _EndJoin(UnstructuredJoin, BpmnTaskSpec):
             w = task.workflow
             if w == my_task.workflow:
                 is_mine = True
-            while w and w.outer_workflow != w:
-                w = w.outer_workflow
+            while w and w.parent is not None:
+                w = w.parent
                 if w == my_task.workflow:
                     is_mine = True
             if is_mine:

--- a/SpiffWorkflow/bpmn/specs/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/event_definitions.py
@@ -48,10 +48,6 @@ class EventDefinition(object):
         self.internal, self.external = True, True
         self.description = description
 
-    @property
-    def event_type(self):
-        return f'{self.__class__.__module__}.{self.__class__.__name__}'
-
     def has_fired(self, my_task):
         return my_task._get_internal_data('event_fired', False)
 
@@ -59,26 +55,21 @@ class EventDefinition(object):
         my_task._set_internal_data(event_fired=True)
 
     def throw(self, my_task):
-        self._throw(
-            event=my_task.task_spec.event_definition,
-            workflow=my_task.workflow,
-            parent=my_task.workflow.parent
-        )
+        self._throw(my_task)
 
     def reset(self, my_task):
         my_task._set_internal_data(event_fired=False)
 
-    def _throw(self, event, workflow, parent, correlations=None):
-        # This method exists because usually we just want to send the event in our
-        # own task spec, but we can't do that for message events.
-        # We also don't have a more sophisticated method for addressing events to
-        # a particular process, but this at least provides a mechanism for distinguishing
-        # between processes and subprocesses.
-        if self.external and parent is not None:
-            top = workflow._get_outermost_workflow()
-            top.catch(event, correlations)
+    def _throw(self, my_task, **kwargs):
+        if 'target' in kwargs:
+            target = kwargs.pop('target')
+        elif self.internal and not self.external:
+            target = my_task.workflow
         else:
-            workflow.catch(event)
+            target = None
+
+        event_definition = kwargs.pop('event', my_task.task_spec.event_definition)
+        my_task.workflow.catch(event_definition, target, **kwargs)
 
     def __eq__(self, other):
         return self.__class__.__name__ == other.__class__.__name__
@@ -91,7 +82,6 @@ class NamedEventDefinition(EventDefinition):
 
     :param name: the name of this event
     """
-
     def __init__(self, name, **kwargs):
         super(NamedEventDefinition, self).__init__(**kwargs)
         self.name = name
@@ -112,6 +102,8 @@ class CancelEventDefinition(EventDefinition):
         super(CancelEventDefinition, self).__init__(**kwargs)
         self.internal = False
 
+    def _throw(self, my_task, **kwargs):
+        return super()._throw(my_task, target=my_task.workflow.parent_workflow)
 
 class ErrorEventDefinition(NamedEventDefinition):
     """
@@ -180,7 +172,7 @@ class MessageEventDefinition(NamedEventDefinition):
         event.payload = deepcopy(my_task.data)
         correlations = self.get_correlations(my_task, event.payload)
         my_task.workflow.correlations.update(correlations)
-        self._throw(event, my_task.workflow, my_task.workflow.parent, correlations)
+        self._throw(my_task, event=event, correlations=correlations)
 
     def update_internal_data(self, my_task, event_definition):
         my_task.internal_data[event_definition.name] = event_definition.payload
@@ -476,8 +468,4 @@ class MultipleEventDefinition(EventDefinition):
     def throw(self, my_task):
         # Mutiple events throw all associated events when they fire
         for event_definition in self.event_definitions:
-            self._throw(
-                event=event_definition,
-                workflow=my_task.workflow,
-                parent=my_task.workflow.parent
-            )
+            event_definition.throw(my_task)

--- a/SpiffWorkflow/bpmn/specs/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/event_definitions.py
@@ -62,19 +62,19 @@ class EventDefinition(object):
         self._throw(
             event=my_task.task_spec.event_definition,
             workflow=my_task.workflow,
-            outer_workflow=my_task.workflow.outer_workflow
+            parent=my_task.workflow.parent
         )
 
     def reset(self, my_task):
         my_task._set_internal_data(event_fired=False)
 
-    def _throw(self, event, workflow, outer_workflow, correlations=None):
+    def _throw(self, event, workflow, parent, correlations=None):
         # This method exists because usually we just want to send the event in our
         # own task spec, but we can't do that for message events.
         # We also don't have a more sophisticated method for addressing events to
         # a particular process, but this at least provides a mechanism for distinguishing
         # between processes and subprocesses.
-        if self.external and outer_workflow != workflow:
+        if self.external and parent is not None:
             top = workflow._get_outermost_workflow()
             top.catch(event, correlations)
         else:
@@ -151,10 +151,11 @@ class EscalationEventDefinition(NamedEventDefinition):
 class CorrelationProperty:
     """Rules for generating a correlation key when a message is sent or received."""
 
-    def __init__(self, name, retrieval_expression, correlation_keys, expected_value=None):
-        self.name = name                            # This is the property name
-        self.retrieval_expression = retrieval_expression  # This is how it's generated
-        self.correlation_keys = correlation_keys    # These are the keys it's used by
+    def __init__(self, name, retrieval_expression, correlation_keys):
+        self.name = name                                    # This is the property name
+        self.retrieval_expression = retrieval_expression    # This is how it's generated
+        self.correlation_keys = correlation_keys            # These are the keys it's used by
+
 
 class MessageEventDefinition(NamedEventDefinition):
     """The default message event."""
@@ -179,7 +180,7 @@ class MessageEventDefinition(NamedEventDefinition):
         event.payload = deepcopy(my_task.data)
         correlations = self.get_correlations(my_task, event.payload)
         my_task.workflow.correlations.update(correlations)
-        self._throw(event, my_task.workflow, my_task.workflow.outer_workflow, correlations)
+        self._throw(event, my_task.workflow, my_task.workflow.parent, correlations)
 
     def update_internal_data(self, my_task, event_definition):
         my_task.internal_data[event_definition.name] = event_definition.payload
@@ -192,35 +193,17 @@ class MessageEventDefinition(NamedEventDefinition):
             my_task.set_data(**payload)
 
     def get_correlations(self, task, payload):
-        correlation_keys = {}
+        correlations = {}
         for property in self.correlation_properties:
             for key in property.correlation_keys:
-                if key not in correlation_keys:
-                    correlation_keys[key] = {}
+                if key not in correlations:
+                    correlations[key] = {}
                 try:
-                    correlation_keys[key][property.name] = task.workflow.script_engine._evaluate(property.retrieval_expression, payload)
-                except WorkflowException as we:
-                    we.add_note(
-                        f"Failed to evaluate correlation property '{property.name}'"
-                        f" invalid expression '{property.retrieval_expression}'")
-                    we.task_spec = task.task_spec
-                    raise we
-        return correlation_keys
-
-    def conversation(self):
-        """An event may have many correlation properties, this figures out
-        which conversation exists across all of them, or return None if they
-        do not share a topic. """
-        conversation = None
-        if len(self.correlation_properties) > 0:
-            for prop in self.correlation_properties:
-                for key in prop.correlation_keys:
-                    conversation = key
-                    for prop in self.correlation_properties:
-                        if conversation not in prop.correlation_keys:
-                            break
-                    return conversation
-        return None
+                    correlations[key][property.name] = task.workflow.script_engine._evaluate(property.retrieval_expression, payload)
+                except WorkflowException:
+                    # Just ignore missing keys.  The dictionaries have to match exactly
+                    pass
+        return correlations
 
 
 class NoneEventDefinition(EventDefinition):
@@ -496,5 +479,5 @@ class MultipleEventDefinition(EventDefinition):
             self._throw(
                 event=event_definition,
                 workflow=my_task.workflow,
-                outer_workflow=my_task.workflow.outer_workflow
+                parent=my_task.workflow.parent
             )

--- a/SpiffWorkflow/bpmn/specs/event_definitions.py
+++ b/SpiffWorkflow/bpmn/specs/event_definitions.py
@@ -69,7 +69,7 @@ class EventDefinition(object):
             target = None
 
         event_definition = kwargs.pop('event', my_task.task_spec.event_definition)
-        my_task.workflow.catch(event_definition, target, **kwargs)
+        my_task.workflow.top_workflow.catch(event_definition, target, **kwargs)
 
     def __eq__(self, other):
         return self.__class__.__name__ == other.__class__.__name__

--- a/SpiffWorkflow/bpmn/specs/mixins/events/end_event.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/events/end_event.py
@@ -49,7 +49,7 @@ class EndEvent(ThrowingEvent):
 
             # We are finished.  Set the workflow data and cancel all tasks
             my_task.workflow.set_data(**my_task.data)
-            for task in my_task.workflow.get_tasks(TaskState.NOT_FINISHED_MASK, workflow=my_task.workflow):
+            for task in my_task.workflow.get_tasks(TaskState.NOT_FINISHED_MASK):
                 task.cancel()
 
         elif isinstance(self.event_definition, CancelEventDefinition):

--- a/SpiffWorkflow/bpmn/specs/mixins/events/event_types.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/events/event_types.py
@@ -35,6 +35,7 @@ class CatchingEvent(TaskSpec):
         self.event_definition = event_definition
 
     def catches(self, my_task, event_definition, correlations=None):
+        correlations = correlations or {}
         if self.event_definition == event_definition:
             return all([correlations.get(key) == my_task.workflow.correlations.get(key) for key in correlations ])
         else:

--- a/SpiffWorkflow/bpmn/workflow.py
+++ b/SpiffWorkflow/bpmn/workflow.py
@@ -217,14 +217,12 @@ class BpmnWorkflow(Workflow):
         if len(tasks) > 1:
             # Is this really a valid check?
             raise WorkflowException(
-                f"This process has multiple tasks waiting on the same message '{event_definition.name}', which is not supported. ")
+                f"This process has multiple tasks waiting on the same message '{event_definition.name}', which is not supported.")
 
         task = tasks[0]
         # Need a better way of extracting these
-        event_definition.correlation_properties = task.task_spec.event_definition.correlation_properties
         correlations = event_definition.get_correlations(task, message.payload)
-        if len(correlations) == 0:
-            raise WorkflowException(f'No matching correlations for {message.name}')
+        task.workflow.correlations.update(correlations)
         self.catch(event_definition, correlations=correlations)
 
     def waiting_events(self):

--- a/SpiffWorkflow/camunda/specs/event_definitions.py
+++ b/SpiffWorkflow/camunda/specs/event_definitions.py
@@ -45,7 +45,7 @@ class MessageEventDefinition(MessageEventDefinition):
         # We can't update our own payload, because if this task is reached again
         # we have to evaluate it again so we have to create a new event
         event = MessageEventDefinition(self.name, payload=result, result_var=self.result_var)
-        self._throw(event, my_task.workflow, my_task.workflow.outer_workflow)
+        self._throw(event, my_task.workflow, my_task.workflow.parent)
 
     def update_internal_data(self, my_task, event_definition):
         if event_definition.result_var is None:

--- a/SpiffWorkflow/camunda/specs/event_definitions.py
+++ b/SpiffWorkflow/camunda/specs/event_definitions.py
@@ -45,7 +45,7 @@ class MessageEventDefinition(MessageEventDefinition):
         # We can't update our own payload, because if this task is reached again
         # we have to evaluate it again so we have to create a new event
         event = MessageEventDefinition(self.name, payload=result, result_var=self.result_var)
-        self._throw(event, my_task.workflow, my_task.workflow.parent)
+        self._throw(my_task, event=event)
 
     def update_internal_data(self, my_task, event_definition):
         if event_definition.result_var is None:

--- a/SpiffWorkflow/serializer/dict.py
+++ b/SpiffWorkflow/serializer/dict.py
@@ -505,12 +505,11 @@ class DictionarySerializer(Serializer):
         workflow.task_tree = self.deserialize_task(workflow, s_state['task_tree'], reset_specs)
 
         # Re-connect parents and update states if necessary
-        tasklist = workflow.get_tasks()
         root = workflow.get_tasks_from_spec_name('Root')[0]
         update_state = root.state != TaskState.COMPLETED
-        for task in tasklist:
+        for task in workflow.get_tasks_iterator():
             if task.parent is not None:
-                task.parent = workflow.get_task_from_id(task.parent, tasklist)
+                task.parent = workflow.get_task_from_id(task.parent)
             if update_state:
                 if task.state == 32:
                     task.state = TaskState.COMPLETED
@@ -518,7 +517,7 @@ class DictionarySerializer(Serializer):
                     task.state = TaskState.CANCELLED
 
         if workflow.last_task is not None:
-            workflow.last_task = workflow.get_task_from_id(s_state['last_task'],tasklist)
+            workflow.last_task = workflow.get_task_from_id(s_state['last_task'])
 
         return workflow
 

--- a/SpiffWorkflow/serializer/dict.py
+++ b/SpiffWorkflow/serializer/dict.py
@@ -519,7 +519,6 @@ class DictionarySerializer(Serializer):
 
         if workflow.last_task is not None:
             workflow.last_task = workflow.get_task_from_id(s_state['last_task'],tasklist)
-        workflow.update_task_mapping()
 
         return workflow
 
@@ -531,7 +530,6 @@ class DictionarySerializer(Serializer):
                 " internal_data to store the subworkflow).")
         s_state = dict()
         s_state['id'] = task.id
-        s_state['workflow_name'] = task.workflow.name
         s_state['parent'] = task.parent.id if task.parent is not None else None
         if not skip_children:
             s_state['children'] = [self.serialize_task(child) for child in task.children]
@@ -548,7 +546,7 @@ class DictionarySerializer(Serializer):
         old_spec_name = s_state['task_spec']
         if old_spec_name in ignored_specs:
             return None
-        task_spec = workflow.get_task_spec_from_name(old_spec_name)
+        task_spec = workflow.spec.get_task_spec_from_name(old_spec_name)
         if task_spec is None:
             raise MissingSpecError("Unknown task spec: " + old_spec_name)
         task = Task(workflow, task_spec)

--- a/SpiffWorkflow/serializer/xml.py
+++ b/SpiffWorkflow/serializer/xml.py
@@ -656,9 +656,6 @@ class XmlSerializer(Serializer):
         if workflow.last_task is not None:
             SubElement(elem, 'last-task').text = str(workflow.last_task.id)
 
-        # outer_workflow
-        # SubElement(elem, 'outer-workflow').text = workflow.outer_workflow.id
-
         if workflow.success:
             SubElement(elem, 'success')
         task_tree_elem = SubElement(elem, 'task-tree')
@@ -673,10 +670,6 @@ class XmlSerializer(Serializer):
 
         workflow.data = self.deserialize_value_map(elem.find('data'))
         workflow.success = elem.find('success') is not None
-
-        # outer_workflow
-        # workflow.outer_workflow =
-        # find_workflow_by_id(remap_workflow_id(elem['outer_workflow']))
 
         task_tree_elem = elem.find('task-tree')
         workflow.task_tree = self.deserialize_task(workflow, task_tree_elem[0])
@@ -731,7 +724,7 @@ class XmlSerializer(Serializer):
         assert isinstance(workflow, Workflow)
 
         task_spec_name = elem.findtext('spec')
-        task_spec = workflow.get_task_spec_from_name(task_spec_name)
+        task_spec = workflow.spec.get_task_spec_from_name(task_spec_name)
         task = Task(workflow, task_spec)
         task.id = elem.findtext('id')
         # The parent is later resolved by the workflow deserializer

--- a/SpiffWorkflow/specs/CancelTask.py
+++ b/SpiffWorkflow/specs/CancelTask.py
@@ -32,7 +32,7 @@ class CancelTask(Trigger):
 
     def _run_hook(self, my_task):
         for task_name in self.context:
-            cancel_tasks = my_task.workflow.get_task_spec_from_name(task_name)
+            cancel_tasks = my_task.workflow.spec.get_task_spec_from_name(task_name)
             for cancel_task in my_task._get_root()._find_any(cancel_tasks):
                 cancel_task.cancel()
         return True

--- a/SpiffWorkflow/specs/Choose.py
+++ b/SpiffWorkflow/specs/Choose.py
@@ -57,7 +57,7 @@ class Choose(Trigger):
         self.choice = choice is not None and choice or []
 
     def _run_hook(self, my_task):
-        context = my_task.workflow.get_task_spec_from_name(self.context)
+        context = my_task.workflow.spec.get_task_spec_from_name(self.context)
         triggered = []
         for task in my_task.workflow.task_tree:
             if task.thread_id != my_task.thread_id:

--- a/SpiffWorkflow/specs/ExclusiveChoice.py
+++ b/SpiffWorkflow/specs/ExclusiveChoice.py
@@ -64,10 +64,10 @@ class ExclusiveChoice(MultiChoice):
 
     def _run_hook(self, my_task):
 
-        output = self._wf_spec.get_task_spec_from_name(self.default_task_spec)
+        output = my_task.workflow.spec.get_task_spec_from_name(self.default_task_spec)
         for condition, spec_name in self.cond_task_specs:
             if condition is not None and condition._matches(my_task):
-                output = self._wf_spec.get_task_spec_from_name(spec_name)
+                output = my_task.workflow.spec.get_task_spec_from_name(spec_name)
                 break
 
         if output is None:

--- a/SpiffWorkflow/specs/Gate.py
+++ b/SpiffWorkflow/specs/Gate.py
@@ -54,7 +54,7 @@ class Gate(TaskSpec):
 
     def _update_hook(self, my_task):
         super()._update_hook(my_task)
-        context_task = my_task.workflow.get_task_spec_from_name(self.context)
+        context_task = my_task.workflow.spec.get_task_spec_from_name(self.context)
         root_task = my_task.workflow.task_tree
         for task in root_task._find_any(context_task):
             if task.thread_id != my_task.thread_id:

--- a/SpiffWorkflow/specs/Join.py
+++ b/SpiffWorkflow/specs/Join.py
@@ -139,7 +139,7 @@ class Join(TaskSpec):
         # We are looking for all task instances that must be joined.
         # We limit our search by starting at the split point.
         if self.split_task:
-            task_spec = my_task.workflow.get_task_spec_from_name(self.split_task)
+            task_spec = my_task.workflow.spec.get_task_spec_from_name(self.split_task)
             split_task = my_task._find_ancestor(task_spec)
         else:
             split_task = my_task.workflow.task_tree

--- a/SpiffWorkflow/specs/MultiChoice.py
+++ b/SpiffWorkflow/specs/MultiChoice.py
@@ -95,9 +95,9 @@ class MultiChoice(TaskSpec):
             if self.choice is not None and output not in self.choice:
                 continue
             if condition is None:
-                unconditional.append(self._wf_spec.get_task_spec_from_name(output))
+                unconditional.append(my_task.workflow.spec.get_task_spec_from_name(output))
             else:
-                conditional.append(self._wf_spec.get_task_spec_from_name(output))
+                conditional.append(my_task.workflow.spec.get_task_spec_from_name(output))
         state = TaskState.MAYBE if my_task.state == TaskState.MAYBE else TaskState.LIKELY
         my_task._sync_children(unconditional, state)
         for spec in conditional:
@@ -109,7 +109,7 @@ class MultiChoice(TaskSpec):
             if self.choice is not None and output not in self.choice:
                 continue
             if condition is None or condition._matches(my_task):
-                outputs.append(self._wf_spec.get_task_spec_from_name(output))
+                outputs.append(my_task.workflow.spec.get_task_spec_from_name(output))
         return outputs
 
     def _run_hook(self, my_task):

--- a/SpiffWorkflow/specs/SubWorkflow.py
+++ b/SpiffWorkflow/specs/SubWorkflow.py
@@ -98,8 +98,7 @@ class SubWorkflow(TaskSpec):
         with open(file_name) as fp:
             xml = etree.parse(fp).getroot()
         wf_spec = WorkflowSpec.deserialize(serializer, xml, filename=file_name)
-        outer_workflow = my_task.workflow.outer_workflow
-        subworkflow = Workflow(wf_spec, parent=outer_workflow)
+        subworkflow = Workflow(wf_spec)
         my_task._sync_children(self.outputs, TaskState.FUTURE)
         for child in subworkflow.task_tree.children:
             my_task.children.insert(0, child)

--- a/SpiffWorkflow/specs/ThreadMerge.py
+++ b/SpiffWorkflow/specs/ThreadMerge.py
@@ -105,7 +105,7 @@ class ThreadMerge(Join):
             my_task._set_state(TaskState.WAITING)
             return
 
-        split_task_spec = my_task.workflow.get_task_spec_from_name(self.split_task)
+        split_task_spec = my_task.workflow.spec.get_task_spec_from_name(self.split_task)
         split_task = my_task._find_ancestor(split_task_spec)
 
         # Find the inbound task that was completed last.

--- a/SpiffWorkflow/specs/Trigger.py
+++ b/SpiffWorkflow/specs/Trigger.py
@@ -84,7 +84,7 @@ class Trigger(TaskSpec):
         times = int(valueof(my_task, self.times, 1)) + self.queued
         for i in range(times):
             for task_name in self.context:
-                task_spec = my_task.workflow.get_task_spec_from_name(task_name)
+                task_spec = my_task.workflow.spec.get_task_spec_from_name(task_name)
                 task_spec._on_trigger(my_task)
         self.queued = 0
         return True

--- a/SpiffWorkflow/spiff/specs/event_definitions.py
+++ b/SpiffWorkflow/spiff/specs/event_definitions.py
@@ -35,7 +35,7 @@ class MessageEventDefinition(MessageEventDefinition):
         event.payload = my_task.workflow.script_engine.evaluate(my_task, self.expression)
         correlations = self.get_correlations(my_task, event.payload)
         my_task.workflow.correlations.update(correlations)
-        self._throw(event, my_task.workflow, my_task.workflow.outer_workflow, correlations)
+        self._throw(event, my_task.workflow, my_task.workflow.parent, correlations)
 
     def update_task_data(self, my_task):
         my_task.data[self.message_var] = my_task.internal_data[self.name]

--- a/SpiffWorkflow/spiff/specs/event_definitions.py
+++ b/SpiffWorkflow/spiff/specs/event_definitions.py
@@ -35,7 +35,7 @@ class MessageEventDefinition(MessageEventDefinition):
         event.payload = my_task.workflow.script_engine.evaluate(my_task, self.expression)
         correlations = self.get_correlations(my_task, event.payload)
         my_task.workflow.correlations.update(correlations)
-        self._throw(event, my_task.workflow, my_task.workflow.parent, correlations)
+        self._throw(my_task, event=event, correlations=correlations)
 
     def update_task_data(self, my_task):
         my_task.data[self.message_var] = my_task.internal_data[self.name]

--- a/SpiffWorkflow/task.py
+++ b/SpiffWorkflow/task.py
@@ -259,7 +259,6 @@ class Task(object):
         extra = dct or {}
         extra.update({
             'workflow_spec': self.workflow.spec.name,
-            'workflow_name': self.workflow.spec.description,
             'task_spec': self.task_spec.name,
             'task_name': self.task_spec.description,
             'task_id': self.id,

--- a/SpiffWorkflow/workflow.py
+++ b/SpiffWorkflow/workflow.py
@@ -195,26 +195,21 @@ class Workflow(object):
         """
         return [task for task in self.get_tasks_iterator() if task.task_spec.name == name]
 
-    def get_task_from_id(self, task_id, tasklist=None):
+    def get_task_from_id(self, task_id):
         """
         Returns the task with the given id.
 
         :type id:integer
         :param id: The id of a task.
-        :param tasklist: Optional cache of get_tasks for operations
-                         where we are calling multiple times as when we
-                         are deserializing the workflow
         :rtype: Task
         :returns: The task with the given id.
         """
         if task_id is None:
             raise WorkflowException('task_id is None', task_spec=self.spec)
-        tasklist = tasklist or self.task_tree
         for task in self.task_tree:
             if task.id == task_id:
-                return task
-        msg = 'A task with the given task_id (%s) was not found' % task_id
-        raise TaskNotFoundException(msg, task_spec=self.spec)
+                return task    
+        raise TaskNotFoundException(f'A task with id {task_id} was not found', task_spec=self.spec)
 
     def run_task_from_id(self, task_id):
         """
@@ -235,6 +230,7 @@ class Workflow(object):
         :param data: optionall set the task data
         """
         task = self.get_task_from_id(task_id)
+        self.last_task = task.parent
         return task.reset_token(data)
 
     def run_next(self, pick_up=True, halt_on_manual=True):

--- a/tests/SpiffWorkflow/bpmn/ApprovalsTest.py
+++ b/tests/SpiffWorkflow/bpmn/ApprovalsTest.py
@@ -46,8 +46,6 @@ class ApprovalsTest(BpmnWorkflowTestCase):
     def testRunThroughHappy(self):
 
         self.do_next_named_step('First_Approval_Wins.Manager_Approval')
-        self.complete_subworkflow()
-        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.First_Approval_Wins_Done')
 
         self.do_next_named_step('Approvals.Manager_Approval__P_')
@@ -57,15 +55,11 @@ class ApprovalsTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Parallel_Approvals_SP.Step1')
         self.do_next_named_step('Parallel_Approvals_SP.Manager_Approval')
         self.do_next_named_step('Parallel_Approvals_SP.Supervisor_Approval')
-        self.complete_subworkflow()
-        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.Parallel_SP_Done')
 
     def testRunThroughHappyOtherOrders(self):
 
         self.do_next_named_step('First_Approval_Wins.Supervisor_Approval')
-        self.complete_subworkflow()
-        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.First_Approval_Wins_Done')
 
         self.do_next_named_step('Approvals.Supervisor_Approval__P_')
@@ -75,15 +69,11 @@ class ApprovalsTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Parallel_Approvals_SP.Manager_Approval')
         self.do_next_named_step('Parallel_Approvals_SP.Step1')
         self.do_next_named_step('Parallel_Approvals_SP.Supervisor_Approval')
-        self.complete_subworkflow()
-        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.Parallel_SP_Done')
 
     def testSaveRestore(self):
 
         self.do_next_named_step('First_Approval_Wins.Manager_Approval')
-        self.complete_subworkflow()
-        self.complete_subworkflow()
         self.save_restore()
         self.do_next_exclusive_step('Approvals.First_Approval_Wins_Done')
 
@@ -96,16 +86,12 @@ class ApprovalsTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Parallel_Approvals_SP.Manager_Approval')
         self.do_next_exclusive_step('Parallel_Approvals_SP.Step1')
         self.do_next_exclusive_step('Parallel_Approvals_SP.Supervisor_Approval')
-        self.complete_subworkflow()
-        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.Parallel_SP_Done')
 
     def testSaveRestoreWaiting(self):
 
         self.do_next_named_step('First_Approval_Wins.Manager_Approval')
         self.save_restore()
-        self.complete_subworkflow()
-        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.First_Approval_Wins_Done')
 
         self.save_restore()
@@ -122,8 +108,6 @@ class ApprovalsTest(BpmnWorkflowTestCase):
         self.save_restore()
         self.do_next_exclusive_step('Parallel_Approvals_SP.Supervisor_Approval')
         self.save_restore()
-        self.complete_subworkflow()
-        self.complete_subworkflow()
         self.do_next_exclusive_step('Approvals.Parallel_SP_Done')
 
 

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
@@ -76,7 +76,7 @@ class BpmnWorkflowTestCase(unittest.TestCase):
                     if (p.task_spec.name == parent_name or p.task_spec.bpmn_name == parent_name):
                         found = True
                         break
-                    if p.parent is None and p.workflow != p.workflow.outer_workflow:
+                    if p.parent is None and p.workflow != p.workflow.parent:
                         p = switch_workflow(p)
                     else:
                         p = p.parent

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
@@ -117,13 +117,6 @@ class BpmnWorkflowTestCase(unittest.TestCase):
             tasks[0].set_data(**set_attribs)
         tasks[0].run()
 
-    def complete_subworkflow(self):
-        # A side effect of finer grained contol over task execution is that tasks require more explicit intervention
-        # to change states.  Subworkflows tasks no longer go directly to ready when the subworkflow completes.
-        # So they may need to explicitly refreshed to become ready, and then run.
-        self.workflow.refresh_waiting_tasks()
-        self.workflow.do_engine_steps()
-
     def save_restore(self):
 
         script_engine = self.workflow.script_engine

--- a/tests/SpiffWorkflow/bpmn/CallActivityTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivityTest.py
@@ -17,7 +17,6 @@ class CallActivityTest(BpmnWorkflowTestCase):
 
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses)
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertDictEqual(self.workflow.data, {'pre_var': 'some string', 'my_var': 'World', 'my_other_var': 'Mike'})
 
     def test_call_activity_has_same_script_engine(self):
@@ -26,7 +25,6 @@ class CallActivityTest(BpmnWorkflowTestCase):
 
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses, script_engine=CustomScriptEngine())
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertTrue(self.workflow.is_completed())
         self.assertIsInstance(self.workflow.script_engine, CustomScriptEngine)
 
@@ -42,7 +40,6 @@ class CallActivityTest(BpmnWorkflowTestCase):
         # data should be removed in the final output as well.
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses)
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertTrue(self.workflow.is_completed())
         self.assertNotIn('remove_this_var', self.workflow.last_task.data.keys())
 

--- a/tests/SpiffWorkflow/bpmn/CollaborationTest.py
+++ b/tests/SpiffWorkflow/bpmn/CollaborationTest.py
@@ -1,5 +1,5 @@
 from SpiffWorkflow.bpmn.specs.mixins.subworkflow_task import CallActivity
-from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow, BpmnMessage
 from SpiffWorkflow.task import TaskState
 
 from .BpmnWorkflowTestCase import BpmnWorkflowTestCase
@@ -60,16 +60,14 @@ class CollaborationTest(BpmnWorkflowTestCase):
         self.assertEqual('from_name', events[0]['value'][0].retrieval_expression)
         self.assertEqual('lover_name', events[0]['value'][0].name)
 
-        # As shown above, the waiting event is looking for a payload with a
-        # 'from_name' that should be used to retrieve the lover's name.
-        new_message_payload = {'from_name': 'Peggy', 'other_nonsense': 1001}
-        workflow.catch_bpmn_message('Love Letter Response', new_message_payload)
+        message = BpmnMessage(
+            None,
+            'Love Letter Response',
+            {'from_name': 'Peggy', 'other_nonsense': 1001}
+        )
+        workflow.catch_bpmn_message(message)
         workflow.do_engine_steps()
-        # The external message created above should be caught
         self.assertEqual(receive.state, TaskState.COMPLETED)
-        # Spiff extensions allow us to specify the destination of a workflow
-        # but base BPMN does not, and all keys are added directly to the
-        # task data.
         self.assertEqual(workflow.last_task.data, {'from_name': 'Peggy', 'lover_name': 'Peggy', 'other_nonsense': 1001})
         self.assertEqual(workflow.correlations, {'lover':{'lover_name':'Peggy'}})
         self.assertEqual(workflow.is_completed(), True)

--- a/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
+++ b/tests/SpiffWorkflow/bpmn/CustomScriptTest.py
@@ -36,8 +36,6 @@ class CustomInlineScriptTest(BpmnWorkflowTestCase):
         if save_restore:
             self.save_restore()
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
-        self.complete_subworkflow()
         if save_restore:
             self.save_restore()
         data = self.workflow.last_task.data

--- a/tests/SpiffWorkflow/bpmn/NestedProcessesTest.py
+++ b/tests/SpiffWorkflow/bpmn/NestedProcessesTest.py
@@ -20,7 +20,7 @@ class NestedProcessesTest(BpmnWorkflowTestCase):
         self.complete_task('Action2', True)
         self.assertEqual(1, len(self.workflow.get_tasks(TaskState.READY)))
         self.complete_task('Action3', True)
-        self.complete_workflow()
+        self.assertTrue(self.workflow.is_completed())
 
     def testResetToTop(self):
 
@@ -36,7 +36,7 @@ class NestedProcessesTest(BpmnWorkflowTestCase):
 
         self.complete_task('Action2')
         self.complete_task('Action3')
-        self.complete_workflow()
+        self.assertTrue(self.workflow.is_completed())
 
     def testResetToIntermediate(self):
 
@@ -53,16 +53,27 @@ class NestedProcessesTest(BpmnWorkflowTestCase):
         task.run()
 
         self.complete_task('Action3')
-        self.complete_workflow()
+        self.assertTrue(self.workflow.is_completed())
+
+    def testResetToSubworkflow(self):
+
+        self.complete_task('Action1', True)
+        self.complete_task('Action2', True)
+        self.complete_task('Action3', True)
+
+        # "Nested level 1"
+        task = self.workflow.get_tasks_from_spec_name('sid-C014B4B9-889F-4EE9-9949-C89502C35CF0')[0]
+        self.workflow.reset_from_task_id(task.id)
+
+        self.workflow.do_engine_steps()
+        self.assertEqual(len(self.workflow.subprocesses), 1)
+        self.assertEqual(task.state, TaskState.WAITING)
+        self.complete_task('Action2', True)
+        self.complete_task('Action3', True)
+        self.assertTrue(self.workflow.is_completed())
 
     def complete_task(self, name, save_restore=False):
         self.do_next_named_step(name)
         self.workflow.do_engine_steps()
-        if save_restore:
-            self.save_restore()
-
-    def complete_workflow(self):
-        self.complete_subworkflow()
-        self.complete_subworkflow()
-        self.complete_subworkflow()
-        self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
+        #if save_restore:
+        #    self.save_restore()

--- a/tests/SpiffWorkflow/bpmn/NestedProcessesTest.py
+++ b/tests/SpiffWorkflow/bpmn/NestedProcessesTest.py
@@ -75,5 +75,5 @@ class NestedProcessesTest(BpmnWorkflowTestCase):
     def complete_task(self, name, save_restore=False):
         self.do_next_named_step(name)
         self.workflow.do_engine_steps()
-        #if save_restore:
-        #    self.save_restore()
+        if save_restore:
+            self.save_restore()

--- a/tests/SpiffWorkflow/bpmn/ResetSubProcessTest.py
+++ b/tests/SpiffWorkflow/bpmn/ResetSubProcessTest.py
@@ -70,7 +70,6 @@ class ResetSubProcessTest(BpmnWorkflowTestCase):
         self.assertEqual(task.get_name(),'Subtask2A')
         task.run()
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         task = self.workflow.get_ready_user_tasks()[0]
         self.assertEqual(task.get_name(),'Task2')
         task.run()

--- a/tests/SpiffWorkflow/bpmn/ResetSubProcessTest.py
+++ b/tests/SpiffWorkflow/bpmn/ResetSubProcessTest.py
@@ -24,7 +24,7 @@ class ResetSubProcessTest(BpmnWorkflowTestCase):
         state = self.serializer.serialize_json(self.workflow)
         self.workflow = self.serializer.deserialize_json(state)
         self.workflow.spec = spec
-        self.workflow.subprocesses = subprocesses
+        self.workflow.subprocess_specs = subprocesses
 
     def testSaveRestore(self):
         self.actualTest(True)
@@ -38,13 +38,10 @@ class ResetSubProcessTest(BpmnWorkflowTestCase):
         task = self.workflow.get_ready_user_tasks()[0]
         self.save_restore()
         top_level_task = self.workflow.get_tasks_from_spec_name('Task1')[0]
-#        top_level_task.reset_token({}, reset_data=True)
         self.workflow.reset_from_task_id(top_level_task.id)
         task = self.workflow.get_ready_user_tasks()[0]
-        self.assertEqual(len(self.workflow.get_ready_user_tasks()), 1,
-                         "There should only be one task in a ready state.")
+        self.assertEqual(len(self.workflow.get_ready_user_tasks()), 1, "There should only be one task in a ready state.")
         self.assertEqual(task.get_name(), 'Task1')
-
 
     def actualTest(self, save_restore=False):
 

--- a/tests/SpiffWorkflow/bpmn/events/ActionManagementTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/ActionManagementTest.py
@@ -48,7 +48,6 @@ class ActionManagementTest(BpmnWorkflowTestCase):
 
         self.do_next_named_step("Complete Work", choice="Done")
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
 
         self.assertTrue(self.workflow.is_completed())
 
@@ -86,8 +85,6 @@ class ActionManagementTest(BpmnWorkflowTestCase):
 
         self.do_next_named_step("Complete Work", choice="Done")
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
-
         self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughCancel(self):

--- a/tests/SpiffWorkflow/bpmn/events/CallActivityEscalationTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/CallActivityEscalationTest.py
@@ -80,7 +80,6 @@ class CallActivityEscalationTest(BpmnWorkflowTestCase):
         for task in self.workflow.get_tasks(TaskState.READY):
             task.set_data(should_escalate=False)
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.save_restore()
         self.workflow.run_all()
         self.assertEqual(True, self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/events/MessageInterruptsSpTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageInterruptsSpTest.py
@@ -29,7 +29,6 @@ class MessageInterruptsSpTest(BpmnWorkflowTestCase):
 
         self.do_next_exclusive_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.save_restore()
 
         self.do_next_exclusive_step('Ack Subprocess Done')

--- a/tests/SpiffWorkflow/bpmn/events/MessageInterruptsTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageInterruptsTest.py
@@ -33,7 +33,6 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.WAITING)))
 
         self.save_restore()
@@ -64,7 +63,6 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.save_restore()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
@@ -80,7 +78,6 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.do_next_exclusive_step('Do Something That Takes A Long Time')
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.WAITING)))
 
         self.workflow.do_engine_steps()
@@ -104,7 +101,6 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.do_next_exclusive_step('Acknowledge Interrupt Message')
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
 

--- a/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptTest.py
@@ -31,7 +31,6 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.WAITING)))
 
         self.save_restore()
@@ -71,7 +70,6 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughHappy(self):
@@ -87,7 +85,6 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.do_next_exclusive_step('Do Something That Takes A Long Time')
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.WAITING)))
 
         self.workflow.do_engine_steps()
@@ -118,7 +115,6 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Do Something That Takes A Long Time')
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageInterruptOtherOrder(self):
@@ -145,7 +141,6 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Acknowledge Non-Interrupt Message')
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughMessageInterruptOtherOrderSaveAndRestore(self):
@@ -177,5 +172,4 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))

--- a/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptsSpTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptsSpTest.py
@@ -28,7 +28,6 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
 
         self.do_next_exclusive_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.save_restore()
 
         self.do_next_exclusive_step('Ack Subprocess Done')
@@ -53,7 +52,6 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
 
         self.do_next_named_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.save_restore()
 
         self.do_next_named_step('Ack Subprocess Done')
@@ -81,7 +79,6 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.workflow.catch(MessageEventDefinition('Test Message'))
         self.do_next_named_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.save_restore()
 
         self.do_next_named_step('Acknowledge SP Parallel Message')
@@ -114,7 +111,6 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
 
         self.do_next_named_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.save_restore()
 
         self.do_next_named_step('Ack Subprocess Done')

--- a/tests/SpiffWorkflow/bpmn/events/MessagesTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessagesTest.py
@@ -30,7 +30,6 @@ class MessagesTest(BpmnWorkflowTestCase):
         self.assertEqual('Test Message', self.workflow.get_tasks(TaskState.READY)[0].task_spec.bpmn_name)
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))
 
     def testRunThroughSaveAndRestore(self):
@@ -51,5 +50,4 @@ class MessagesTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(0, len(self.workflow.get_tasks(TaskState.READY | TaskState.WAITING)))

--- a/tests/SpiffWorkflow/bpmn/events/MultipleThrowEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MultipleThrowEventTest.py
@@ -19,7 +19,6 @@ class MultipleThrowEventIntermediateCatchTest(BpmnWorkflowTestCase):
         if save_restore:
             self.save_restore()
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(len(self.workflow.get_waiting_tasks()), 0)
         self.assertEqual(self.workflow.is_completed(), True)
 
@@ -45,5 +44,4 @@ class MultipleThrowEventStartsEventTest(BpmnWorkflowTestCase):
         self.assertEqual(len(ready_tasks), 1)
         ready_tasks[0].run()
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(self.workflow.is_completed(), True)

--- a/tests/SpiffWorkflow/bpmn/events/NITimerDurationBoundaryTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/NITimerDurationBoundaryTest.py
@@ -66,7 +66,6 @@ class NITimerDurationTest(BpmnWorkflowTestCase):
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(self.workflow.is_completed(), True)
         self.assertEqual(self.workflow.last_task.data, {'work_done': 'Yes', 'delay_reason': 'Just Because'})
 

--- a/tests/SpiffWorkflow/bpmn/events/TransactionSubprocssTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TransactionSubprocssTest.py
@@ -22,7 +22,6 @@ class TransactionSubprocessTest(BpmnWorkflowTestCase):
         ready_tasks[0].update_data({'quantity': 2})
         ready_tasks[0].run()
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertIn('value', self.workflow.last_task.data)
 
         # Check that workflow and next task completed

--- a/tests/SpiffWorkflow/bpmn/parallel_gateway_tests/ParallelMultipleSplitsTest.py
+++ b/tests/SpiffWorkflow/bpmn/parallel_gateway_tests/ParallelMultipleSplitsTest.py
@@ -33,7 +33,6 @@ class ParallelMultipleSplitsTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
         self.do_next_named_step('SP 3 - Yes Task')
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
 
         self.do_next_named_step('Done')
         self.workflow.do_engine_steps()

--- a/tests/SpiffWorkflow/bpmn/serializer/BpmnWorkflowSerializerTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/BpmnWorkflowSerializerTest.py
@@ -162,7 +162,6 @@ class BpmnWorkflowSerializerTest(BaseTestCase):
         self.assertIsInstance(w1, BpmnWorkflow)
         self.assertIsInstance(w2, BpmnWorkflow)
         self.assertEqual(w1.data, w2.data)
-        self.assertEqual(w1.name, w2.name)
         for task in w1.get_ready_user_tasks():
             w2_task = w2.get_task_from_id(task.id)
             self.assertIsNotNone(w2_task)

--- a/tests/SpiffWorkflow/camunda/CallActivityMessageTest.py
+++ b/tests/SpiffWorkflow/camunda/CallActivityMessageTest.py
@@ -41,7 +41,6 @@ class CallActivityMessageTest(BaseTestCase):
             current_task.update_data(step[1])
             current_task.run()
             self.workflow.do_engine_steps()
-            self.complete_subworkflow()
             if save_restore:
                 self.save_restore()
             ready_tasks = self.workflow.get_tasks(TaskState.READY)

--- a/tests/SpiffWorkflow/camunda/NIMessageBoundaryTest.py
+++ b/tests/SpiffWorkflow/camunda/NIMessageBoundaryTest.py
@@ -82,7 +82,6 @@ class NIMessageBoundaryTest(BaseTestCase):
         task.data['work_completed'] = 'Lots of Stuff'
         self.workflow.run_task_from_id(task.id)
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()
         self.assertEqual(self.workflow.is_completed(),True)
         self.assertEqual(self.workflow.last_task.data,{'Event_InterruptBoundary_Response': 'Youre late!',
                                                        'flag_task': 'Yes',

--- a/tests/SpiffWorkflow/camunda/ResetTokenSubWorkflowTest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenSubWorkflowTest.py
@@ -77,7 +77,6 @@ class ResetTokenTestSubProcess(BaseTestCase):
             task.update_data({step['formvar']: step['answer']})
             task.run()
             self.workflow.do_engine_steps()
-            self.complete_subworkflow()
             if save_restore:
                 self.save_restore()
 

--- a/tests/SpiffWorkflow/camunda/SubWorkflowTest.py
+++ b/tests/SpiffWorkflow/camunda/SubWorkflowTest.py
@@ -33,7 +33,6 @@ class SubWorkflowTest(BaseTestCase):
             task.update_data({"Field"+answer: answer})
             task.run()
             self.workflow.do_engine_steps()
-            self.complete_subworkflow()
             if save_restore:
                 self.save_restore()
 

--- a/tests/SpiffWorkflow/camunda/serializer/CamundaExtensionsTest.py
+++ b/tests/SpiffWorkflow/camunda/serializer/CamundaExtensionsTest.py
@@ -18,7 +18,7 @@ class CamundaExtensionsTest(BaseTestCase):
 
     def assertMyExtension(self):
         """Assure that we have a very specific extension on specific task."""
-        task = self.workflow.get_task_spec_from_name("Task_User_Select_Type")
+        task = self.workflow.spec.get_task_spec_from_name("Task_User_Select_Type")
         self.assertIsNotNone(task)
         self.assertTrue(hasattr(task, 'extensions'))
         self.assertTrue("my_extension" in task.extensions)

--- a/tests/SpiffWorkflow/core/specs/SubWorkflowTest.py
+++ b/tests/SpiffWorkflow/core/specs/SubWorkflowTest.py
@@ -109,7 +109,7 @@ class TaskSpecTest(unittest.TestCase):
 
         # Now refresh waiting tasks:
         # Update the state of every WAITING task.
-        for thetask in self.workflow._get_waiting_tasks():
+        for thetask in [t for t in self.workflow.get_tasks(TaskState.WAITING)]:
             thetask.task_spec._update(thetask)
 
         self.do_next_unique_task('last')

--- a/tests/SpiffWorkflow/dmn/DecisionRunner.py
+++ b/tests/SpiffWorkflow/dmn/DecisionRunner.py
@@ -16,6 +16,7 @@ class Workflow:
         self.script_engine = script_engine
         self.parent = None
         self.spec = WorkflowSpec()
+        self.top_workflow = self
 
 class TaskSpec:
     def __init__(self):

--- a/tests/SpiffWorkflow/dmn/DecisionRunner.py
+++ b/tests/SpiffWorkflow/dmn/DecisionRunner.py
@@ -2,16 +2,20 @@ import os
 
 from lxml import etree
 
-from SpiffWorkflow.bpmn.PythonScriptEngineEnvironment import Box
 from SpiffWorkflow.dmn.engine.DMNEngine import DMNEngine
 from SpiffWorkflow.dmn.parser.DMNParser import DMNParser, get_dmn_ns
 
+class WorkflowSpec:
+    def __init__(self):
+        self.file = 'my_mock_file'
+        self.name = 'Mock Workflow Spec'
+        self.task_specs = {}
 
 class Workflow:
     def __init__(self, script_engine):
         self.script_engine = script_engine
-        self.outer_workflow = self
-        self.spec = Box({'file': 'my_mock_file'})
+        self.parent = None
+        self.spec = WorkflowSpec()
 
 class TaskSpec:
     def __init__(self):

--- a/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
+++ b/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
@@ -84,4 +84,3 @@ class PrescriptPostsciptTest(BaseTestCase):
         ready_tasks = self.workflow.get_tasks(TaskState.READY)
         ready_tasks[0].set_data(**data)
         self.workflow.do_engine_steps()
-        self.complete_subworkflow()


### PR DESCRIPTION
This PR splits adds a simple `BpmnSubworkflow` class that
- keeps track of the task id that controls the subprocess
- allows better navigation inside nested subprocesses
- adds a depth property

The order of execution inside `do_engine_steps` has changed.  Tasks are completed by subprocess, starting with those at the lowest depth.  This allows `do_engine_steps` to refresh waiting tasks whenever all the available tasks in a subprocess are complete.  This should make it more intuitive to use.

It also cleans up some methods in both `Workflow` and `BpmnWorkflow`, and removes some BPMN related attributes that have migrated into the base `Workflow` class.