### PR TITLE
Bugfix/update split task inputs

### DIFF
--- a/SpiffWorkflow/bpmn/parser/ProcessParser.py
+++ b/SpiffWorkflow/bpmn/parser/ProcessParser.py
@@ -43,7 +43,6 @@ class ProcessParser(NodeParser):
         """
         super().__init__(node, nsmap, filename=filename, lane=lane)
         self.parser = p
-        self.parsed_nodes = {}
         self.lane = lane
         self.spec = None
         self.process_executable = self.is_executable()
@@ -100,8 +99,8 @@ class ProcessParser(NodeParser):
         can be called by a TaskParser instance, that is owned by this
         ProcessParser.
         """
-        if node.get('id') in self.parsed_nodes:
-            return self.parsed_nodes[node.get('id')]
+        if node.get('id') in self.spec.task_specs:
+            return self.spec.task_specs[node.get('id')]
 
         (node_parser, spec_class) = self.parser._get_parser_class(node.tag)
         if not node_parser or not spec_class:

--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -216,7 +216,8 @@ class TaskParser(NodeParser):
                     self.raise_validation_exception('When looking for a task spec, we found two items, '
                         'perhaps a form has the same ID? (%s)' % target_ref)
 
-                c = self.process_parser.parse_node(target_node)
+                split_task = self.spec.task_specs.get(f'{target_ref}.BoundaryEventSplit')
+                c = self.process_parser.parse_node(target_node) if split_task is None else split_task
                 position = self.get_position(target_node)
                 children.append((position, c, sequence_flow))
 

--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -203,7 +203,6 @@ class TaskParser(NodeParser):
             boundary_event_nodes = self.doc_xpath('.//bpmn:boundaryEvent[@attachedToRef="%s"]' % self.bpmn_id)
             if boundary_event_nodes:
                 parent = self._add_boundary_event(boundary_event_nodes)
-            self.process_parser.parsed_nodes[self.node.get('id')] = self.task
 
             children = []
             outgoing = self.doc_xpath('.//bpmn:sequenceFlow[@sourceRef="%s"]' % self.bpmn_id)
@@ -219,7 +218,7 @@ class TaskParser(NodeParser):
 
                 c = self.process_parser.parse_node(target_node)
                 position = self.get_position(target_node)
-                children.append((position, c, target_node, sequence_flow))
+                children.append((position, c, sequence_flow))
 
             if children:
                 # Sort children by their y coordinate.
@@ -229,11 +228,11 @@ class TaskParser(NodeParser):
 
                 default_outgoing = self.node.get('default')
                 if len(children) == 1 and isinstance(self.task, (ExclusiveGateway, InclusiveGateway)):
-                    (position, c, target_node, sequence_flow) = children[0]
+                    (position, c, sequence_flow) = children[0]
                     if self.parse_condition(sequence_flow) is None:
                         default_outgoing = sequence_flow.get('id')
 
-                for (position, c, target_node, sequence_flow) in children:
+                for (position, c, sequence_flow) in children:
                     self.connect_outgoing(c, sequence_flow, sequence_flow.get('id') == default_outgoing)
 
             return parent if boundary_event_nodes else self.task

--- a/tests/SpiffWorkflow/bpmn/ParserTest.py
+++ b/tests/SpiffWorkflow/bpmn/ParserTest.py
@@ -46,3 +46,16 @@ class ParserTest(unittest.TestCase):
         self.assertRaisesRegex(
             ValidationException, "The process '\w+' was not found*",
             self.parser.get_spec, "Process")
+
+    def testBoundaryEvent(self):
+        bpmn_file = os.path.join(os.path.dirname(__file__), 'data', 'boundary_event_split.bpmn')
+        self.parser.add_bpmn_file(bpmn_file)
+        spec = self.parser.get_spec('Process_0ymnx41')
+        gw1 = spec.task_specs.get('gw_1')
+        gw2 = spec.task_specs.get('gw_2')
+        task = spec.task_specs.get('task_2')
+        split_task = spec.task_specs.get(f'{task.name}.BoundaryEventSplit')
+        self.assertNotIn(task, gw1.outputs)
+        self.assertIn(split_task, gw1.outputs)
+        self.assertNotIn(task, gw2.outputs)
+        self.assertIn(split_task, gw2.outputs)

--- a/tests/SpiffWorkflow/bpmn/data/boundary_event_split.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/boundary_event_split.bpmn
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1oz74lp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_0ymnx41" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_01pj69c</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="gw_1" default="Flow_1e2doc4">
+      <bpmn:incoming>Flow_01pj69c</bpmn:incoming>
+      <bpmn:outgoing>Flow_1imjpib</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1e2doc4</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_01pj69c" sourceRef="StartEvent_1" targetRef="gw_1" />
+    <bpmn:exclusiveGateway id="gw_2" default="Flow_1baqf6p">
+      <bpmn:incoming>Flow_1imjpib</bpmn:incoming>
+      <bpmn:outgoing>Flow_1baqf6p</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0a5mw5g</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1imjpib" sourceRef="gw_1" targetRef="gw_2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">False</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:task id="task_1">
+      <bpmn:incoming>Flow_1baqf6p</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qrmpxi</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1baqf6p" sourceRef="gw_2" targetRef="task_1" />
+    <bpmn:task id="task_2">
+      <bpmn:incoming>Flow_0a5mw5g</bpmn:incoming>
+      <bpmn:incoming>Flow_1e2doc4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1or38ex</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0a5mw5g" sourceRef="gw_2" targetRef="task_2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">True</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1e2doc4" sourceRef="gw_1" targetRef="task_2" />
+    <bpmn:endEvent id="Event_0wmymez">
+      <bpmn:incoming>Flow_0qrmpxi</bpmn:incoming>
+      <bpmn:incoming>Flow_1or38ex</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0qrmpxi" sourceRef="task_1" targetRef="Event_0wmymez" />
+    <bpmn:sequenceFlow id="Flow_1or38ex" sourceRef="task_2" targetRef="Event_0wmymez" />
+    <bpmn:boundaryEvent id="Event_0sh7wyp" attachedToRef="task_2">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0aridnp" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_00eeq9m" attachedToRef="task_1">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0rlpg5k" />
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0ymnx41">
+      <bpmndi:BPMNEdge id="Flow_01pj69c_di" bpmnElement="Flow_01pj69c">
+        <di:waypoint x="188" y="177" />
+        <di:waypoint x="395" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1imjpib_di" bpmnElement="Flow_1imjpib">
+        <di:waypoint x="445" y="177" />
+        <di:waypoint x="495" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1baqf6p_di" bpmnElement="Flow_1baqf6p">
+        <di:waypoint x="545" y="177" />
+        <di:waypoint x="600" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0a5mw5g_di" bpmnElement="Flow_0a5mw5g">
+        <di:waypoint x="520" y="202" />
+        <di:waypoint x="520" y="290" />
+        <di:waypoint x="600" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e2doc4_di" bpmnElement="Flow_1e2doc4">
+        <di:waypoint x="420" y="202" />
+        <di:waypoint x="420" y="320" />
+        <di:waypoint x="600" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qrmpxi_di" bpmnElement="Flow_0qrmpxi">
+        <di:waypoint x="700" y="177" />
+        <di:waypoint x="762" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1or38ex_di" bpmnElement="Flow_1or38ex">
+        <di:waypoint x="700" y="290" />
+        <di:waypoint x="731" y="290" />
+        <di:waypoint x="731" y="177" />
+        <di:waypoint x="762" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Gateway_1vvx4a6_di" bpmnElement="gw_1" isMarkerVisible="true">
+        <dc:Bounds x="395" y="152" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0vqubcb_di" bpmnElement="gw_2" isMarkerVisible="true">
+        <dc:Bounds x="495" y="152" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10scr9s_di" bpmnElement="task_1">
+        <dc:Bounds x="600" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0rfxfcx_di" bpmnElement="task_2">
+        <dc:Bounds x="600" y="250" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0wmymez_di" bpmnElement="Event_0wmymez">
+        <dc:Bounds x="762" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0becpnz_di" bpmnElement="Event_0sh7wyp">
+        <dc:Bounds x="642" y="312" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0n62i6p_di" bpmnElement="Event_00eeq9m">
+        <dc:Bounds x="642" y="119" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
This makes sure all inputs to a task with a boundary event connect to the split task rather than the task itself.