### PR TITLE
Improvement/updates to multiinstance

### DIFF
--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -64,7 +64,7 @@ class TaskParser(NodeParser):
         self.spec_class = spec_class
         self.spec = self.process_parser.spec
 
-    def _copy_task_attrs(self, original):
+    def _copy_task_attrs(self, original, loop_characteristics=None):
 
         self.task.inputs = original.inputs
         self.task.outputs = original.outputs
@@ -95,7 +95,7 @@ class TaskParser(NodeParser):
 
         original = self.spec.task_specs.pop(self.task.name)
         self.task = self.STANDARD_LOOP_CLASS(self.spec, original.name, '', maximum, condition, test_before)
-        self._copy_task_attrs(original)
+        self._copy_task_attrs(original, loop_characteristics)
 
     def _add_multiinstance_task(self, loop_characteristics):
 
@@ -156,7 +156,7 @@ class TaskParser(NodeParser):
             self.task = self.SEQUENTIAL_MI_CLASS(self.spec, original.name, **params)
         else:
             self.task = self.PARALLEL_MI_CLASS(self.spec, original.name, **params)
-        self._copy_task_attrs(original)
+        self._copy_task_attrs(original, loop_characteristics)
 
     def _add_boundary_event(self, children):
 

--- a/SpiffWorkflow/bpmn/specs/bpmn_task_spec.py
+++ b/SpiffWorkflow/bpmn/specs/bpmn_task_spec.py
@@ -93,3 +93,15 @@ class BpmnTaskSpec(TaskSpec):
             my_task.data.pop(obj.bpmn_id, None)
 
         super()._on_complete_hook(my_task)
+
+    def task_info(self, my_task):
+        # This method can be extended to provide task specific info for different spec types
+        # Since almost all spec types can be MI, add instance info here if present
+        info = {}
+        if 'key_or_index' in my_task.internal_data:
+            info['instance'] = my_task.internal_data.get('key_or_index')
+        if 'item' in my_task.internal_data:
+            info['instance'] = my_task.internal_data.get('item')
+        if 'iteration' in my_task.internal_data:
+            info['iteration'] = my_task.internal_data.get('iteration')
+        return info

--- a/SpiffWorkflow/bpmn/specs/mixins/multiinstance_task.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/multiinstance_task.py
@@ -21,21 +21,21 @@ from copy import deepcopy
 from collections.abc import Iterable, Sequence, Mapping, MutableSequence, MutableMapping
 
 from SpiffWorkflow.task import TaskState
-from SpiffWorkflow.specs.base import TaskSpec
 from SpiffWorkflow.util.deep_merge import DeepMerge
+from SpiffWorkflow.bpmn.specs.bpmn_task_spec import BpmnTaskSpec
 from SpiffWorkflow.bpmn.exceptions import WorkflowDataException
 
 
-class LoopTask(TaskSpec):
+class LoopTask(BpmnTaskSpec):
 
     def process_children(self, my_task):
         """
         Handle any newly completed children and update merged tasks.
         Returns a boolean indicating whether there is a child currently running
         """
-        merged = my_task.internal_data.get('merged') or []
+        merged = self._merged_children(my_task)
         child_running = False
-        for child in filter(lambda c: c.task_spec.name == self.task_spec, my_task.children):
+        for child in self._instances(my_task):
             if child._has_state(TaskState.FINISHED_MASK) and str(child.id) not in merged:
                 self.child_completed_action(my_task, child)
                 merged.append(str(child.id))
@@ -47,6 +47,12 @@ class LoopTask(TaskSpec):
     def child_completed_action(self, my_task, child):
         raise NotImplementedError
 
+    def _merged_children(self, my_task):
+        return my_task.internal_data.get('merged', [])
+    
+    def _instances(self, my_task):
+        return filter(lambda c: c.task_spec.name == self.task_spec, my_task.children)
+
 
 class StandardLoopTask(LoopTask):
 
@@ -56,6 +62,14 @@ class StandardLoopTask(LoopTask):
         self.maximum = maximum
         self.condition = condition
         self.test_before = test_before
+
+    def task_info(self, my_task):
+        info = super().task_info(my_task)
+        info['iterations_completed'] = len(self._merged_children(my_task))
+        if self.maximum:
+            info['iterations_remaining'] = self.maximum - info['iterations_completed']
+        info['instance_map'] = dict((idx, str(t.id)) for idx, t in enumerate(self._instances(my_task)))
+        return info
 
     def _update_hook(self, my_task):
 
@@ -77,12 +91,13 @@ class StandardLoopTask(LoopTask):
             child = my_task._add_child(task_spec, TaskState.WAITING)
             child.triggered = True
             child.data = deepcopy(my_task.data)
+            child.internal_data['iteration'] = len(self._merged_children(my_task))
 
     def child_completed_action(self, my_task, child):
         DeepMerge.merge(my_task.data, child.data)
 
     def loop_complete(self, my_task):
-        merged = my_task.internal_data.get('merged') or []
+        merged = self._merged_children(my_task)
         if not self.test_before and len(merged) == 0:
             # "test before" isn't really compatible our execution model in a transparent way
             # This guarantees that the task will run at least once if test_before is False
@@ -107,6 +122,27 @@ class MultiInstanceTask(LoopTask):
         self.input_item = input_item
         self.output_item = output_item
         self.condition = condition
+
+    def task_info(self, my_task):
+        info = super().task_info(my_task)
+        info.update({
+            'completed': [],
+            'running': [],
+            'future': my_task.internal_data.get('remaining', []),
+            'instance_map': {},
+        })
+        for task in self._instances(my_task):
+            key_or_index = task.internal_data.get('key_or_index')
+            value = task.internal_data.get('item') if key_or_index is None else key_or_index
+            if task._has_state(TaskState.FINISHED_MASK):
+                info['completed'].append(value)
+            else:
+                info['running'].append(value)
+            try:
+                info['instance_map'][value] = str(task.id)
+            except TypeError:
+                info['instance_map'][str(value)] = str(task.id)
+        return info
 
     def child_completed_action(self, my_task, child):
         """This merges child data into this task's data."""
@@ -138,11 +174,13 @@ class MultiInstanceTask(LoopTask):
             child.data[self.input_item.bpmn_id] = deepcopy(item)
         if key_or_index is not None:
             child.internal_data['key_or_index'] = key_or_index
+        else:
+            child.internal_data['item'] = item
         child.task_spec._update(child)
 
     def check_completion_condition(self, my_task):
 
-        merged = my_task.internal_data.get('merged', [])
+        merged = self._merged_children(my_task)
         if len(merged) > 0:
             last_child = [c for c in my_task.children if str(c.id) == merged[-1]][0]
             return my_task.workflow.script_engine.evaluate(last_child, self.condition)
@@ -197,6 +235,13 @@ class SequentialMultiInstanceTask(MultiInstanceTask):
             return True
         else:
             return self.add_next_child(my_task)
+
+    def task_info(self, my_task):
+        info = super().task_info(my_task)
+        cardinality = my_task.internal_data.get('cardinality')
+        if cardinality is not None:
+            info['future'] = [v for v in range(len(info['completed']) + len(info['running']), cardinality)]
+        return info
 
     def add_next_child(self, my_task):
 
@@ -307,7 +352,7 @@ class ParallelMultiInstanceTask(MultiInstanceTask):
         else:
             # For tasks specifying the cardinality, use the index as the "item"
             cardinality = my_task.workflow.script_engine.evaluate(my_task, self.cardinality)
-            children = ((None, idx) for idx in range(cardinality))
+            children = ((idx, idx) for idx in range(cardinality))
 
         if not my_task.internal_data.get('started', False):
 
@@ -323,4 +368,4 @@ class ParallelMultiInstanceTask(MultiInstanceTask):
 
             my_task.internal_data['started'] = True
         else:
-            return len(my_task.internal_data.get('merged', [])) == len(children)
+            return len(self._merged_children(my_task)) == len(children)

--- a/SpiffWorkflow/bpmn/specs/mixins/multiinstance_task.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/multiinstance_task.py
@@ -130,8 +130,11 @@ class MultiInstanceTask(LoopTask):
         task_spec = my_task.workflow.spec.task_specs[self.task_spec]
         child = my_task._add_child(task_spec, TaskState.WAITING)
         child.triggered = True
-        child.data = deepcopy(my_task.data)
-        if self.input_item is not None:
+        if self.input_item is not None and self.input_item.bpmn_id in my_task.data:
+            raise WorkflowDataException(f'Multiinstance input item {self.input_item.bpmn_id} already exists.', my_task)
+        if self.output_item is not None and self.output_item.bpmn_id in my_task.data:
+            raise WorkflowDataException(f'Multiinstance output item {self.output_item.bpmn_id} already exists.', my_task)
+        if self.input_item is not None:                
             child.data[self.input_item.bpmn_id] = deepcopy(item)
         if key_or_index is not None:
             child.internal_data['key_or_index'] = key_or_index

--- a/SpiffWorkflow/camunda/parser/task_spec.py
+++ b/SpiffWorkflow/camunda/parser/task_spec.py
@@ -75,7 +75,7 @@ class CamundaTaskParser(TaskParser):
             self.task = SequentialMultiInstanceTask(self.spec, original.name, **params)
         else:
             self.task = ParallelMultiInstanceTask(self.spec, original.name, **params)
-        self._copy_task_attrs(original)
+        self._copy_task_attrs(original, loop_characteristics)
 
 
 class BusinessRuleTaskParser(CamundaTaskParser):

--- a/SpiffWorkflow/spiff/parser/task_spec.py
+++ b/SpiffWorkflow/spiff/parser/task_spec.py
@@ -110,13 +110,14 @@ class SpiffTaskParser(TaskParser):
         operator['parameters'] = parameters
         return operator
 
-    def _copy_task_attrs(self, original):
+    def _copy_task_attrs(self, original, loop_characteristics):
         # I am so disappointed I have to do this.
         super()._copy_task_attrs(original)
-        self.task.prescript = original.prescript
-        self.task.postscript = original.postscript
-        original.prescript = None
-        original.postscript = None
+        if loop_characteristics.attrib.get('{' + SPIFFWORKFLOW_MODEL_NS + '}' + 'scriptsOnInstances') != 'true':
+            self.task.prescript = original.prescript
+            self.task.postscript = original.postscript
+            original.prescript = None
+            original.postscript = None
 
     def create_task(self):
         # The main task parser already calls this, and even sets an attribute, but

--- a/tests/SpiffWorkflow/bpmn/ParallelMultiInstanceTest.py
+++ b/tests/SpiffWorkflow/bpmn/ParallelMultiInstanceTest.py
@@ -17,14 +17,23 @@ class BaseTestCase(BpmnWorkflowTestCase):
         any_task = self.workflow.get_tasks_from_spec_name('any_task')[0]
         any_task.task_spec.data_input = TaskDataReference(data_input) if data_input is not None else None
         any_task.task_spec.data_output = TaskDataReference(data_output) if data_output is not None else None
-
         self.workflow.do_engine_steps()
+
+        task_info = any_task.task_spec.task_info(any_task)
+        self.assertEqual(len(task_info['completed']), 0)
+        self.assertEqual(len(task_info['running']), 3)
+        self.assertEqual(len(task_info['future']), 0)
+        self.assertEqual(len(task_info['instance_map']), 3)
+        instance_map = task_info['instance_map']
+
         ready_tasks = self.workflow.get_ready_user_tasks()
         self.assertEqual(len(ready_tasks), 3)
         while len(ready_tasks) > 0:
             task = ready_tasks[0]
+            task_info = task.task_spec.task_info(task)
             self.assertEqual(task.task_spec.name, 'any_task [child]')
             self.assertIn('input_item', task.data)
+            self.assertEqual(instance_map[task_info['instance']], str(task.id))
             task.data['output_item'] = task.data['input_item'] * 2
             task.run()
             if save_restore:
@@ -32,6 +41,12 @@ class BaseTestCase(BpmnWorkflowTestCase):
             ready_tasks = self.workflow.get_ready_user_tasks()
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
+
+        any_task = self.workflow.get_tasks_from_spec_name('any_task')[0]
+        task_info = any_task.task_spec.task_info(any_task)
+        self.assertEqual(len(task_info['completed']), 3)
+        self.assertEqual(len(task_info['running']), 0)
+        self.assertEqual(len(task_info['future']), 0)
         self.assertTrue(self.workflow.is_completed())
 
     def run_workflow_with_condition(self, data):

--- a/tests/SpiffWorkflow/spiff/MultiInstanceTaskTest.py
+++ b/tests/SpiffWorkflow/spiff/MultiInstanceTaskTest.py
@@ -27,3 +27,26 @@ class MultiInstanceTaskTest(BaseTestCase):
             'input_data': [2, 3, 4],  # Prescript adds 1 to input
             'output_data': [3, 5, 7],  # Postscript subtracts 1 from output
         })
+
+    def testMultiInstanceTaskWithInstanceScripts(self):
+        spec, subprocesses = self.load_workflow_spec('script_on_mi.bpmn', 'Process_1')
+        self.workflow = BpmnWorkflow(spec, subprocesses)
+        start = self.workflow.get_tasks_from_spec_name('Start')[0]
+        start.data = {'input_data': [1, 2, 3]}
+        self.workflow.do_engine_steps()
+        task = self.workflow.get_tasks_from_spec_name('any_task')[0]
+        self.workflow.do_engine_steps()
+
+        self.save_restore()
+
+        ready_tasks = self.workflow.get_ready_user_tasks()
+        for task in ready_tasks:
+            task.data['output_item'] = task.data['input_item'] * 2
+            task.run()
+            self.workflow.do_engine_steps()
+
+        self.assertTrue(self.workflow.is_completed())
+        self.assertDictEqual(self.workflow.data, {
+            'input_data': [1, 2, 3],  # Prescript modifies input item
+            'output_data': [3, 5, 7],
+        })

--- a/tests/SpiffWorkflow/spiff/data/script_on_mi.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/script_on_mi.bpmn
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19o7vxg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="Event_1ftsuzw">
+      <bpmn:outgoing>Flow_1hjrex4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="any_task" name="Any Task">
+      <bpmn:extensionElements>
+        <spiffworkflow:preScript>input_item += 1</spiffworkflow:preScript>
+        <spiffworkflow:postScript>output_item -= 1</spiffworkflow:postScript>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1hjrex4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xndbxy</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics spiffworkflow:scriptsOnInstances="true">
+        <bpmn:loopDataInputRef>input_data</bpmn:loopDataInputRef>
+        <bpmn:loopDataOutputRef>output_data</bpmn:loopDataOutputRef>
+        <bpmn:inputDataItem id="input_item" name="input item" />
+        <bpmn:outputDataItem id="output_item" name="output item" />
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1hjrex4" sourceRef="Event_1ftsuzw" targetRef="any_task" />
+    <bpmn:endEvent id="Event_0c80924">
+      <bpmn:incoming>Flow_1xndbxy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1xndbxy" sourceRef="any_task" targetRef="Event_0c80924" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="Flow_1xndbxy_di" bpmnElement="Flow_1xndbxy">
+        <di:waypoint x="380" y="120" />
+        <di:waypoint x="432" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hjrex4_di" bpmnElement="Flow_1hjrex4">
+        <di:waypoint x="228" y="120" />
+        <di:waypoint x="280" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1ftsuzw_di" bpmnElement="Event_1ftsuzw">
+        <dc:Bounds x="192" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1iqs4li_di" bpmnElement="any_task">
+        <dc:Bounds x="280" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c80924_di" bpmnElement="Event_0c80924">
+        <dc:Bounds x="432" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
This PR adds a `task_info` method that can be used to provide runtime information about tasks, based on the task spec and the task itself.  The immediate requirement is to provide information about multiinstance tasks; however, this is a generic method that can be extended by any spec type to provide additional information to a process engine that is defined by that type based on the current state of the task.

Additionally, it
- adds the ability to choose whether pre and post scripts on MI task specs in the `spiff` package should be attached to the MI task or the instance
- raises an error if the specified input or output item of an MI task is already present in the task data