### PR TITLE
Improvement/replace root with spec start

### DIFF
--- a/SpiffWorkflow/bpmn/serializer/migration/version_1_3.py
+++ b/SpiffWorkflow/bpmn/serializer/migration/version_1_3.py
@@ -92,7 +92,6 @@ def remove_boundary_event_parent(dct):
                     new_tasks[new_task['id']] = new_task
         
         wf['tasks'].update(new_tasks)
-        pass
 
     update_specs(dct['spec'])
     for sp_spec in dct['subprocess_specs'].values():
@@ -101,3 +100,21 @@ def remove_boundary_event_parent(dct):
     update_tasks(dct)
     for sp in dct['subprocesses'].values():
         update_tasks(sp)
+
+def remove_root_task(dct):
+    
+    def update(wf):
+        root = wf['tasks'].get(wf['root'])
+        if root['task_spec'] == 'Root':
+            wf['tasks'].pop(root['id'])
+            start = wf['tasks'].get(root['children'][0])
+            start['parent'] = None
+            wf['root'] = start['id']
+
+    update(dct)          
+    for sp in dct['subprocesses'].values():
+        update(sp)
+
+    dct['spec']['task_specs'].pop('Root', None)
+    for spec in dct['subprocess_specs'].values():
+        spec['task_specs'].pop('Root', None)

--- a/SpiffWorkflow/bpmn/serializer/migration/version_migration.py
+++ b/SpiffWorkflow/bpmn/serializer/migration/version_migration.py
@@ -30,12 +30,17 @@ from .version_1_2 import (
     convert_simple_tasks,
     update_bpmn_attributes,
 )
-from .version_1_3 import update_event_definition_attributes, remove_boundary_event_parent
+from .version_1_3 import (
+    update_event_definition_attributes,
+    remove_boundary_event_parent,
+    remove_root_task,
+)
 
 def from_version_1_2(old):
     new = deepcopy(old)
     update_event_definition_attributes(new)
     remove_boundary_event_parent(new)
+    remove_root_task(new)
     new['VERSION'] = "1.3"
     return new
 

--- a/SpiffWorkflow/bpmn/serializer/workflow.py
+++ b/SpiffWorkflow/bpmn/serializer/workflow.py
@@ -168,6 +168,7 @@ class BpmnWorkflowSerializer:
         """
         # These properties are applicable to top level & subprocesses
         dct = self.process_to_dict(workflow)
+        dct['spec'] = self.spec_converter.convert(workflow.spec)
         # These are only used at the top-level      
         dct['subprocess_specs'] = dict(
             (name, self.spec_converter.convert(spec)) for name, spec in workflow.subprocess_specs.items()
@@ -218,6 +219,7 @@ class BpmnWorkflowSerializer:
     def subworkflow_to_dict(self, workflow):
         dct = self.process_to_dict(workflow)
         dct['parent_task_id'] = str(workflow.parent_task_id)
+        dct['spec'] = workflow.spec.name
         return dct
 
     def task_to_dict(self, task):
@@ -292,7 +294,6 @@ class BpmnWorkflowSerializer:
 
     def process_to_dict(self, process):
         return {
-            'spec': self.spec_converter.convert(process.spec),
             'data': self.data_converter.convert(process.data),
             'correlations': process.correlations,
             'last_task': str(process.last_task.id) if process.last_task is not None else None,

--- a/SpiffWorkflow/bpmn/specs/bpmn_process_spec.py
+++ b/SpiffWorkflow/bpmn/specs/bpmn_process_spec.py
@@ -36,9 +36,6 @@ class BpmnProcessSpec(WorkflowSpec):
         LXML node. (optional)
         """
         super(BpmnProcessSpec, self).__init__(name=name, filename=filename, nostart=True)
-        # Add a root task to ensure all tasks in the workflow are bpmn tasks
-        # The serializer ignores this task
-        SimpleBpmnTask(self, 'Root')
         self.start = BpmnStartTask(self, 'Start')
         self.end = _EndJoin(self, '%s.EndJoin' % (self.name))
         self.end.connect(SimpleBpmnTask(self, 'End'))

--- a/SpiffWorkflow/bpmn/specs/bpmn_process_spec.py
+++ b/SpiffWorkflow/bpmn/specs/bpmn_process_spec.py
@@ -35,7 +35,7 @@ class BpmnProcessSpec(WorkflowSpec):
         :param svg: This provides the SVG representation of the workflow as an
         LXML node. (optional)
         """
-        super(BpmnProcessSpec, self).__init__(name=name, filename=filename, nostart=True)
+        super(BpmnProcessSpec, self).__init__(name=name, filename=filename)
         self.start = BpmnStartTask(self, 'Start')
         self.end = _EndJoin(self, '%s.EndJoin' % (self.name))
         self.end.connect(SimpleBpmnTask(self, 'End'))

--- a/SpiffWorkflow/bpmn/workflow.py
+++ b/SpiffWorkflow/bpmn/workflow.py
@@ -335,10 +335,8 @@ class BpmnWorkflow(Workflow):
 
             new = spec_class(self.spec, f'{wf_spec.name}_{len(self.subprocesses)}', wf_spec.name)
             self.spec.start.connect(new)
-            task = Task(self, new)
             start = self.get_tasks_from_spec_name('Start', workflow=self)[0]
-            start.children.append(task)
-            task.parent = start
+            task = Task(self, new, parent=start)
             # This (indirectly) calls create_subprocess
             task.task_spec._update(task)
             return self.subprocesses[task.id]

--- a/SpiffWorkflow/serializer/dict.py
+++ b/SpiffWorkflow/serializer/dict.py
@@ -505,8 +505,7 @@ class DictionarySerializer(Serializer):
         workflow.task_tree = self.deserialize_task(workflow, s_state['task_tree'], reset_specs)
 
         # Re-connect parents and update states if necessary
-        root = workflow.get_tasks_from_spec_name('Root')[0]
-        update_state = root.state != TaskState.COMPLETED
+        update_state = workflow.task_tree.state != TaskState.COMPLETED
         for task in workflow.get_tasks_iterator():
             if task.parent is not None:
                 task.parent = workflow.get_task_from_id(task.parent)

--- a/SpiffWorkflow/serializer/dict.py
+++ b/SpiffWorkflow/serializer/dict.py
@@ -446,8 +446,6 @@ class DictionarySerializer(Serializer):
         spec.description = s_state['description']
 
         # Handle Start Task
-        spec.start = None
-        del spec.task_specs['Start']
         start_task_spec_state = s_state['task_specs']['Start']
         start_task_spec = StartTask.deserialize(self, spec, start_task_spec_state)
         spec.start = start_task_spec

--- a/SpiffWorkflow/serializer/prettyxml.py
+++ b/SpiffWorkflow/serializer/prettyxml.py
@@ -288,7 +288,6 @@ class XmlSerializer(Serializer):
 
         # Read all task specs and create a list of successors.
         workflow_spec = WorkflowSpec(name, filename)
-        del workflow_spec.task_specs['Start']
         end = Simple(workflow_spec, 'End'), []
         read_specs = dict(end=end)
         for child_node in root_node.getchildren():

--- a/SpiffWorkflow/serializer/xml.py
+++ b/SpiffWorkflow/serializer/xml.py
@@ -624,7 +624,7 @@ class XmlSerializer(Serializer):
     def deserialize_workflow_spec(self, elem, **kwargs):
         name = elem.findtext('name')
         filename = elem.findtext('filename')
-        spec = WorkflowSpec(name, filename=filename, nostart=True)
+        spec = WorkflowSpec(name, filename=filename)
         spec.description = elem.findtext('description')
 
         # Add all tasks.

--- a/SpiffWorkflow/specs/SubWorkflow.py
+++ b/SpiffWorkflow/specs/SubWorkflow.py
@@ -100,10 +100,8 @@ class SubWorkflow(TaskSpec):
         wf_spec = WorkflowSpec.deserialize(serializer, xml, filename=file_name)
         subworkflow = Workflow(wf_spec)
         my_task._sync_children(self.outputs, TaskState.FUTURE)
-        for child in subworkflow.task_tree.children:
-            my_task.children.insert(0, child)
-            child.parent = my_task
-            child.state = TaskState.READY
+        subworkflow.task_tree.parent = my_task
+        my_task.children.insert(0, subworkflow.task_tree)
         subworkflow.completed_event.connect(self._on_subworkflow_completed, my_task)
         my_task._set_internal_data(subworkflow=subworkflow)
         my_task._set_state(TaskState.WAITING)

--- a/SpiffWorkflow/specs/WorkflowSpec.py
+++ b/SpiffWorkflow/specs/WorkflowSpec.py
@@ -26,7 +26,7 @@ class WorkflowSpec(object):
     This class represents the specification of a workflow.
     """
 
-    def __init__(self, name=None, filename=None, nostart=False):
+    def __init__(self, name=None, filename=None, addstart=False):
         """
         Constructor.
         """
@@ -35,7 +35,7 @@ class WorkflowSpec(object):
         self.file = filename
         self.task_specs = dict()
         self.start = None
-        if not nostart:
+        if addstart:
             self.start = StartTask(self)
 
     def _add_notify(self, task_spec):

--- a/tests/SpiffWorkflow/camunda/ResetTokenParallelTaskCountTest.py
+++ b/tests/SpiffWorkflow/camunda/ResetTokenParallelTaskCountTest.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-import unittest
-
 from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
 from tests.SpiffWorkflow.camunda.BaseTestCase import BaseTestCase
 
@@ -23,7 +19,7 @@ class ResetTokenParallelTaskCountTest(BaseTestCase):
         self.actual_test(save_restore=True)
 
     def actual_test(self, save_restore=False):
-        total = 10  # I would expect there to be 9 tasks, but we get 10.
+        total = 9
 
         # Set the workflow in motion, and assure we have the right
         # number of tasks
@@ -44,9 +40,3 @@ class ResetTokenParallelTaskCountTest(BaseTestCase):
         task.reset_token(data)
         self.assertEquals(total, len(self.workflow.get_tasks()))
         self.assertEquals(1, len(self.workflow.get_ready_user_tasks()))
-
-def suite():
-    return unittest.TestLoader().loadTestsFromTestCase(ResetTokenParallelTaskCountTest)
-
-if __name__ == '__main__':
-    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/core/PersistSmallWorkflowTest.py
+++ b/tests/SpiffWorkflow/core/PersistSmallWorkflowTest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 
 from SpiffWorkflow.workflow import Workflow
@@ -89,10 +88,7 @@ class PersistSmallWorkflowTest(unittest.TestCase):
             len(new_workflow.get_tasks()), len(old_workflow.get_tasks()))
         self.assertEqual(new_workflow.spec.start.get_data(
             'marker'), old_workflow.spec.start.get_data('marker'))
-        self.assertEqual(
-            1, len([t for t in new_workflow.get_tasks() if t.task_spec.name == 'Start']))
-        self.assertEqual(
-            1, len([t for t in new_workflow.get_tasks() if t.task_spec.name == 'Root']))
+        self.assertEqual(1, len([t for t in new_workflow.get_tasks() if t.task_spec.name == 'Start']))
 
     def testDeserialization2(self):
         """
@@ -110,9 +106,3 @@ class PersistSmallWorkflowTest(unittest.TestCase):
         self.assertEqual('task_a2', old_workflow.last_task.get_name())
         new_workflow.run_all()
         self.assertEqual('task_a2', old_workflow.last_task.get_name())
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromTestCase(PersistSmallWorkflowTest)
-if __name__ == '__main__':
-    unittest.TextTestRunner(verbosity=2).run(suite())

--- a/tests/SpiffWorkflow/core/PersistSmallWorkflowTest.py
+++ b/tests/SpiffWorkflow/core/PersistSmallWorkflowTest.py
@@ -13,7 +13,7 @@ from SpiffWorkflow.serializer.dict import DictionarySerializer
 class ASmallWorkflow(WorkflowSpec):
 
     def __init__(self):
-        super(ASmallWorkflow, self).__init__(name="asmallworkflow")
+        super(ASmallWorkflow, self).__init__(name="asmallworkflow", addstart=True)
 
         multichoice = MultiChoice(self, 'multi_choice_1')
         self.start.connect(multichoice)

--- a/tests/SpiffWorkflow/core/WorkflowTest.py
+++ b/tests/SpiffWorkflow/core/WorkflowTest.py
@@ -17,7 +17,7 @@ data_dir = os.path.join(os.path.dirname(__file__), 'data')
 class WorkflowTest(unittest.TestCase):
 
     def testConstructor(self):
-        wf_spec = WorkflowSpec()
+        wf_spec = WorkflowSpec(addstart=True)
         wf_spec.start.connect(Cancel(wf_spec, 'name'))
         Workflow(wf_spec)
 

--- a/tests/SpiffWorkflow/core/specs/JoinTest.py
+++ b/tests/SpiffWorkflow/core/specs/JoinTest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from SpiffWorkflow.specs.Join import Join
 
 from .TaskSpecTest import TaskSpecTest
@@ -10,6 +8,4 @@ class JoinTest(TaskSpecTest):
         if 'testtask' in self.wf_spec.task_specs:
             del self.wf_spec.task_specs['testtask']
 
-        return Join(self.wf_spec,
-                    'testtask',
-                    description='foo')
+        return Join(self.wf_spec, 'testtask', description='foo')

--- a/tests/SpiffWorkflow/core/specs/MergeTest.py
+++ b/tests/SpiffWorkflow/core/specs/MergeTest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from .JoinTest import JoinTest
 from SpiffWorkflow.specs.Merge import Merge
 from SpiffWorkflow.specs.WorkflowSpec import WorkflowSpec
@@ -60,7 +58,7 @@ class MergeTest(JoinTest):
             if task.task_spec is simple1:
                 self.assertIn('first', task.data)
                 self.assertIn('second', task.data)
-                self.assertEqual(task.data, {'Start': 1,
+                self.assertEqual(task.data, {'everywhere': 1, 'Start': 1,
                                              'merge 1': 1, 'name': 'Start', 'simple 1': 1,
                                              'second': 1, 'first': 1})
                 found['simple1'] = task
@@ -69,12 +67,12 @@ class MergeTest(JoinTest):
                 self.assertIn('second', task.data)
                 self.assertIn('third', task.data)
                 self.assertIn('fourth', task.data)
-                self.assertEqual(task.data, {'merge 2': 1,
+                self.assertEqual(task.data, {'everywhere': 1, 'merge 2': 1,
                                              'simple 2': 1, 'name': 'Start', 'third': 1, 'bump': 1,
                                              'Start': 1, 'second': 1, 'first': 1, 'fourth': 1})
                 found['simple2'] = task
             if task.task_spec is unmerged:
-                self.assertEqual(task.data, {'Start': 1,
+                self.assertEqual(task.data, {'everywhere': 1, 'Start': 1,
                                              'second': 1, 'name': 'Start', 'unmerged': 1})
                 found['unmerged'] = task
         self.assertIn('simple1', found)

--- a/tests/SpiffWorkflow/core/specs/MergeTest.py
+++ b/tests/SpiffWorkflow/core/specs/MergeTest.py
@@ -11,13 +11,11 @@ class MergeTest(JoinTest):
         if 'testtask' in self.wf_spec.task_specs:
             del self.wf_spec.task_specs['testtask']
 
-        return Merge(self.wf_spec,
-                     'testtask',
-                     description='foo')
+        return Merge(self.wf_spec, 'testtask', description='foo')
 
     def test_Merge_data_merging(self):
         """Test that Merge task actually merges data"""
-        wf_spec = WorkflowSpec()
+        wf_spec = WorkflowSpec(addstart=True)
         first = Simple(wf_spec, 'first')
         second = Simple(wf_spec, 'second')
         third = Simple(wf_spec, 'third')

--- a/tests/SpiffWorkflow/core/specs/TaskSpecTest.py
+++ b/tests/SpiffWorkflow/core/specs/TaskSpecTest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 
 from SpiffWorkflow.specs.Join import Join
@@ -17,7 +16,7 @@ class TaskSpecTest(unittest.TestCase):
         return TaskSpec(self.wf_spec, 'testtask', description='foo')
 
     def setUp(self):
-        self.wf_spec = WorkflowSpec()
+        self.wf_spec = WorkflowSpec(addstart=True)
         self.spec = self.create_instance()
 
     def testConstructor(self):

--- a/tests/SpiffWorkflow/core/specs/WorkflowSpecTest.py
+++ b/tests/SpiffWorkflow/core/specs/WorkflowSpecTest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import unittest
 import os
 import pickle
@@ -22,10 +21,10 @@ data_file = 'data.pkl'
 class WorkflowSpecTest(unittest.TestCase):
 
     def setUp(self):
-        self.wf_spec = WorkflowSpec()
+        self.wf_spec = WorkflowSpec(addstart=True)
 
     def testConstructor(self):
-        spec = WorkflowSpec('my spec')
+        spec = WorkflowSpec('my spec', addstart=True)
         self.assertEqual('my spec', spec.name)
 
     def testGetTaskSpecFromName(self):

--- a/tests/SpiffWorkflow/core/util.py
+++ b/tests/SpiffWorkflow/core/util.py
@@ -42,7 +42,7 @@ def on_reached_cb(workflow, task, taken_path):
 
 def on_complete_cb(workflow, task, taken_path):
     # Record the path.
-    indent = '  ' * (task._get_depth() - 1)
+    indent = '  ' * task._get_depth()
     taken_path.append('%s%s' % (indent, task.get_name()))
     # In workflows that load a subworkflow, the newly loaded children
     # will not have on_reached_cb() assigned. By using this function, we


### PR DESCRIPTION
This changes `Workflow` to use the spec start task as the root of the task tree rather than adding an additional task.

This also changes the `nostart` option of `WorkflowSpec` to optionally add a start task if True, getting rid of the confusing double negative (previously the task was added `if not nostart`).

Also correct a bug (or at least an inefficiency) I introduced while changing how subworkflows are handled.