### PR TITLE
Unify connect() argument name to 'taskspec'

### DIFF
--- a/SpiffWorkflow/specs/ExclusiveChoice.py
+++ b/SpiffWorkflow/specs/ExclusiveChoice.py
@@ -45,7 +45,7 @@ class ExclusiveChoice(MultiChoice):
         super(ExclusiveChoice, self).__init__(wf_spec, name, **kwargs)
         self.default_task_spec = None
 
-    def connect(self, task_spec):
+    def connect(self, taskspec):
         """
         Connects the task spec that is executed if no other condition
         matches.
@@ -54,8 +54,8 @@ class ExclusiveChoice(MultiChoice):
         :param task_spec: The following task spec.
         """
         assert self.default_task_spec is None
-        self.default_task_spec = task_spec.name
-        super().connect(task_spec)
+        self.default_task_spec = taskspec.name
+        super().connect(taskspec)
 
     def test(self):
         super().test()

--- a/SpiffWorkflow/specs/MultiChoice.py
+++ b/SpiffWorkflow/specs/MultiChoice.py
@@ -46,11 +46,11 @@ class MultiChoice(TaskSpec):
         self.cond_task_specs = []
         self.choice = None
 
-    def connect(self, task_spec):
+    def connect(self, taskspec):
         """
         Convenience wrapper around connect_if() where condition is set to None.
         """
-        return self.connect_if(None, task_spec)
+        return self.connect_if(None, taskspec)
 
     def connect_if(self, condition, task_spec):
         """

--- a/SpiffWorkflow/specs/ThreadSplit.py
+++ b/SpiffWorkflow/specs/ThreadSplit.py
@@ -67,15 +67,15 @@ class ThreadSplit(TaskSpec):
         else:
             self.thread_starter = None
 
-    def connect(self, task_spec):
+    def connect(self, taskspec):
         """
         Connect the *following* task to this one. In other words, the
         given task is added as an output task.
 
         task -- the task to connect to.
         """
-        self.thread_starter._outputs.append(task_spec.name)
-        task_spec._connect_notify(self.thread_starter)
+        self.thread_starter._outputs.append(taskspec.name)
+        taskspec._connect_notify(self.thread_starter)
 
     def _get_activated_tasks(self, my_task, destination):
         """


### PR DESCRIPTION
In the base class `TaskSpec`, it use `taskspec` as the argument name of `connect()`.