### PR TITLE
default the category for a DataObject to None

### DIFF
--- a/SpiffWorkflow/spiff/specs/data_object.py
+++ b/SpiffWorkflow/spiff/specs/data_object.py
@@ -1,6 +1,6 @@
 from SpiffWorkflow.bpmn.specs.data_spec import DataObject as BpmnDataObject
 
 class DataObject(BpmnDataObject):
-    def __init__(self, category, *args, **kwargs):
+    def __init__(self, category=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.category = category


### PR DESCRIPTION
This hopefully fixes issues where a data object does not have a category.