### PR TITLE
update publish actions to use latest versions

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -7,11 +7,11 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install pypa/build
       run: >-
         python -m
@@ -27,7 +27,7 @@ jobs:
         --outdir dist/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         username: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
I copied these versions from the READMEs of the respective actions pages.  Not sure how to test.  Somebody should definitely review this.