### PR TITLE
clean up script engine methods

### DIFF
--- a/SpiffWorkflow/bpmn/script_engine/feel_engine.py
+++ b/SpiffWorkflow/bpmn/script_engine/feel_engine.py
@@ -32,11 +32,6 @@ def feelConvertTime(datestr,parsestr):
 
 class FeelInterval():
     def __init__(self, begin, end, leftOpen=False, rightOpen=False):
-        warnings.warn(
-            'The FEEL script engine is deprecated and will be removed in the next release',
-            DeprecationWarning,
-            stacklevel=2,
-        )
         # pesky thing with python floats and Decimal comparison
         if isinstance(begin,float):
             begin = Decimal("%0.5f"%begin)
@@ -274,6 +269,11 @@ class FeelLikeScriptEngine(PythonScriptEngine):
     expressions in a mini-language of your own.
     """
     def __init__(self, environment=None):
+        warnings.warn(
+            'The FEEL script engine is deprecated and will be removed in the next release',
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(environment=environment)
 
     def validate(self, expression):
@@ -294,17 +294,10 @@ class FeelLikeScriptEngine(PythonScriptEngine):
             proposed_python = lhs + proposed_python
         return proposed_python
 
-    def _evaluate(self, expression, context, task=None, external_context=None):
-        """
-        Evaluate the given expression, within the context of the given task and
-        return the result.
-        """
+    def evaluate(self, task, expression, external_context=None):
         if external_context is None:
             external_context = {}
-
-        revised = self.patch_expression(expression)
-        external_context.update(externalFuncs)
-        return super()._evaluate(revised, context, external_context=external_context)
+        return self._evaluate(expression, task.data, external_context=external_context) 
 
     def execute(self, task, script, data, external_context=None):
         """
@@ -313,8 +306,15 @@ class FeelLikeScriptEngine(PythonScriptEngine):
         if external_context is None:
             external_context = {}
         external_context.update(externalFuncs)
-        super().execute(task, script, external_context)
+        return super().execute(task, script, external_context)
 
-
-
-
+    def _evaluate(self, expression, context, task=None, external_context=None):
+        """
+        Evaluate the given expression, within the context of the given task and
+        return the result.
+        """
+        if external_context is None:
+            external_context = {}
+        external_context.update(externalFuncs)
+        revised = self.patch_expression(expression)
+        return self.environment.evaluate(revised, context, external_context=external_context)

--- a/SpiffWorkflow/bpmn/script_engine/python_environment.py
+++ b/SpiffWorkflow/bpmn/script_engine/python_environment.py
@@ -30,6 +30,9 @@ class BasePythonScriptEngineEnvironment:
     def execute(self, script, context, external_context=None):
         raise NotImplementedError("Subclass must implement this method")
 
+    def call_service(self, operation_name, operation_params, task_data):
+        raise NotImplementedError("To call external services override the script engine and implement `call_service`.")
+
 
 class TaskDataEnvironment(BasePythonScriptEngineEnvironment):
 

--- a/SpiffWorkflow/bpmn/specs/event_definitions/message.py
+++ b/SpiffWorkflow/bpmn/specs/event_definitions/message.py
@@ -59,7 +59,7 @@ class MessageEventDefinition(EventDefinition):
                 if key not in correlations:
                     correlations[key] = {}
                 try:
-                    correlations[key][property.name] = task.workflow.script_engine._evaluate(property.retrieval_expression, payload)
+                    correlations[key][property.name] = task.workflow.script_engine.environment.evaluate(property.retrieval_expression, payload)
                 except WorkflowException:
                     # Just ignore missing keys.  The dictionaries have to match exactly
                     pass

--- a/SpiffWorkflow/dmn/engine/DMNEngine.py
+++ b/SpiffWorkflow/dmn/engine/DMNEngine.py
@@ -122,8 +122,7 @@ class DMNEngine:
             external_context = {
                 'dmninputexpr': script_engine.evaluate(task, input_expr)
             }
-            return script_engine.evaluate(task, match_expr,
-                                          external_context=external_context)
+            return script_engine.evaluate(task, match_expr, external_context=external_context)
 
         # The input expression just has to be something that can be parsed as is by the engine.
         script_engine.validate(input_expr)

--- a/tests/SpiffWorkflow/dmn/feel_engine/FeelBoolDecisionTest.py
+++ b/tests/SpiffWorkflow/dmn/feel_engine/FeelBoolDecisionTest.py
@@ -23,9 +23,3 @@ class FeelBoolDecisionTestClass(unittest.TestCase):
     def test_bool_decision_string_output3(self):
         res = self.runner.decide(None)
         self.assertEqual(res.description, 'ELSE Row Annotation')
-
-def suite():
-    return unittest.TestLoader().loadTestsFromTestCase(FeelBoolDecisionTestClass)
-
-if __name__ == '__main__':
-    unittest.TextTestRunner(verbosity=2).run(suite())


### PR DESCRIPTION
This PR
- moves the implementation of the `call_service` method to the scripting environment (though the engine itself will retain the method with a deprecation warning through the next release)
- remove the `_execute` and `_evaluate`  methods in favor of just calling the environment directly.

This moves towards creating a clearer distinction between the how the script engine interacts with the workflow (which most people are likely to not need to extend) vs how exec and eval work (which people are likely to do), providing a unified extension mechanism (for most use cases).