### PR TITLE
Feature/performance improvements

### DIFF
--- a/SpiffWorkflow/bpmn/specs/control.py
+++ b/SpiffWorkflow/bpmn/specs/control.py
@@ -124,13 +124,10 @@ class StartEventJoin(Join, BpmnTaskSpec):
 class _EndJoin(UnstructuredJoin, BpmnTaskSpec):
 
     def _check_threshold_unstructured(self, my_task):
-        # Look at the tree to find all ready and waiting tasks (excluding
-        # ourself). The EndJoin waits for everyone!
-        for task in TaskIterator(my_task.workflow.task_tree, state=TaskState.READY|TaskState.WAITING, end_at_spec=self.name):
-            if task.task_spec == my_task.task_spec:
+        # Look at the tree to find all ready and waiting tasks (excluding ourself). The EndJoin waits for everyone!
+        for task in TaskIterator(my_task.workflow.task_tree, state=TaskState.NOT_FINISHED_MASK, end_at_spec=self.name):
+            if task == my_task:
                 continue
-            # This method returns waiting tasks so that they can be cancelled on cancelling joins
-            # This is not a cancelling join so we can omit building the list and return false as soon as we find any waiting task
             may_fire = False
             break
         else:

--- a/SpiffWorkflow/bpmn/specs/control.py
+++ b/SpiffWorkflow/bpmn/specs/control.py
@@ -135,8 +135,7 @@ class _EndJoin(UnstructuredJoin, BpmnTaskSpec):
             break
         else:
             may_fire = True
-
-        return may_fire, []
+        return may_fire
 
     def _run_hook(self, my_task):
         result = super(_EndJoin, self)._run_hook(my_task)

--- a/SpiffWorkflow/bpmn/specs/control.py
+++ b/SpiffWorkflow/bpmn/specs/control.py
@@ -126,7 +126,7 @@ class _EndJoin(UnstructuredJoin, BpmnTaskSpec):
     def _check_threshold_unstructured(self, my_task):
         # Look at the tree to find all ready and waiting tasks (excluding
         # ourself). The EndJoin waits for everyone!
-        for task in TaskIterator(my_task.workflow.task_tree, state=TaskState.READY|TaskState.WAITING):
+        for task in TaskIterator(my_task.workflow.task_tree, state=TaskState.READY|TaskState.WAITING, end_at_spec=self.name):
             if task.task_spec == my_task.task_spec:
                 continue
             # This method returns waiting tasks so that they can be cancelled on cancelling joins

--- a/SpiffWorkflow/bpmn/specs/mixins/parallel_gateway.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/parallel_gateway.py
@@ -45,7 +45,6 @@ class ParallelGateway(UnstructuredJoin):
 
         tasks = my_task.workflow.get_tasks(spec_name=self.name)
         # Look up which tasks have parents completed.
-        waiting_tasks = []
         waiting_inputs = set(self.inputs)
 
         def remove_ancestor(task):
@@ -61,8 +60,5 @@ class ParallelGateway(UnstructuredJoin):
             # Do not wait for descendants of this task
             elif task.is_descendant_of(my_task):
                 remove_ancestor(task)
-            # Ignore predicted tasks; we don't care about anything not definite
-            elif task.parent.has_state(TaskState.DEFINITE_MASK):
-                waiting_tasks.append(task.parent)
 
-        return len(waiting_inputs) == 0, waiting_tasks
+        return len(waiting_inputs) == 0

--- a/SpiffWorkflow/bpmn/specs/mixins/parallel_gateway.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/parallel_gateway.py
@@ -17,7 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301  USA
 
-from SpiffWorkflow.util.task import TaskState, TaskFilter
+from SpiffWorkflow.util.task import TaskState
 from .unstructured_join import UnstructuredJoin
 
 
@@ -41,9 +41,9 @@ class ParallelGateway(UnstructuredJoin):
     Essentially, this means that we must wait until we have a completed parent
     task on each incoming sequence.
     """
-    def _check_threshold_unstructured(self, my_task, force=False):
+    def _check_threshold_unstructured(self, my_task):
 
-        tasks = my_task.workflow.get_tasks(task_filter=TaskFilter(spec_name=self.name)) 
+        tasks = my_task.workflow.get_tasks(spec_name=self.name)
         # Look up which tasks have parents completed.
         waiting_tasks = []
         waiting_inputs = set(self.inputs)
@@ -65,4 +65,4 @@ class ParallelGateway(UnstructuredJoin):
             elif task.parent.has_state(TaskState.DEFINITE_MASK):
                 waiting_tasks.append(task.parent)
 
-        return force or len(waiting_inputs) == 0, waiting_tasks
+        return len(waiting_inputs) == 0, waiting_tasks

--- a/SpiffWorkflow/bpmn/specs/mixins/unstructured_join.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/unstructured_join.py
@@ -27,7 +27,7 @@ class UnstructuredJoin(Join):
     for the BPMN style threading
     """
     def _do_join(self, my_task):
-        split_task = self._get_split_task(my_task)
+        split_task = my_task.find_ancestor(self.split_task) or my_task.workflow.task_tree
 
         # Identify all corresponding task instances within the thread.
         # Also remember which of those instances was most recently changed,

--- a/SpiffWorkflow/bpmn/specs/mixins/unstructured_join.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/unstructured_join.py
@@ -63,3 +63,14 @@ class UnstructuredJoin(Join):
                 task._drop_children()
             else:
                 task.data.update(collected_data)
+
+    def _update_hook(self, my_task):
+
+        # Check whether enough incoming branches have completed.
+        my_task._inherit_data()
+        may_fire = self._check_threshold_unstructured(my_task)
+        if may_fire:
+            self._do_join(my_task)
+        elif not my_task.has_state(TaskState.FINISHED_MASK):
+            my_task._set_state(TaskState.WAITING)
+        return may_fire

--- a/SpiffWorkflow/bpmn/specs/mixins/unstructured_join.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/unstructured_join.py
@@ -37,9 +37,6 @@ class UnstructuredJoin(Join):
         last_changed = None
         thread_tasks = []
         for task in TaskIterator(split_task, spec_name=self.name):
-            if task.thread_id != my_task.thread_id:
-                # Ignore tasks from other threads.  (Do we need this condition?)
-                continue
             if not task.parent.has_state(TaskState.FINISHED_MASK):
                 # For an inclusive join, this can happen - it's a future join
                 continue

--- a/SpiffWorkflow/bpmn/util/task.py
+++ b/SpiffWorkflow/bpmn/util/task.py
@@ -54,12 +54,11 @@ class BpmnTaskIterator(TaskIterator):
         task = self.task_list.pop(0)
         subprocess = task.workflow.top_workflow.subprocesses.get(task.id)
 
-        if task.task_spec.name == self.end_at_spec:
-            self.task_list = []
-        elif all([
+        if all([
             len(task._children) > 0 or subprocess is not None,
             task.state >= self.min_state or subprocess is not None,
             self.depth < self.max_depth,
+            task.task_spec.name != self.end_at_spec,
         ]):
             if subprocess is None:
                 next_tasks = task.children

--- a/SpiffWorkflow/specs/Join.py
+++ b/SpiffWorkflow/specs/Join.py
@@ -156,7 +156,7 @@ class Join(TaskSpec):
         waiting_tasks = []
         completed = 0
         spec_names = [ts.name for ts in self.inputs]
-        for task in TaskIterator(my_task.workflow.task_tree):
+        for task in TaskIterator(my_task.workflow.task_tree, end_at_spec=self.name):
             if not task.task_spec.name in spec_names:
                 continue
             if task.parent is None or task.has_state(TaskState.COMPLETED):
@@ -204,8 +204,6 @@ class Join(TaskSpec):
         my_task._inherit_data()
         if my_task.has_state(TaskState.FINISHED_MASK):
             may_fire, waiting_tasks = False, []
-        elif my_task.has_state(TaskState.READY):
-            may_fire, waiting_tasks = True, []
         elif self.split_task is None:
             may_fire, waiting_tasks = self._check_threshold_unstructured(my_task)
         else:
@@ -228,7 +226,7 @@ class Join(TaskSpec):
         split_task = self._get_split_task(my_task) or my_task.workflow.task_tree
         # Identify all corresponding task instances within the thread.
         thread_tasks = []
-        for task in TaskIterator(split_task, spec_name=self.name):
+        for task in TaskIterator(split_task, spec_name=self.name, end_at_spec=self.name):
             # Ignore tasks from other threads.
             if task.thread_id != my_task.thread_id:
                 continue

--- a/SpiffWorkflow/specs/ThreadMerge.py
+++ b/SpiffWorkflow/specs/ThreadMerge.py
@@ -112,8 +112,7 @@ class ThreadMerge(Join):
             if self.split_task and task.is_descendant_of(my_task):
                 continue
             changed = task.parent.last_state_change
-            if last_changed is None \
-                    or changed > last_changed.parent.last_state_change:
+            if last_changed is None or changed > last_changed.parent.last_state_change:
                 last_changed = task
             tasks.append(task)
 

--- a/SpiffWorkflow/util/task.py
+++ b/SpiffWorkflow/util/task.py
@@ -218,13 +218,11 @@ class TaskIterator:
             raise StopIteration()
 
         task = self.task_list.pop(0)
-
-        if task.task_spec.name == self.end_at_spec:
-            self.task_list = []
-        elif all([
+        if all([
             len(task._children) > 0,
             task.state >= self.min_state,
             self.depth < self.max_depth,
+            task.task_spec.name != self.end_at_spec,
         ]):
             if self.depth_first:
                 self.task_list = task.children + self.task_list

--- a/tests/SpiffWorkflow/bpmn/CollaborationTest.py
+++ b/tests/SpiffWorkflow/bpmn/CollaborationTest.py
@@ -35,7 +35,7 @@ class CollaborationTest(BpmnWorkflowTestCase):
         buddy = self.workflow.get_next_task(spec_name='process_buddy')
         self.assertIsInstance(buddy.task_spec, CallActivityMixin)
         self.assertEqual(buddy.task_spec.spec, 'process_buddy')
-        self.assertEqual(buddy.state, TaskState.WAITING)
+        self.assertEqual(buddy.state, TaskState.STARTED)
 
     def testBpmnMessage(self):
 

--- a/tests/SpiffWorkflow/bpmn/IOSpecTest.py
+++ b/tests/SpiffWorkflow/bpmn/IOSpecTest.py
@@ -61,9 +61,8 @@ class CallActivityDataTest(BpmnWorkflowTestCase):
         self.assertNotIn('unused', task.data)
 
         self.complete_subprocess()
-        # Refreshing causes the subprocess to become ready
-        self.workflow.refresh_waiting_tasks()
-        task = self.workflow.get_next_task(state=TaskState.READY)
+        # This is the subprocess
+        task = self.workflow.get_next_task(spec_name='Activity_1wdjypm')
         # Originals should not change
         self.assertEqual(task.data['in_1'], 1)
         self.assertEqual(task.data['in_2'], "hello world")
@@ -74,11 +73,11 @@ class CallActivityDataTest(BpmnWorkflowTestCase):
 
     def advance_to_subprocess(self):
         # Once we enter the subworkflow it becomes a waiting task
-        waiting = self.workflow.get_tasks(state=TaskState.WAITING)
-        while len(waiting) == 0:
+        started = self.workflow.get_tasks(state=TaskState.STARTED)
+        while len(started) == 0:
             next_task = self.workflow.get_next_task(state=TaskState.READY)
             next_task.run()
-            waiting = self.workflow.get_tasks(state=TaskState.WAITING)
+            started = self.workflow.get_tasks(state=TaskState.STARTED)
 
     def complete_subprocess(self):
         # Complete the ready tasks in the subprocess

--- a/tests/SpiffWorkflow/bpmn/NestedProcessesTest.py
+++ b/tests/SpiffWorkflow/bpmn/NestedProcessesTest.py
@@ -68,7 +68,7 @@ class NestedProcessesTest(BpmnWorkflowTestCase):
 
         self.workflow.do_engine_steps()
         self.assertEqual(len(self.workflow.subprocesses), 1)
-        self.assertEqual(task.state, TaskState.WAITING)
+        self.assertEqual(task.state, TaskState.STARTED)
         self.complete_task('Action2', True)
         self.complete_task('Action3', True)
         self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/events/ActionManagementTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/ActionManagementTest.py
@@ -40,7 +40,8 @@ class ActionManagementTest(BpmnWorkflowTestCase):
         time.sleep(self.START_TIME_DELTA)
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
         self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.READY)))
 
         self.do_next_named_step("Start Work")
@@ -62,18 +63,21 @@ class ActionManagementTest(BpmnWorkflowTestCase):
         time.sleep(self.START_TIME_DELTA)
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
         self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.READY)))
 
         self.do_next_named_step("Start Work")
         self.workflow.do_engine_steps()
 
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
-        self.assertEqual('Finish Time', self.workflow.get_tasks(state=TaskState.WAITING)[1].task_spec.bpmn_name)
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual('Finish Time', self.workflow.get_next_task(state=TaskState.WAITING).task_spec.bpmn_name)
         time.sleep(self.FINISH_TIME_DELTA)
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
-        self.assertEqual(3, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
         self.assertNotEqual('Finish Time', self.workflow.get_tasks(state=TaskState.WAITING)[0].task_spec.bpmn_name)
 
         overdue_escalation_task = [
@@ -109,10 +113,12 @@ class ActionManagementTest(BpmnWorkflowTestCase):
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
+
         time.sleep(self.START_TIME_DELTA)
         self.workflow.refresh_waiting_tasks()
         self.workflow.do_engine_steps()
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
         self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.READY)))
 
         self.do_next_named_step("Start Work")

--- a/tests/SpiffWorkflow/bpmn/events/MessageInterruptsSpTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageInterruptsSpTest.py
@@ -24,7 +24,8 @@ class MessageInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.do_next_exclusive_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
@@ -35,7 +36,7 @@ class MessageInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughInterruptSaveAndRestore(self):
 
@@ -46,7 +47,8 @@ class MessageInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
         self.workflow.do_engine_steps()
@@ -57,4 +59,4 @@ class MessageInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/events/MessageInterruptsTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageInterruptsTest.py
@@ -24,7 +24,8 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.do_next_exclusive_step('Do Something That Takes A Long Time')
         self.save_restore()
@@ -35,7 +36,7 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughMessageInterruptSaveAndRestore(self):
 
@@ -46,14 +47,15 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
         self.save_restore()
 
         self.workflow.do_engine_steps()
         self.save_restore()
-        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
 
         self.do_next_exclusive_step('Acknowledge Interrupt Message')
@@ -61,7 +63,7 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
 
         self.workflow.do_engine_steps()
         self.save_restore()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughHappy(self):
 
@@ -70,7 +72,8 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.do_next_exclusive_step('Do Something That Takes A Long Time')
 
@@ -78,7 +81,7 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughMessageInterrupt(self):
 
@@ -87,15 +90,16 @@ class MessageInterruptsTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
 
         self.workflow.do_engine_steps()
-        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
 
         self.do_next_exclusive_step('Acknowledge Interrupt Message')
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptTest.py
@@ -24,7 +24,8 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.do_next_exclusive_step('Do Something That Takes A Long Time')
         self.save_restore()
@@ -35,7 +36,7 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughMessageInterruptSaveAndRestore(self):
 
@@ -46,13 +47,15 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
         self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.READY)))
 
         self.do_next_named_step('Acknowledge Non-Interrupt Message')
@@ -68,7 +71,7 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughHappy(self):
 
@@ -77,7 +80,8 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.do_next_exclusive_step('Do Something That Takes A Long Time')
 
@@ -85,7 +89,7 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughMessageInterrupt(self):
 
@@ -94,24 +98,27 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
 
         self.workflow.do_engine_steps()
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
         self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.READY)))
 
         self.do_next_named_step('Acknowledge Non-Interrupt Message')
 
         self.workflow.do_engine_steps()
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(3, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.do_next_named_step('Do Something That Takes A Long Time')
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughMessageInterruptOtherOrder(self):
 
@@ -120,12 +127,14 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.workflow.do_engine_steps()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
 
         self.workflow.do_engine_steps()
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
         self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.READY)))
 
         self.do_next_named_step('Do Something That Takes A Long Time')
@@ -136,7 +145,7 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.do_next_named_step('Acknowledge Non-Interrupt Message')
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughMessageInterruptOtherOrderSaveAndRestore(self):
 
@@ -148,13 +157,15 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
         self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.READY)))
 
         self.do_next_named_step('Do Something That Takes A Long Time')
@@ -167,4 +178,4 @@ class MessageNonInterruptTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptsSpTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessageNonInterruptsSpTest.py
@@ -24,7 +24,8 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.do_next_exclusive_step('Do Something In a Subprocess')
         self.workflow.do_engine_steps()
@@ -35,7 +36,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughMessageSaveAndRestore(self):
 
@@ -46,7 +47,8 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
 
@@ -63,7 +65,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughMessageOrder2SaveAndRestore(self):
 
@@ -74,7 +76,8 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
         self.do_next_named_step('Do Something In a Subprocess')
@@ -90,7 +93,7 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughMessageOrder3SaveAndRestore(self):
 
@@ -101,7 +104,8 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.READY)))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
 
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
 
@@ -118,4 +122,4 @@ class MessageNonInterruptsSpTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/events/MessagesTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/MessagesTest.py
@@ -21,7 +21,8 @@ class MessagesTest(BpmnWorkflowTestCase):
         self.do_next_exclusive_step('Select Test', choice='Messages')
         self.workflow.do_engine_steps()
         self.assertEqual([], self.workflow.get_tasks(state=TaskState.READY))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Wrong Message'), {}))
         self.assertEqual([], self.workflow.get_tasks(state=TaskState.READY))
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
@@ -30,7 +31,7 @@ class MessagesTest(BpmnWorkflowTestCase):
         self.assertEqual('Test Message', self.workflow.get_tasks(state=TaskState.READY)[0].task_spec.bpmn_name)
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())
 
     def testRunThroughSaveAndRestore(self):
 
@@ -41,7 +42,8 @@ class MessagesTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.assertEqual([], self.workflow.get_tasks(state=TaskState.READY))
-        self.assertEqual(2, len(self.workflow.get_tasks(state=TaskState.WAITING)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.STARTED)))
+        self.assertEqual(1, len(self.workflow.get_tasks(state=TaskState.WAITING)))
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Wrong Message'), {}))
         self.assertEqual([], self.workflow.get_tasks(state=TaskState.READY))
         self.workflow.catch(BpmnEvent(MessageEventDefinition('Test Message'), {}))
@@ -50,4 +52,4 @@ class MessagesTest(BpmnWorkflowTestCase):
         self.save_restore()
 
         self.workflow.do_engine_steps()
-        self.assertEqual(0, len(self.workflow.get_tasks(state=TaskState.READY|TaskState.WAITING)))
+        self.assertTrue(self.workflow.is_completed())

--- a/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/TimerDurationBoundaryTest.py
@@ -22,13 +22,13 @@ class TimerDurationTest(BpmnWorkflowTestCase):
 
     def actual_test(self,save_restore = False):
         self.workflow.do_engine_steps()
-        ready_tasks = self.workflow.get_tasks(state=TaskState.READY)
-        ready_tasks[0].run()
+        ready_tasks = self.workflow.get_next_task(state=TaskState.READY)
+        ready_tasks.run()
         self.workflow.do_engine_steps()
 
         loopcount = 0
         # test bpmn has a timeout of .03s; we should terminate loop before that.
-        while len(self.workflow.get_tasks(state=TaskState.WAITING)) == 2 and loopcount < 11:
+        while len(self.workflow.get_tasks(state=TaskState.WAITING)) == 1 and loopcount < 11:
             if save_restore:
                 self.save_restore()
             time.sleep(0.01)

--- a/tests/SpiffWorkflow/camunda/CallActivityMessageTest.py
+++ b/tests/SpiffWorkflow/camunda/CallActivityMessageTest.py
@@ -30,9 +30,9 @@ class CallActivityMessageTest(BaseTestCase):
 
         self.workflow.do_engine_steps()
         ready_tasks = self.workflow.get_tasks(state=TaskState.READY)
-        waiting_tasks = self.workflow.get_tasks(state=TaskState.WAITING)
+        started_tasks = self.workflow.get_tasks(state=TaskState.STARTED)
         self.assertEqual(1, len(ready_tasks),'Expected to have one ready task')
-        self.assertEqual(2, len(waiting_tasks), 'Expected to have two waiting tasks')
+        self.assertEqual(2, len(started_tasks), 'Expected to have two started tasks')
 
         for step in steps:
             current_task = ready_tasks[0]

--- a/tests/SpiffWorkflow/core/IteratorTest.py
+++ b/tests/SpiffWorkflow/core/IteratorTest.py
@@ -43,7 +43,7 @@ class DepthFirstTest(IterationTest):
         tasks = self.workflow.get_tasks(end_at_spec='c')
         self.assertEqual(
             [t.task_spec.name for t in tasks],
-            ['Start', 'a', 'a1', 'last', 'End', 'a2', 'last', 'End', 'c']
+            ['Start', 'a', 'a1', 'last', 'End', 'a2', 'last', 'End', 'c', 'b', 'b1', 'last', 'End', 'b2', 'last', 'End']
         )
 
     def test_get_tasks_max_depth(self):
@@ -67,7 +67,7 @@ class BreadthFirstTest(IterationTest):
         tasks = self.workflow.get_tasks(end_at_spec='c', depth_first=False)
         self.assertEqual(
             [t.task_spec.name for t in tasks],
-            ['Start', 'a', 'b', 'a1', 'a2', 'c']
+            ['Start', 'a', 'b', 'a1', 'a2', 'c', 'b1', 'b2', 'last', 'last', 'last', 'last', 'End', 'End', 'End', 'End']
         )
 
     def test_get_tasks_max_depth(self):


### PR DESCRIPTION
This PR
- makes some improvements to the BPMN task iterator (namely not descending into completed subprocesses to look for unfinished tasks)
- changes the behavior of the `end_at_spec` argument to `get_tasks` such that it checks all branches rather than stopping at the first instance
- transitions subworkflow tasks to `STARTED` instead of `WAITING` while they are running to prevent repeatedly checking whether they have finished
- improves the readability of the code in `Join` task spec of the core spec module
- completely reimplements how joins are handled in the BPMN module

The impetus for these improvements were workflow getting bogged down when large numbers of branches are active at once.  The main bottleneck turned out to be repeatedly updating waiting joins.  When a merge point is reached on any branch, the task transitions to waiting until enough branches complete.  Every time any task completes, all waiting tasks in workflow are re-checked to see if they've become runnable.

So what I've done is maintain only the most recently completed task in a waiting state and preemptively cancelled the others incrementally rather than cancelling all but one when the gateway threshold is finally reached.  This is where the bulk of the improvment comes from.  But not constantly updating waiting subprocesses also helps.

Additionally, checking whether the subprocess is finished involves finding the subprocess, so that should alleviate some runtime errors regarding the size of the dictionary where they're maintained changing as well.

In one example, processing time went from 11 seconds to 5 seconds. We are seeing huge improvements for some processes.