### PR TITLE
ensure parser knows about all namepsaces

### DIFF
--- a/SpiffWorkflow/bpmn/parser/node_parser.py
+++ b/SpiffWorkflow/bpmn/parser/node_parser.py
@@ -56,12 +56,12 @@ class NodeParser:
     def get_description(self):
         return self.process_parser.parser.spec_descriptions.get(self.node.tag)
 
-    def xpath(self, xpath, extra_ns=None):
-        return self._xpath(self.node, xpath, extra_ns)
+    def xpath(self, xpath):
+        return self._xpath(self.node, xpath)
 
-    def doc_xpath(self, xpath, extra_ns=None):
+    def doc_xpath(self, xpath):
         root = self.node.getroottree().getroot()
-        return self._xpath(root, xpath, extra_ns)
+        return self._xpath(root, xpath)
 
     def attribute(self, attribute, namespace=None, node=None):
         if node is None:
@@ -156,13 +156,8 @@ class NodeParser:
         if noderef is not None:
             return noderef.getparent().get('name')
 
-    def _xpath(self, node, xpath, extra_ns=None):
-        if extra_ns is not None:
-            nsmap = self.nsmap.copy()
-            nsmap.update(extra_ns)
-        else:
-            nsmap = self.nsmap
-        return node.xpath(xpath, namespaces=nsmap)
+    def _xpath(self, node, xpath):
+        return node.xpath(xpath, namespaces=self.nsmap)
 
     def raise_validation_exception(self, message):
         raise ValidationException(message, self.node, self.filename)

--- a/tests/SpiffWorkflow/dmn/DecisionRunner.py
+++ b/tests/SpiffWorkflow/dmn/DecisionRunner.py
@@ -3,7 +3,8 @@ import os
 from lxml import etree
 
 from SpiffWorkflow.dmn.engine.DMNEngine import DMNEngine
-from SpiffWorkflow.dmn.parser.DMNParser import DMNParser, get_dmn_ns
+from SpiffWorkflow.dmn.parser.DMNParser import DMNParser
+from SpiffWorkflow.bpmn.parser.node_parser import DEFAULT_NSMAP
 
 class WorkflowSpec:
     def __init__(self):
@@ -38,7 +39,12 @@ class DecisionRunner:
         with open(fn) as fh:
             node = etree.parse(fh)
 
-        self.dmnParser = DMNParser(None, node.getroot(), get_dmn_ns(node.getroot()))
+        nsmap = DEFAULT_NSMAP.copy()
+        nsmap.update(node.getroot().nsmap)
+        if None in nsmap:
+            nsmap['dmn'] = nsmap.pop(None)
+
+        self.dmnParser = DMNParser(None, node.getroot(), nsmap)
         self.dmnParser.parse()
 
         decision = self.dmnParser.decision

--- a/tests/SpiffWorkflow/dmn/VersionTest.py
+++ b/tests/SpiffWorkflow/dmn/VersionTest.py
@@ -9,6 +9,7 @@ class DmnVersionTest(unittest.TestCase):
 
     def setUp(self):
         self.parser = BpmnDmnParser()
+        self.parser.namespaces.update({'dmn': 'https://www.omg.org/spec/DMN/20191111/MODEL/'})
 
     def test_load_v1_0(self):
         filename = os.path.join(data_dir, 'dmn_version_20151101_test.dmn')


### PR DESCRIPTION
This makes namespaces more consistent in the DMN parser. It should resolve the issue is spiff arena where dMN input expressions were not being parsed.