### PR TITLE
rename events & run in hook functions

### DIFF
--- a/SpiffWorkflow/specs/AcquireMutex.py
+++ b/SpiffWorkflow/specs/AcquireMutex.py
@@ -52,7 +52,7 @@ class AcquireMutex(TaskSpec):
         super()._update_hook(my_task)
         mutex = my_task.workflow._get_mutex(self.mutex)
         if mutex.testandset():
-            self.entered_event.emit(my_task.workflow, my_task)
+            self.update_event.emit(my_task.workflow, my_task)
             return True
         else:
             my_task._set_state(TaskState.WAITING)

--- a/SpiffWorkflow/specs/ThreadMerge.py
+++ b/SpiffWorkflow/specs/ThreadMerge.py
@@ -120,7 +120,7 @@ class ThreadMerge(Join):
         # completed, except for the first one, which should be READY.
         for task in tasks:
             if task == last_changed:
-                self.entered_event.emit(my_task.workflow, my_task)
+                self.update_event.emit(my_task.workflow, my_task)
                 task._ready()
             else:
                 task._set_state(TaskState.COMPLETED)

--- a/tests/SpiffWorkflow/bpmn/events/CallActivityEscalationTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/CallActivityEscalationTest.py
@@ -8,7 +8,7 @@ from ..BpmnWorkflowTestCase import BpmnWorkflowTestCase
 __author__ = 'kbogus@gmail.com'
 
 
-def on_reached_cb(workflow, task, completed_set):
+def on_ready_cb(workflow, task, completed_set):
     # In workflows that load a subworkflow, the newly loaded children
     # will not have on_reached_cb() assigned. By using this function, we
     # re-assign the function in every step, thus making sure that new
@@ -24,9 +24,9 @@ def on_complete_cb(workflow, task, completed_set):
 
 
 def track_task(task_spec, completed_set):
-    if task_spec.reached_event.is_connected(on_reached_cb):
-        task_spec.reached_event.disconnect(on_reached_cb)
-    task_spec.reached_event.connect(on_reached_cb, completed_set)
+    if task_spec.ready_event.is_connected(on_ready_cb):
+        task_spec.ready_event.disconnect(on_ready_cb)
+    task_spec.ready_event.connect(on_ready_cb, completed_set)
     if task_spec.completed_event.is_connected(on_complete_cb):
         task_spec.completed_event.disconnect(on_complete_cb)
     task_spec.completed_event.connect(on_complete_cb, completed_set)


### PR DESCRIPTION
This PR adds an optional callback when a task transitions to an error state and aligns the existing callbacks with task states.  It also moves execution into the hook functions where applicable.  `entereted_event` was renamed to `update_event`, `finished_event` was changed to `run_event` and `reached_event` was removed`.  The current set of callbacks are

- `update_event` (emitted in `_update_hook`)
- `ready_event` (emitted in `_on_ready_hook`)
- `completed_event` (emitted in `_on_complete_hook` on successful completion)
- `error_event` (emitted in `_on_error_hook` on unsuccessful completion)
- `run_event` (emitted in `_run_hook` whenever a task is run regardless of result)
- `cancelled_event` (called in `_on_cancel`)