### PR TITLE
omit default on inclusive gw with matched conditions

### DIFF
--- a/SpiffWorkflow/bpmn/specs/mixins/inclusive_gateway.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/inclusive_gateway.py
@@ -119,8 +119,8 @@ class InclusiveGateway(MultiChoice, UnstructuredJoin):
         return complete
 
     def _run_hook(self, my_task):
-        outputs = self._get_matching_outputs(my_task)
-        if len(outputs) == 0:
+        matches, defaults = self._get_matching_outputs(my_task)
+        if len(matches + defaults) == 0:
             raise WorkflowTaskException('No conditions satisfied on gateway', task=my_task)
-        my_task._sync_children(outputs, TaskState.FUTURE)
+        my_task._sync_children(matches or defaults, TaskState.FUTURE)
         return True

--- a/tests/SpiffWorkflow/bpmn/InclusiveGatewayTest.py
+++ b/tests/SpiffWorkflow/bpmn/InclusiveGatewayTest.py
@@ -32,6 +32,11 @@ class InclusiveGatewayTest(BpmnWorkflowTestCase):
 
     def testParallelCondition(self):
         self.set_data({'v': 0, 'u': 1, 'w': 1})
+        gw = self.workflow.get_next_task(state=TaskState.READY)
+        gw.run()
+        self.assertIsNone(self.workflow.get_next_task(spec_name='increment_v'))
+        self.assertTrue(self.workflow.get_next_task(spec_name='u_plus_v').state, TaskState.READY)
+        self.assertTrue(self.workflow.get_next_task(spec_name='w_plus_v').state, TaskState.READY)
         self.workflow.do_engine_steps()
         self.assertTrue(self.workflow.is_completed())
         self.assertDictEqual(self.workflow.data, {'v': 0, 'u': 1, 'w': 1})


### PR DESCRIPTION
BPMN multichoice (inclusive gateway splits) don't work the same way as core module multichoice tasks.  This separates outputs by matched condition vs default condition so that the behavior can be overridden.