### PR TITLE
add spec and workflow diff utils

### DIFF
--- a/SpiffWorkflow/bpmn/util/diff.py
+++ b/SpiffWorkflow/bpmn/util/diff.py
@@ -1,0 +1,141 @@
+from .task import BpmnTaskFilter
+
+class SpecDiff:
+
+    def __init__(self, serializer, original, new):
+        """This class is used to hold results for comparisions between two workflow specs.
+
+        Attributes:
+            registry: a serializer's registry
+            unmatched (list(`TaskSpec`)): a list of task specs that cannot be aligned
+            alignment (dict): a mapping of old task spec to new
+            updated (dict): a mapping of old task spec to changed attributes
+
+        The chief basis for alignment is `TaskSpec.name` (ie, the BPMN ID of the spec): if the IDs are identical,
+        it is assumed the task specs correspond.  If a spec in the old version does not have an ID in the new,
+        some attempt to match based on inputs and outputs is made.
+
+        The general procdedure is to attempt to align as many tasks based on ID as possible first, and then
+        attempt to match by other means while backing out of the traversal.
+
+        Updates are organized primarily by the specs from the original version.
+        """
+
+        self.registry = serializer.registry
+        self.unmatched = [spec for spec in new.task_specs.values() if spec.name not in original.task_specs]
+        self.alignment = {}
+        self.updated = {}
+        self._align(original.start, new)
+
+    @property
+    def added(self):
+        """Task specs from the new version that did not exist in the old"""
+        return self.unmatched
+
+    @property
+    def removed(self):
+        """Task specs from the old version that were removed from the new"""
+        return [orig for orig, new in self.alignment.items() if new is None]
+
+    @property
+    def changed(self):
+        """Task specs with updated attributes"""
+        return dict((ts, changes) for ts, changes in self.updated.items() if changes)
+
+    def _align(self, spec, new):
+
+        candidate = new.task_specs.get(spec.name)
+        self.alignment[spec] = candidate
+        if candidate is not None:
+            self.updated[spec] = self._compare_task_specs(spec, candidate)
+
+        # Traverse the spec, prioritizing matching by name
+        # Without this starting point, alignment would be way too difficult
+        for output in spec.outputs:
+            if output not in self.alignment:
+                self._align(output, new)
+
+        # If name matching fails, attempt to align by structure
+        if candidate is None:
+            self._search_unmatched(spec)
+
+    def _search_unmatched(self, spec):
+        # If any outputs were matched, we can use its unmatched inputs as candidates
+        for match in self._substitutions(spec.outputs):
+            for parent in [ts for ts in match.inputs if ts in self.unmatched]:
+                if self._aligned(spec.outputs, parent.outputs):
+                    path = [parent]     # We may need to check ancestor inputs as well as this spec's inputs
+                    searched = []       # We have to keep track of what we've looked at in case of loops
+                    self._find_ancestor(spec, path, searched)
+
+    def _find_ancestor(self, spec, path, searched):
+        if path[-1] not in searched:
+            searched.append(path[-1])
+        # Stop if we reach a previously matched spec or if an ancestor's inputs match
+        if path[-1] not in self.unmatched or self._aligned(spec.inputs, path[-1].inputs):
+            self.alignment[spec] = path[0]
+            self.unmatched.remove(path[0])
+        else:
+            for parent in [ts for ts in path[-1].inputs if ts not in searched]:
+                self._find_ancestor(spec, path + [parent], searched)
+
+    def _substitutions(self, spec_list, skip_unaligned=True):
+        subs = [self.alignment[ts] for ts in spec_list]
+        return [ts for ts in subs if ts is not None] if skip_unaligned else subs
+
+    def _aligned(self, original, candidates):
+        subs = self._substitutions(original, skip_unaligned=False)
+        return len(subs) == len(candidates) and \
+            all(first is not None and first.name == second.name for first, second in zip(subs, candidates))
+
+    def _compare_task_specs(self, spec, candidate):
+        s1 = self.registry.convert(spec)
+        s2 = self.registry.convert(candidate)
+        if s1.get('typename') != s2.get('typename'):
+            return ['typename']
+        else:
+            return [key for key, value in s1.items() if s2.get(key) != value]
+
+class WorkflowDiff:
+    """This class is used to determine which tasks in a workflow are affected by updates
+    to its WorkflowSpec.
+
+    Attributes
+        workflow (`BpmnWorkflow`): a workflow instance
+        spec_diff (`SpecDiff`): the results of a comparision of two specs
+        removed (list(`Task`)): a list of tasks whose specs do not exist in the new version
+        changed (list(`Task`)): a list of tasks with aligned specs where attributes have changed
+        alignment (dict): a mapping of old task spec to new task spec
+    """
+
+    def __init__(self, workflow, spec_diff):
+        self.workflow = workflow
+        self.spec_diff = spec_diff
+        self.removed = []
+        self.changed = []
+        self.alignment = {}
+        self._align()
+
+    def filter_tasks(self, tasks, **kwargs):
+        """Applies task filtering arguments to a list of tasks.
+
+        Args:
+            tasks (list(`Task`)): a list of of tasks
+
+        Keyword Args:
+            any keyword arg that may be passed to `BpmnTaskFilter`
+
+        Returns:
+            a list containing tasks matching the filter
+        """
+        task_filter = BpmnTaskFilter(**kwargs)
+        return [t for t in tasks if task_filter.matches(t)]
+
+    def _align(self):
+        for task in self.workflow.get_tasks(skip_subprocesses=True):
+            if task.task_spec in self.spec_diff.changed:
+                self.changed.append(task)
+            if task.task_spec in self.spec_diff.removed:
+                self.removed.append(task)
+            else:
+                self.alignment[task] = self.spec_diff.alignment[task.task_spec]

--- a/tests/SpiffWorkflow/bpmn/DiffUtilTest.py
+++ b/tests/SpiffWorkflow/bpmn/DiffUtilTest.py
@@ -1,0 +1,125 @@
+from SpiffWorkflow import TaskState
+from SpiffWorkflow.bpmn import BpmnWorkflow
+from SpiffWorkflow.bpmn.util.diff import SpecDiff, WorkflowDiff
+
+from .BpmnWorkflowTestCase import BpmnWorkflowTestCase
+
+class CompareSpecTest(BpmnWorkflowTestCase):
+
+    def test_tasks_added(self):
+        v1_spec, v1_sp_specs = self.load_workflow_spec('diff/v1.bpmn', 'Process')
+        v2_spec, v2_sp_specs = self.load_workflow_spec('diff/v2.bpmn', 'Process')
+        result = SpecDiff(self.serializer, v1_spec, v2_spec)
+        self.assertEqual(len(result.added), 3)
+        self.assertIn(v2_spec.task_specs.get('Gateway_1618q26'), result.added)
+        self.assertIn(v2_spec.task_specs.get('Activity_1ds7clb'), result.added)
+        self.assertIn(v2_spec.task_specs.get('Event_0tatpgq'), result.added)
+
+    def test_tasks_removed(self):
+        v1_spec, v1_sp_specs = self.load_workflow_spec('diff/v1.bpmn', 'Process')
+        v2_spec, v2_sp_specs = self.load_workflow_spec('diff/v2.bpmn', 'Process')
+        result = SpecDiff(self.serializer, v2_spec, v1_spec)
+        self.assertEqual(len(result.removed), 3)
+        self.assertIn(v2_spec.task_specs.get('Gateway_1618q26'), result.removed)
+        self.assertIn(v2_spec.task_specs.get('Activity_1ds7clb'), result.removed)
+        self.assertIn(v2_spec.task_specs.get('Event_0tatpgq'), result.removed)
+
+    def test_tasks_changed(self):
+        v2_spec, v2_sp_specs = self.load_workflow_spec('diff/v2.bpmn', 'Process')
+        v3_spec, v3_sp_specs = self.load_workflow_spec('diff/v3.bpmn', 'Process')
+        result = SpecDiff(self.serializer, v2_spec, v3_spec)
+        # The deafult output was changed and a the conditional output was converted to a subprocess
+        self.assertListEqual(
+            result.changed.get(v2_spec.task_specs.get('Gateway_1618q26')),
+            ['outputs', 'cond_task_specs', 'default_task_spec']
+        )
+        # The generic task was changed to a subprocess
+        self.assertListEqual(
+            result.changed.get(v2_spec.task_specs.get('Activity_1ds7clb')),
+            ['typename']
+        )
+
+    def test_alignment(self):
+        v2_spec, v2_sp_specs = self.load_workflow_spec('diff/v2.bpmn', 'Process')
+        v3_spec, v3_sp_specs = self.load_workflow_spec('diff/v3.bpmn', 'Process')
+        result = SpecDiff(self.serializer, v2_spec, v3_spec)
+        old_end_event = v2_spec.task_specs.get('Event_0rilo47')
+        new_end_event = v3_spec.task_specs.get('Event_18osyv3')
+        self.assertEqual(result.alignment[old_end_event], new_end_event)
+        for old, new in result.alignment.items():
+            if old is not old_end_event:
+                self.assertEqual(old.name, new.name)
+
+    def test_multiple(self):
+        v4_spec, v4_sp_specs = self.load_workflow_spec('diff/v4.bpmn', 'Process')
+        v5_spec, v5_sp_specs = self.load_workflow_spec('diff/v5.bpmn', 'Process')
+        result = SpecDiff(self.serializer, v4_spec, v5_spec)
+        self.assertEqual(len(result.removed), 4)
+        self.assertEqual(len(result.changed), 4)
+        self.assertIn(v4_spec.task_specs.get('Gateway_0z1qhgl'), result.removed)
+        self.assertIn(v4_spec.task_specs.get('Gateway_1acqedb'), result.removed)
+        self.assertIn(v4_spec.task_specs.get('Activity_1lmz1t0'), result.removed)
+        self.assertIn(v4_spec.task_specs.get('Activity_11gnihu'), result.removed)
+        self.assertListEqual(
+            result.changed.get(v4_spec.task_specs.get('Gateway_1618q26')),
+            ['outputs', 'cond_task_specs', 'default_task_spec']
+        )
+        self.assertListEqual(
+            result.changed.get(v4_spec.task_specs.get('Gateway_0p4fq77')),
+            ['inputs']
+        )
+        self.assertListEqual(
+            result.changed.get(v4_spec.task_specs.get('Activity_1ds7clb')),
+            ['typename']
+        )
+
+class CompareWorkflowTest(BpmnWorkflowTestCase):
+
+    def test_changed(self):
+        v3_spec, v3_sp_specs = self.load_workflow_spec('diff/v3.bpmn', 'Process')
+        v4_spec, v4_sp_specs = self.load_workflow_spec('diff/v4.bpmn', 'Process')
+        spec_diff = SpecDiff(self.serializer, v3_spec, v4_spec)
+        sp_spec_diff = SpecDiff(
+            self.serializer,
+            v3_sp_specs['Activity_1ds7clb'],
+            v4_sp_specs['Activity_1ds7clb']
+        )
+        workflow = BpmnWorkflow(v3_spec, v3_sp_specs)
+        task = workflow.get_next_task(state=TaskState.READY, manual=False)
+        while task is not None:
+            task.run()
+            task = workflow.get_next_task(state=TaskState.READY, manual=False)
+        wf_diff = WorkflowDiff(workflow, spec_diff)
+        self.assertEqual(len(wf_diff.changed), 2)
+        self.assertIn(workflow.get_next_task(spec_name='Activity_0b53566'), wf_diff.changed)
+        self.assertIn(workflow.get_next_task(spec_name='Gateway_1618q26'), wf_diff.changed)
+        sp = workflow.get_subprocess(workflow.get_next_task(spec_name='Activity_1ds7clb'))
+        sp_diff = WorkflowDiff(sp, sp_spec_diff)
+        self.assertEqual(len(sp_diff.changed), 2)
+        self.assertIn(workflow.get_next_task(spec_name='Activity_0uijumg'), sp_diff.changed)
+        self.assertIn(workflow.get_next_task(spec_name='Event_1wlwaz1'), sp_diff.changed)
+
+    def test_removed(self):
+        v4_spec, v4_sp_specs = self.load_workflow_spec('diff/v4.bpmn', 'Process')
+        v5_spec, v5_sp_specs = self.load_workflow_spec('diff/v5.bpmn', 'Process')
+        spec_diff = SpecDiff(self.serializer, v4_spec, v5_spec)
+        sp_spec_diff = SpecDiff(
+            self.serializer,
+            v4_sp_specs['Activity_1ds7clb'],
+            v5_sp_specs['Activity_1ds7clb']
+        )
+        workflow = BpmnWorkflow(v4_spec, v4_sp_specs)
+        task = workflow.get_next_task(state=TaskState.READY)
+        while task is not None:
+            if task.task_spec.name != 'Activity_16ggmbf':
+                task.run()
+            else:
+                break
+            task = workflow.get_next_task(state=TaskState.READY)
+        wf_diff = WorkflowDiff(workflow, spec_diff)
+        self.assertEqual(len(wf_diff.removed), 5)
+        self.assertIn(workflow.get_next_task(spec_name='Gateway_0z1qhgl'), wf_diff.removed)
+        self.assertIn(workflow.get_next_task(spec_name='Activity_1lmz1t0'), wf_diff.removed)
+        self.assertIn(workflow.get_next_task(spec_name='Activity_11gnihu'), wf_diff.removed)
+        self.assertIn(workflow.get_next_task(spec_name='Gateway_1acqedb'), wf_diff.removed)
+

--- a/tests/SpiffWorkflow/bpmn/data/diff/v1.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/diff/v1.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1rubmzk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1waieul</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1waieul" sourceRef="StartEvent_1" targetRef="Activity_0b53566" />
+    <bpmn:task id="Activity_0b53566" name="First Task">
+      <bpmn:incoming>Flow_1waieul</bpmn:incoming>
+      <bpmn:outgoing>Flow_0732j85</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_0rilo47">
+      <bpmn:incoming>Flow_0732j85</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0732j85" sourceRef="Activity_0b53566" targetRef="Event_0rilo47" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNEdge id="Flow_1waieul_di" bpmnElement="Flow_1waieul">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0732j85_di" bpmnElement="Flow_0732j85">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0b53566_di" bpmnElement="Activity_0b53566">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0rilo47_di" bpmnElement="Event_0rilo47">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/diff/v2.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/diff/v2.bpmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1rubmzk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1waieul</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1waieul" sourceRef="StartEvent_1" targetRef="Activity_0b53566" />
+    <bpmn:endEvent id="Event_0rilo47">
+      <bpmn:incoming>Flow_196caxc</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0732j85" sourceRef="Activity_0b53566" targetRef="Gateway_1618q26" />
+    <bpmn:exclusiveGateway id="Gateway_1618q26" default="Flow_196caxc">
+      <bpmn:incoming>Flow_0732j85</bpmn:incoming>
+      <bpmn:outgoing>Flow_196caxc</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1yo5kfp</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_196caxc" sourceRef="Gateway_1618q26" targetRef="Event_0rilo47" />
+    <bpmn:task id="Activity_1ds7clb" name="Second Task">
+      <bpmn:incoming>Flow_1yo5kfp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vf03wy</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1yo5kfp" sourceRef="Gateway_1618q26" targetRef="Activity_1ds7clb">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">v == 1</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_0tatpgq">
+      <bpmn:incoming>Flow_1vf03wy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1vf03wy" sourceRef="Activity_1ds7clb" targetRef="Event_0tatpgq" />
+    <bpmn:scriptTask id="Activity_0b53566" name="First Task">
+      <bpmn:incoming>Flow_1waieul</bpmn:incoming>
+      <bpmn:outgoing>Flow_0732j85</bpmn:outgoing>
+      <bpmn:script>v = 1</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNEdge id="Flow_1waieul_di" bpmnElement="Flow_1waieul">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0732j85_di" bpmnElement="Flow_0732j85">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="415" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_196caxc_di" bpmnElement="Flow_196caxc">
+        <di:waypoint x="465" y="117" />
+        <di:waypoint x="662" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yo5kfp_di" bpmnElement="Flow_1yo5kfp">
+        <di:waypoint x="440" y="142" />
+        <di:waypoint x="440" y="220" />
+        <di:waypoint x="500" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vf03wy_di" bpmnElement="Flow_1vf03wy">
+        <di:waypoint x="600" y="220" />
+        <di:waypoint x="662" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1618q26_di" bpmnElement="Gateway_1618q26" isMarkerVisible="true">
+        <dc:Bounds x="415" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ds7clb_di" bpmnElement="Activity_1ds7clb">
+        <dc:Bounds x="500" y="180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0rilo47_di" bpmnElement="Event_0rilo47">
+        <dc:Bounds x="662" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bgl4de_di" bpmnElement="Activity_0b53566">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tatpgq_di" bpmnElement="Event_0tatpgq">
+        <dc:Bounds x="662" y="202" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/diff/v3.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/diff/v3.bpmn
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1rubmzk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1waieul</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1waieul" sourceRef="StartEvent_1" targetRef="Activity_0b53566" />
+    <bpmn:sequenceFlow id="Flow_0732j85" sourceRef="Activity_0b53566" targetRef="Gateway_1618q26" />
+    <bpmn:exclusiveGateway id="Gateway_1618q26" default="Flow_196caxc">
+      <bpmn:incoming>Flow_0732j85</bpmn:incoming>
+      <bpmn:outgoing>Flow_196caxc</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1yo5kfp</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_196caxc" sourceRef="Gateway_1618q26" targetRef="Gateway_0z1qhgl" />
+    <bpmn:sequenceFlow id="Flow_1yo5kfp" sourceRef="Gateway_1618q26" targetRef="Activity_1ds7clb">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">v == 1</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_0tatpgq">
+      <bpmn:incoming>Flow_1vf03wy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1vf03wy" sourceRef="Activity_1ds7clb" targetRef="Event_0tatpgq" />
+    <bpmn:scriptTask id="Activity_0b53566" name="First Task">
+      <bpmn:incoming>Flow_1waieul</bpmn:incoming>
+      <bpmn:outgoing>Flow_0732j85</bpmn:outgoing>
+      <bpmn:script>v = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:parallelGateway id="Gateway_0z1qhgl">
+      <bpmn:incoming>Flow_196caxc</bpmn:incoming>
+      <bpmn:outgoing>Flow_10bii11</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0bg2qz3</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:task id="Activity_1lmz1t0" name="Branch 1">
+      <bpmn:incoming>Flow_10bii11</bpmn:incoming>
+      <bpmn:outgoing>Flow_179j6nm</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_10bii11" sourceRef="Gateway_0z1qhgl" targetRef="Activity_1lmz1t0" />
+    <bpmn:task id="Activity_11gnihu" name="Branch 2">
+      <bpmn:incoming>Flow_0bg2qz3</bpmn:incoming>
+      <bpmn:outgoing>Flow_13a8dzq</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0bg2qz3" sourceRef="Gateway_0z1qhgl" targetRef="Activity_11gnihu" />
+    <bpmn:sequenceFlow id="Flow_179j6nm" sourceRef="Activity_1lmz1t0" targetRef="Gateway_1acqedb" />
+    <bpmn:parallelGateway id="Gateway_1acqedb">
+      <bpmn:incoming>Flow_179j6nm</bpmn:incoming>
+      <bpmn:incoming>Flow_13a8dzq</bpmn:incoming>
+      <bpmn:outgoing>Flow_0nghd76</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_13a8dzq" sourceRef="Activity_11gnihu" targetRef="Gateway_1acqedb" />
+    <bpmn:endEvent id="Event_18osyv3">
+      <bpmn:incoming>Flow_0nghd76</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0nghd76" sourceRef="Gateway_1acqedb" targetRef="Event_18osyv3" />
+    <bpmn:subProcess id="Activity_1ds7clb" name="Subprocess">
+      <bpmn:incoming>Flow_1yo5kfp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vf03wy</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0moh1o1">
+        <bpmn:outgoing>Flow_0owkw79</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:task id="Activity_0uijumg" name="Second Task">
+        <bpmn:incoming>Flow_0owkw79</bpmn:incoming>
+        <bpmn:outgoing>Flow_1uyv02i</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_0owkw79" sourceRef="Event_0moh1o1" targetRef="Activity_0uijumg" />
+      <bpmn:endEvent id="Event_1wlwaz1">
+        <bpmn:incoming>Flow_1uyv02i</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1uyv02i" sourceRef="Activity_0uijumg" targetRef="Event_1wlwaz1" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNEdge id="Flow_1waieul_di" bpmnElement="Flow_1waieul">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0732j85_di" bpmnElement="Flow_0732j85">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="415" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_196caxc_di" bpmnElement="Flow_196caxc">
+        <di:waypoint x="465" y="117" />
+        <di:waypoint x="505" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yo5kfp_di" bpmnElement="Flow_1yo5kfp">
+        <di:waypoint x="440" y="142" />
+        <di:waypoint x="440" y="450" />
+        <di:waypoint x="500" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vf03wy_di" bpmnElement="Flow_1vf03wy">
+        <di:waypoint x="870" y="450" />
+        <di:waypoint x="962" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10bii11_di" bpmnElement="Flow_10bii11">
+        <di:waypoint x="555" y="117" />
+        <di:waypoint x="600" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bg2qz3_di" bpmnElement="Flow_0bg2qz3">
+        <di:waypoint x="530" y="142" />
+        <di:waypoint x="530" y="230" />
+        <di:waypoint x="600" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_179j6nm_di" bpmnElement="Flow_179j6nm">
+        <di:waypoint x="700" y="117" />
+        <di:waypoint x="745" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13a8dzq_di" bpmnElement="Flow_13a8dzq">
+        <di:waypoint x="700" y="230" />
+        <di:waypoint x="770" y="230" />
+        <di:waypoint x="770" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nghd76_di" bpmnElement="Flow_0nghd76">
+        <di:waypoint x="795" y="117" />
+        <di:waypoint x="842" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1618q26_di" bpmnElement="Gateway_1618q26" isMarkerVisible="true">
+        <dc:Bounds x="415" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bgl4de_di" bpmnElement="Activity_0b53566">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1xog2xr_di" bpmnElement="Gateway_0z1qhgl">
+        <dc:Bounds x="505" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1lmz1t0_di" bpmnElement="Activity_1lmz1t0">
+        <dc:Bounds x="600" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11gnihu_di" bpmnElement="Activity_11gnihu">
+        <dc:Bounds x="600" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_11tsr66_di" bpmnElement="Gateway_1acqedb">
+        <dc:Bounds x="745" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18osyv3_di" bpmnElement="Event_18osyv3">
+        <dc:Bounds x="842" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tatpgq_di" bpmnElement="Event_0tatpgq">
+        <dc:Bounds x="962" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18l8a8d_di" bpmnElement="Activity_1ds7clb" isExpanded="true">
+        <dc:Bounds x="500" y="350" width="370" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0owkw79_di" bpmnElement="Flow_0owkw79">
+        <di:waypoint x="578" y="450" />
+        <di:waypoint x="630" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uyv02i_di" bpmnElement="Flow_1uyv02i">
+        <di:waypoint x="730" y="450" />
+        <di:waypoint x="782" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0moh1o1_di" bpmnElement="Event_0moh1o1">
+        <dc:Bounds x="542" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0uijumg_di" bpmnElement="Activity_0uijumg">
+        <dc:Bounds x="630" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wlwaz1_di" bpmnElement="Event_1wlwaz1">
+        <dc:Bounds x="782" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/diff/v4.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/diff/v4.bpmn
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1rubmzk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1waieul</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1waieul" sourceRef="StartEvent_1" targetRef="Activity_0b53566" />
+    <bpmn:sequenceFlow id="Flow_0732j85" sourceRef="Activity_0b53566" targetRef="Gateway_1618q26" />
+    <bpmn:exclusiveGateway id="Gateway_1618q26" default="Flow_196caxc">
+      <bpmn:incoming>Flow_0732j85</bpmn:incoming>
+      <bpmn:outgoing>Flow_196caxc</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1yo5kfp</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_196caxc" sourceRef="Gateway_1618q26" targetRef="Gateway_0z1qhgl" />
+    <bpmn:sequenceFlow id="Flow_1yo5kfp" sourceRef="Gateway_1618q26" targetRef="Activity_1ds7clb">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">v == 2</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_0tatpgq">
+      <bpmn:incoming>Flow_1vf03wy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1vf03wy" sourceRef="Activity_1ds7clb" targetRef="Event_0tatpgq" />
+    <bpmn:scriptTask id="Activity_0b53566" name="First Task">
+      <bpmn:incoming>Flow_1waieul</bpmn:incoming>
+      <bpmn:outgoing>Flow_0732j85</bpmn:outgoing>
+      <bpmn:script>v = 1
+w = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:parallelGateway id="Gateway_0z1qhgl">
+      <bpmn:incoming>Flow_196caxc</bpmn:incoming>
+      <bpmn:outgoing>Flow_10bii11</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0bg2qz3</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:task id="Activity_1lmz1t0" name="Branch 1">
+      <bpmn:incoming>Flow_10bii11</bpmn:incoming>
+      <bpmn:outgoing>Flow_179j6nm</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_10bii11" sourceRef="Gateway_0z1qhgl" targetRef="Activity_1lmz1t0" />
+    <bpmn:task id="Activity_11gnihu" name="Branch 2">
+      <bpmn:incoming>Flow_0bg2qz3</bpmn:incoming>
+      <bpmn:outgoing>Flow_13a8dzq</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0bg2qz3" sourceRef="Gateway_0z1qhgl" targetRef="Activity_11gnihu" />
+    <bpmn:sequenceFlow id="Flow_179j6nm" sourceRef="Activity_1lmz1t0" targetRef="Gateway_1acqedb" />
+    <bpmn:parallelGateway id="Gateway_1acqedb">
+      <bpmn:incoming>Flow_179j6nm</bpmn:incoming>
+      <bpmn:incoming>Flow_13a8dzq</bpmn:incoming>
+      <bpmn:outgoing>Flow_0nghd76</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_13a8dzq" sourceRef="Activity_11gnihu" targetRef="Gateway_1acqedb" />
+    <bpmn:endEvent id="Event_18osyv3">
+      <bpmn:incoming>Flow_02qcc6y</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0nghd76" sourceRef="Gateway_1acqedb" targetRef="Gateway_0p4fq77" />
+    <bpmn:subProcess id="Activity_1ds7clb" name="Subprocess">
+      <bpmn:incoming>Flow_1yo5kfp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vf03wy</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0moh1o1">
+        <bpmn:outgoing>Flow_0owkw79</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:task id="Activity_0uijumg" name="Second Task">
+        <bpmn:incoming>Flow_0owkw79</bpmn:incoming>
+        <bpmn:outgoing>Flow_1uyv02i</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_0owkw79" sourceRef="Event_0moh1o1" targetRef="Activity_0uijumg" />
+      <bpmn:endEvent id="Event_1wlwaz1">
+        <bpmn:incoming>Flow_1c1pmyh</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1uyv02i" sourceRef="Activity_0uijumg" targetRef="Activity_1tog39f" />
+      <bpmn:task id="Activity_1tog39f" name="Third Task">
+        <bpmn:incoming>Flow_1uyv02i</bpmn:incoming>
+        <bpmn:outgoing>Flow_1c1pmyh</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_1c1pmyh" sourceRef="Activity_1tog39f" targetRef="Event_1wlwaz1" />
+    </bpmn:subProcess>
+    <bpmn:exclusiveGateway id="Gateway_0p4fq77" default="Flow_0qg2uqe">
+      <bpmn:incoming>Flow_0nghd76</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qg2uqe</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1yt4wfs</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0qg2uqe" sourceRef="Gateway_0p4fq77" targetRef="Gateway_1yl1oay" />
+    <bpmn:task id="Activity_16ggmbf" name="Optional Task">
+      <bpmn:incoming>Flow_1yt4wfs</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ltsf79</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1yt4wfs" sourceRef="Gateway_0p4fq77" targetRef="Activity_16ggmbf">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">w == 1</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_1yl1oay">
+      <bpmn:incoming>Flow_1ltsf79</bpmn:incoming>
+      <bpmn:incoming>Flow_0qg2uqe</bpmn:incoming>
+      <bpmn:outgoing>Flow_02qcc6y</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1ltsf79" sourceRef="Activity_16ggmbf" targetRef="Gateway_1yl1oay" />
+    <bpmn:sequenceFlow id="Flow_02qcc6y" sourceRef="Gateway_1yl1oay" targetRef="Event_18osyv3" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNEdge id="Flow_1waieul_di" bpmnElement="Flow_1waieul">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0732j85_di" bpmnElement="Flow_0732j85">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="415" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_196caxc_di" bpmnElement="Flow_196caxc">
+        <di:waypoint x="465" y="117" />
+        <di:waypoint x="505" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yo5kfp_di" bpmnElement="Flow_1yo5kfp">
+        <di:waypoint x="440" y="142" />
+        <di:waypoint x="440" y="450" />
+        <di:waypoint x="500" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vf03wy_di" bpmnElement="Flow_1vf03wy">
+        <di:waypoint x="1070" y="450" />
+        <di:waypoint x="1142" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10bii11_di" bpmnElement="Flow_10bii11">
+        <di:waypoint x="555" y="117" />
+        <di:waypoint x="600" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bg2qz3_di" bpmnElement="Flow_0bg2qz3">
+        <di:waypoint x="530" y="142" />
+        <di:waypoint x="530" y="230" />
+        <di:waypoint x="600" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_179j6nm_di" bpmnElement="Flow_179j6nm">
+        <di:waypoint x="700" y="117" />
+        <di:waypoint x="745" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13a8dzq_di" bpmnElement="Flow_13a8dzq">
+        <di:waypoint x="700" y="230" />
+        <di:waypoint x="770" y="230" />
+        <di:waypoint x="770" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nghd76_di" bpmnElement="Flow_0nghd76">
+        <di:waypoint x="795" y="117" />
+        <di:waypoint x="845" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qg2uqe_di" bpmnElement="Flow_0qg2uqe">
+        <di:waypoint x="895" y="117" />
+        <di:waypoint x="1065" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yt4wfs_di" bpmnElement="Flow_1yt4wfs">
+        <di:waypoint x="870" y="142" />
+        <di:waypoint x="870" y="230" />
+        <di:waypoint x="930" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ltsf79_di" bpmnElement="Flow_1ltsf79">
+        <di:waypoint x="1030" y="230" />
+        <di:waypoint x="1090" y="230" />
+        <di:waypoint x="1090" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02qcc6y_di" bpmnElement="Flow_02qcc6y">
+        <di:waypoint x="1115" y="117" />
+        <di:waypoint x="1172" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1618q26_di" bpmnElement="Gateway_1618q26" isMarkerVisible="true">
+        <dc:Bounds x="415" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bgl4de_di" bpmnElement="Activity_0b53566">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1xog2xr_di" bpmnElement="Gateway_0z1qhgl">
+        <dc:Bounds x="505" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1lmz1t0_di" bpmnElement="Activity_1lmz1t0">
+        <dc:Bounds x="600" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11gnihu_di" bpmnElement="Activity_11gnihu">
+        <dc:Bounds x="600" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_11tsr66_di" bpmnElement="Gateway_1acqedb">
+        <dc:Bounds x="745" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0p4fq77_di" bpmnElement="Gateway_0p4fq77" isMarkerVisible="true">
+        <dc:Bounds x="845" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16ggmbf_di" bpmnElement="Activity_16ggmbf">
+        <dc:Bounds x="930" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1yl1oay_di" bpmnElement="Gateway_1yl1oay" isMarkerVisible="true">
+        <dc:Bounds x="1065" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18osyv3_di" bpmnElement="Event_18osyv3">
+        <dc:Bounds x="1172" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tatpgq_di" bpmnElement="Event_0tatpgq">
+        <dc:Bounds x="1142" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18l8a8d_di" bpmnElement="Activity_1ds7clb" isExpanded="true">
+        <dc:Bounds x="500" y="350" width="570" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0owkw79_di" bpmnElement="Flow_0owkw79">
+        <di:waypoint x="578" y="450" />
+        <di:waypoint x="630" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uyv02i_di" bpmnElement="Flow_1uyv02i">
+        <di:waypoint x="730" y="450" />
+        <di:waypoint x="810" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c1pmyh_di" bpmnElement="Flow_1c1pmyh">
+        <di:waypoint x="910" y="450" />
+        <di:waypoint x="992" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0moh1o1_di" bpmnElement="Event_0moh1o1">
+        <dc:Bounds x="542" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0uijumg_di" bpmnElement="Activity_0uijumg">
+        <dc:Bounds x="630" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wlwaz1_di" bpmnElement="Event_1wlwaz1">
+        <dc:Bounds x="992" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1tog39f_di" bpmnElement="Activity_1tog39f">
+        <dc:Bounds x="810" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/SpiffWorkflow/bpmn/data/diff/v5.bpmn
+++ b/tests/SpiffWorkflow/bpmn/data/diff/v5.bpmn
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1rubmzk" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1waieul</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1waieul" sourceRef="StartEvent_1" targetRef="Activity_0b53566" />
+    <bpmn:sequenceFlow id="Flow_0732j85" sourceRef="Activity_0b53566" targetRef="Gateway_1618q26" />
+    <bpmn:exclusiveGateway id="Gateway_1618q26" default="Flow_0stnlzv">
+      <bpmn:incoming>Flow_0732j85</bpmn:incoming>
+      <bpmn:outgoing>Flow_1yo5kfp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0stnlzv</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1yo5kfp" sourceRef="Gateway_1618q26" targetRef="Activity_1ds7clb">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">v == 2</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_0tatpgq">
+      <bpmn:incoming>Flow_1vf03wy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1vf03wy" sourceRef="Activity_1ds7clb" targetRef="Event_0tatpgq" />
+    <bpmn:scriptTask id="Activity_0b53566" name="First Task">
+      <bpmn:incoming>Flow_1waieul</bpmn:incoming>
+      <bpmn:outgoing>Flow_0732j85</bpmn:outgoing>
+      <bpmn:script>v = 1
+w = 1</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_18osyv3">
+      <bpmn:incoming>Flow_02qcc6y</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_0p4fq77" default="Flow_0qg2uqe">
+      <bpmn:incoming>Flow_0stnlzv</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qg2uqe</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1yt4wfs</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0qg2uqe" sourceRef="Gateway_0p4fq77" targetRef="Gateway_1yl1oay" />
+    <bpmn:task id="Activity_16ggmbf" name="Optional Task">
+      <bpmn:incoming>Flow_1yt4wfs</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ltsf79</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1yt4wfs" sourceRef="Gateway_0p4fq77" targetRef="Activity_16ggmbf">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">w == 1</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_1yl1oay">
+      <bpmn:incoming>Flow_1ltsf79</bpmn:incoming>
+      <bpmn:incoming>Flow_0qg2uqe</bpmn:incoming>
+      <bpmn:outgoing>Flow_02qcc6y</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1ltsf79" sourceRef="Activity_16ggmbf" targetRef="Gateway_1yl1oay" />
+    <bpmn:sequenceFlow id="Flow_02qcc6y" sourceRef="Gateway_1yl1oay" targetRef="Event_18osyv3" />
+    <bpmn:sequenceFlow id="Flow_0stnlzv" sourceRef="Gateway_1618q26" targetRef="Gateway_0p4fq77" />
+    <bpmn:transaction id="Activity_1ds7clb" name="Subprocess">
+      <bpmn:incoming>Flow_1yo5kfp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vf03wy</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0moh1o1">
+        <bpmn:outgoing>Flow_0owkw79</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:task id="Activity_0uijumg" name="Second Task">
+        <bpmn:incoming>Flow_0owkw79</bpmn:incoming>
+        <bpmn:outgoing>Flow_1uyv02i</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:endEvent id="Event_1wlwaz1">
+        <bpmn:incoming>Flow_1c1pmyh</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:task id="Activity_1tog39f" name="Third Task">
+        <bpmn:incoming>Flow_1uyv02i</bpmn:incoming>
+        <bpmn:outgoing>Flow_1c1pmyh</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_0owkw79" sourceRef="Event_0moh1o1" targetRef="Activity_0uijumg" />
+      <bpmn:sequenceFlow id="Flow_1uyv02i" sourceRef="Activity_0uijumg" targetRef="Activity_1tog39f" />
+      <bpmn:sequenceFlow id="Flow_1c1pmyh" sourceRef="Activity_1tog39f" targetRef="Event_1wlwaz1" />
+    </bpmn:transaction>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process">
+      <bpmndi:BPMNEdge id="Flow_1waieul_di" bpmnElement="Flow_1waieul">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0732j85_di" bpmnElement="Flow_0732j85">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="415" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yo5kfp_di" bpmnElement="Flow_1yo5kfp">
+        <di:waypoint x="440" y="142" />
+        <di:waypoint x="440" y="450" />
+        <di:waypoint x="500" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vf03wy_di" bpmnElement="Flow_1vf03wy">
+        <di:waypoint x="1070" y="450" />
+        <di:waypoint x="1142" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0stnlzv_di" bpmnElement="Flow_0stnlzv">
+        <di:waypoint x="465" y="117" />
+        <di:waypoint x="575" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02qcc6y_di" bpmnElement="Flow_02qcc6y">
+        <di:waypoint x="845" y="117" />
+        <di:waypoint x="1142" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qg2uqe_di" bpmnElement="Flow_0qg2uqe">
+        <di:waypoint x="625" y="117" />
+        <di:waypoint x="795" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yt4wfs_di" bpmnElement="Flow_1yt4wfs">
+        <di:waypoint x="600" y="142" />
+        <di:waypoint x="600" y="230" />
+        <di:waypoint x="660" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ltsf79_di" bpmnElement="Flow_1ltsf79">
+        <di:waypoint x="760" y="230" />
+        <di:waypoint x="820" y="230" />
+        <di:waypoint x="820" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1618q26_di" bpmnElement="Gateway_1618q26" isMarkerVisible="true">
+        <dc:Bounds x="415" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bgl4de_di" bpmnElement="Activity_0b53566">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tatpgq_di" bpmnElement="Event_0tatpgq">
+        <dc:Bounds x="1142" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0p4fq77_di" bpmnElement="Gateway_0p4fq77" isMarkerVisible="true">
+        <dc:Bounds x="575" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16ggmbf_di" bpmnElement="Activity_16ggmbf">
+        <dc:Bounds x="660" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1yl1oay_di" bpmnElement="Gateway_1yl1oay" isMarkerVisible="true">
+        <dc:Bounds x="795" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_18osyv3_di" bpmnElement="Event_18osyv3">
+        <dc:Bounds x="1142" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0gdygdm_di" bpmnElement="Activity_1ds7clb" isExpanded="true">
+        <dc:Bounds x="500" y="350" width="570" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0owkw79_di" bpmnElement="Flow_0owkw79">
+        <di:waypoint x="578" y="450" />
+        <di:waypoint x="630" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1uyv02i_di" bpmnElement="Flow_1uyv02i">
+        <di:waypoint x="730" y="450" />
+        <di:waypoint x="810" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c1pmyh_di" bpmnElement="Flow_1c1pmyh">
+        <di:waypoint x="910" y="450" />
+        <di:waypoint x="992" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0moh1o1_di" bpmnElement="Event_0moh1o1">
+        <dc:Bounds x="542" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0uijumg_di" bpmnElement="Activity_0uijumg">
+        <dc:Bounds x="630" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wlwaz1_di" bpmnElement="Event_1wlwaz1">
+        <dc:Bounds x="992" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1tog39f_di" bpmnElement="Activity_1tog39f">
+        <dc:Bounds x="810" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
This adds some utilities for
- comparing workflow specs
- identifying tasks in a workflow instance affected by changes to the spec

The spec comparison utility uses a serializer to compare two versions of a spec; the serializer already knows about all the attributes of a particular ask spec so it can be leveraged to avoid implementing attribute comparisons for each type of spec.

The comparisons provides lists of
- specs added in the later version
- specs removed in the later version (or tasks that use removed specs)
- specs that changed between versions (or tasks that use the changed specs)
- an alignment mapping specs from the original to the later version (or from a task to the later version of a task's spec)

This is intended to provide information about whether a spec can be updated on an existing workflow.