### PR TITLE
hack to get messages working

### DIFF
--- a/SpiffWorkflow/bpmn/specs/event_definitions/message.py
+++ b/SpiffWorkflow/bpmn/specs/event_definitions/message.py
@@ -28,7 +28,7 @@ class MessageEventDefinition(EventDefinition):
             correlated = True
         else:
             # Otherwise we have to check to make sure any existing keys match
-            correlated = all([event.correlations.get(key) == correlations.get(key) for key in event.correlations ])
+            correlated = any([event.correlations.get(key) == correlations.get(key) for key in event.correlations ])
         return self == event.event_definition and correlated
 
     def catch(self, my_task, event=None):

--- a/tests/SpiffWorkflow/bpmn/CollaborationTest.py
+++ b/tests/SpiffWorkflow/bpmn/CollaborationTest.py
@@ -60,9 +60,11 @@ class CollaborationTest(BpmnWorkflowTestCase):
         self.assertEqual('from_name', events[0].value[0].retrieval_expression)
         self.assertEqual('lover_name', events[0].value[0].name)
 
+        payload = {'from_name': 'Peggy', 'other_nonsense': 1001}
         message = BpmnEvent(
             receive.task_spec.event_definition,
-            {'from_name': 'Peggy', 'other_nonsense': 1001}
+            payload,
+            receive.task_spec.event_definition.get_correlations(receive, payload),
         )
         self.workflow.send_event(message)
         self.workflow.do_engine_steps()


### PR DESCRIPTION
Not sure about this change.  To me not matching all the correlation keys associated with a message doesn't make sense.  It didn't seem like the spec said one way or the other, but it did say that sent or received messages should set one or more keys.  So maybe one or more applies to matching too.  Anyway this seems to be a fix for other problems we're having.