### PR TITLE
enable parsing of multi-instance nodes

### DIFF
--- a/SpiffWorkflow/bpmn/parser/TaskParser.py
+++ b/SpiffWorkflow/bpmn/parser/TaskParser.py
@@ -101,7 +101,7 @@ class TaskParser(NodeParser):
         sequential = loop_characteristics.get('isSequential') == 'true'
         prefix = 'bpmn:multiInstanceLoopCharacteristics'
         cardinality = self.xpath(f'./{prefix}/bpmn:loopCardinality')
-        loop_input = self.xpath(f'./{prefix}/bpmn:loopDataInputRef')
+        loop_input = self.xpath(f'./{prefix}/bpmn:extensionElements/zeebe:loopCharacteristics')
         if len(cardinality) == 0 and len(loop_input) == 0:
             self.raise_validation_exception(
                 "A multiinstance task must specify a cardinality or a loop input data reference")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "SpiffWorkflow"
+name = "rxrx-SpiffWorkflow"
 description = "A workflow framework and BPMN/DMN Processor"
 authors = [
     {name = "Sartography", email = "dan@sartography.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "rxrx-SpiffWorkflow"
+name = "SpiffWorkflow"
 description = "A workflow framework and BPMN/DMN Processor"
 authors = [
     {name = "Sartography", email = "dan@sartography.com"},


### PR DESCRIPTION
This will fix the parser to respect the convention used in Camunda 8, which uses different attributes to characterize multi-instance nodes than Camunda 7 used