### PR TITLE
initialize data objects on workflow creation

### DIFF
--- a/SpiffWorkflow/bpmn/workflow.py
+++ b/SpiffWorkflow/bpmn/workflow.py
@@ -53,6 +53,8 @@ class BpmnWorkflow(BpmnBaseWorkflow):
         self.correlations = {}
         super(BpmnWorkflow, self).__init__(spec, **kwargs)
 
+        for obj in self.spec.data_objects:
+            self.data['data_objects'][obj] = None
         self.__script_engine = script_engine or PythonScriptEngine()
 
     @property

--- a/tests/SpiffWorkflow/bpmn/DataObjectTest.py
+++ b/tests/SpiffWorkflow/bpmn/DataObjectTest.py
@@ -43,6 +43,8 @@ class DataObjectReferenceTest(BpmnWorkflowTestCase):
     def actual_test(self, save_restore):
 
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses)
+        # Test that the data object has been created
+        self.assertEqual(self.workflow.data['data_objects']['obj_1'], None)
         self.workflow.do_engine_steps()
 
         # Set up the data
@@ -50,7 +52,7 @@ class DataObjectReferenceTest(BpmnWorkflowTestCase):
         ready_tasks[0].data = { 'obj_1': 'hello' }
         ready_tasks[0].run()
         # After task completion, obj_1 should be copied out of the task into the workflow
-        self.assertNotIn('obj_1', ready_tasks[0].data)
+        self.assertEqual(self.workflow.data['data_objects']['obj_1'], 'hello')
         self.assertIn('obj_1', self.workflow.data_objects)
 
         if save_restore:

--- a/tests/SpiffWorkflow/bpmn/events/ConditionalEventTest.py
+++ b/tests/SpiffWorkflow/bpmn/events/ConditionalEventTest.py
@@ -8,8 +8,6 @@ class ConditionalEventTest(BpmnWorkflowTestCase):
     def testIntermediateEvent(self):
         spec, subprocesses = self.load_workflow_spec('conditional_event.bpmn', 'intermediate')
         self.workflow = BpmnWorkflow(spec, subprocesses)
-        # I don't want to complicate the diagram with extra tasks just for initializing this value
-        self.workflow.data_objects['task_a_done'] = False
         self.workflow.do_engine_steps()
         b = self.workflow.get_next_task(spec_name='task_b')
         b.run()
@@ -29,7 +27,6 @@ class ConditionalEventTest(BpmnWorkflowTestCase):
     def testBoundaryEvent(self):
         spec, subprocesses = self.load_workflow_spec('conditional_event.bpmn', 'boundary')
         self.workflow = BpmnWorkflow(spec, subprocesses)
-        self.workflow.data_objects['task_c_done'] = False
         self.workflow.do_engine_steps()
         c = self.workflow.get_next_task(spec_name='task_c')
         c.data['task_c_done'] = True


### PR DESCRIPTION
This initializes data objects when a workflow is created.  This will prevent missing variable errors when accessing data objects before they've been used.  Since the references are visible on the diagram, these errors don't make much sense.