### PR TITLE
add user task form variable

### DIFF
--- a/SpiffWorkflow/spiff/parser/process.py
+++ b/SpiffWorkflow/spiff/parser/process.py
@@ -52,7 +52,8 @@ from SpiffWorkflow.spiff.parser.task_spec import (
     CallActivityParser,
     ServiceTaskParser,
     ScriptTaskParser,
-    BusinessRuleTaskParser
+    BusinessRuleTaskParser,
+    UserTaskParser,
 )
 from SpiffWorkflow.spiff.parser.event_parsers import (
     SpiffStartEventParser,
@@ -94,5 +95,6 @@ class SpiffBpmnParser(BpmnDmnParser):
         full_tag('intermediateThrowEvent'): (SpiffIntermediateThrowEventParser, IntermediateThrowEvent),
         full_tag('sendTask'): (SpiffSendTaskParser, SendTask),
         full_tag('receiveTask'): (SpiffReceiveTaskParser, ReceiveTask),
-        full_tag('businessRuleTask'): (BusinessRuleTaskParser, BusinessRuleTask)
+        full_tag('businessRuleTask'): (BusinessRuleTaskParser, BusinessRuleTask),
+        full_tag('userTask'): (UserTaskParser, UserTask),
     }

--- a/SpiffWorkflow/spiff/parser/task_spec.py
+++ b/SpiffWorkflow/spiff/parser/task_spec.py
@@ -27,7 +27,8 @@ from SpiffWorkflow.spiff.specs.defaults import (
     StandardLoopTask,
     ParallelMultiInstanceTask,
     SequentialMultiInstanceTask,
-    BusinessRuleTask
+    BusinessRuleTask,
+    UserTask,
 )
 
 SPIFFWORKFLOW_NSMAP = {'spiffworkflow': 'http://spiffworkflow.org/bpmn/schema/1.0/core'}
@@ -203,3 +204,20 @@ class BusinessRuleTaskParser(SpiffTaskParser):
     def get_decision_ref(node):
         extensions = SpiffTaskParser._parse_extensions(node)
         return extensions.get('calledDecisionId')
+
+class UserTaskParser(SpiffTaskParser):
+
+    def create_task(self):
+        extensions = self.parse_extensions()
+        variable = extensions.get('variableName')
+        prescript = extensions.get('preScript')
+        postscript = extensions.get('postScript')
+        return UserTask(
+            self.spec,
+            self.bpmn_id,
+            variable=variable,
+            prescript=prescript,
+            postscript=postscript,
+            **self.bpmn_attributes,
+        )
+

--- a/SpiffWorkflow/spiff/specs/defaults.py
+++ b/SpiffWorkflow/spiff/specs/defaults.py
@@ -18,7 +18,6 @@
 # 02110-1301  USA
 
 from SpiffWorkflow.bpmn.specs.mixins import (
-    UserTaskMixin,
     ManualTaskMixin,
     NoneTaskMixin,
     ScriptTaskMixin,
@@ -34,6 +33,7 @@ from SpiffWorkflow.bpmn.specs.mixins import (
 from SpiffWorkflow.dmn.specs import BusinessRuleTaskMixin
 
 from .mixins.service_task import ServiceTask as ServiceTaskMixin
+from .mixins.user_task import UserTask as UserTaskMixin
 from .spiff_task import SpiffBpmnTask
 
 

--- a/SpiffWorkflow/spiff/specs/mixins/user_task.py
+++ b/SpiffWorkflow/spiff/specs/mixins/user_task.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2025 Sartography
+#
+# This file is part of SpiffWorkflow.
+#
+# SpiffWorkflow is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# SpiffWorkflow is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301  USA
+
+
+from SpiffWorkflow.bpmn.specs.mixins.user_task import UserTask
+from SpiffWorkflow.util.deep_merge import DeepMerge
+
+class UserTask(UserTask):
+    def __init__(self, wf_spec, bpmn_id, variable=None, **kwargs):
+        super().__init__(wf_spec, bpmn_id, **kwargs)
+        self.variable = variable
+
+    def add_data_from_form(self, my_task, data):
+        if self.variable is not None:
+            my_task.set_data(**{self.variable: data})
+        else:
+            DeepMerge.merge(my_task.data, data)

--- a/tests/SpiffWorkflow/spiff/UserTaskTest.py
+++ b/tests/SpiffWorkflow/spiff/UserTaskTest.py
@@ -1,0 +1,36 @@
+from SpiffWorkflow.util.task import TaskState
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from .BaseTestCase import BaseTestCase
+
+
+class UserTaskTest(BaseTestCase):
+
+    def setUp(self):
+        pass
+
+    def testVariable(self):
+        workflow = self.run_workflow('one')
+        self.assertIn('order', workflow.data)
+
+    def testNoVariable(self):
+        workflow = self.run_workflow('two')
+        self.assertIn('size', workflow.data)
+        self.assertIn('toppings', workflow.data)
+
+    def run_workflow(self, process_id):
+        spec, subprocesses = self.load_workflow_spec('user_task_variable.bpmn', process_id)
+        workflow = BpmnWorkflow(spec, subprocesses)
+        workflow.do_engine_steps()
+        task = workflow.get_next_task(state=TaskState.READY)
+        order = {
+            'size': 'large',
+            'toppings': [
+                'sausage',
+                'onions',
+                'peppers',
+            ],
+        }
+        task.task_spec.add_data_from_form(task, order)
+        task.run()
+        workflow.do_engine_steps()
+        return workflow

--- a/tests/SpiffWorkflow/spiff/data/user_task_variable.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/user_task_variable.bpmn
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1qnx3d3" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.17.0">
+  <bpmn:collaboration id="Collaboration_11rypv4">
+    <bpmn:participant id="Participant_190ghs2" processRef="two" />
+    <bpmn:participant id="Participant_0kga0m3" processRef="one" />
+  </bpmn:collaboration>
+  <bpmn:process id="two" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0vt1twq</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0yxpeto">
+      <bpmn:incoming>Flow_00ilv2d</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:userTask id="user_task_one" name="User Task">
+      <bpmn:extensionElements>
+        <spiffworkflow:properties>
+          <spiffworkflow:property name="formJsonSchemaFilename" value="pizza_form.json" />
+        </spiffworkflow:properties>
+        <spiffworkflow:variableName />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0vt1twq</bpmn:incoming>
+      <bpmn:outgoing>Flow_00ilv2d</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0vt1twq" sourceRef="StartEvent_1" targetRef="user_task_one" />
+    <bpmn:sequenceFlow id="Flow_00ilv2d" sourceRef="user_task_one" targetRef="Event_0yxpeto" />
+  </bpmn:process>
+  <bpmn:process id="one" isExecutable="true">
+    <bpmn:startEvent id="Event_0pincx2">
+      <bpmn:outgoing>Flow_0qcvsqc</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0wyj6uh">
+      <bpmn:incoming>Flow_1cmc5fv</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:userTask id="user_task_two" name="User Task">
+      <bpmn:extensionElements>
+        <spiffworkflow:properties>
+          <spiffworkflow:property name="formJsonSchemaFilename" value="pizza_form.json" />
+        </spiffworkflow:properties>
+        <spiffworkflow:variableName>order</spiffworkflow:variableName>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0qcvsqc</bpmn:incoming>
+      <bpmn:outgoing>Flow_1cmc5fv</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0qcvsqc" sourceRef="Event_0pincx2" targetRef="user_task_two" />
+    <bpmn:sequenceFlow id="Flow_1cmc5fv" sourceRef="user_task_two" targetRef="Event_0wyj6uh" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_11rypv4">
+      <bpmndi:BPMNShape id="Participant_190ghs2_di" bpmnElement="Participant_190ghs2" isHorizontal="true">
+        <dc:Bounds x="92" y="30" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="232" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0yxpeto_di" bpmnElement="Event_0yxpeto">
+        <dc:Bounds x="512" y="122" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08ynz71_di" bpmnElement="user_task">
+        <dc:Bounds x="330" y="100" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0vt1twq_di" bpmnElement="Flow_0vt1twq">
+        <di:waypoint x="268" y="140" />
+        <di:waypoint x="330" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00ilv2d_di" bpmnElement="Flow_00ilv2d">
+        <di:waypoint x="430" y="140" />
+        <di:waypoint x="512" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_1d6xazy" bpmnElement="Participant_0kga0m3" isHorizontal="true">
+        <dc:Bounds x="92" y="-240" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0ouulug" bpmnElement="Event_0pincx2">
+        <dc:Bounds x="232" y="-148" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0j6zfji" bpmnElement="Event_0wyj6uh">
+        <dc:Bounds x="512" y="-148" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0rfd4sd" bpmnElement="user_task_two">
+        <dc:Bounds x="330" y="-170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0dyifou" bpmnElement="Flow_0qcvsqc">
+        <di:waypoint x="268" y="-130" />
+        <di:waypoint x="330" y="-130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1r3h3hf" bpmnElement="Flow_1cmc5fv">
+        <di:waypoint x="430" y="-130" />
+        <di:waypoint x="512" y="-130" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Allow authors to specify a single variable name when adding data collected from a form.  If no variable is present, the original behavior of adding each form fields separately will be preserved.