### PR TITLE
Parse task metadata values extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ tests-par:
 		echo "  pip install unittest-parallel"; \
 		exit 1; \
 	fi
-	unittest-parallel --module-fixtures -qbs tests/SpiffWorkflow -p \*Test.py -t .
+	unittest-parallel -qbs tests/SpiffWorkflow -p \*Test.py -t .
 
 .PHONY : tests-cov
 tests-cov:

--- a/SpiffWorkflow/spiff/parser/task_spec.py
+++ b/SpiffWorkflow/spiff/parser/task_spec.py
@@ -60,6 +60,8 @@ class SpiffTaskParser(TaskParser):
                 extensions['unitTests'] = SpiffTaskParser._parse_script_unit_tests(node)
             elif name == 'serviceTaskOperator':
                 extensions['serviceTaskOperator'] = SpiffTaskParser._parse_servicetask_operator(node)
+            elif name == 'taskMetadataValues':
+                extensions['taskMetadataValues'] = SpiffTaskParser._parse_task_metadata_values(node)
             else:
                 extensions[name] = node.text
         return extensions
@@ -76,6 +78,14 @@ class SpiffTaskParser(TaskParser):
         for prop_node in property_nodes:
             properties[prop_node.attrib['name']] = prop_node.attrib['value']
         return properties
+
+    @classmethod
+    def _parse_task_metadata_values(cls, node):
+        metadata_value_nodes = cls._node_children_by_tag_name(node, 'taskMetadataValue')
+        metadata_values = {}
+        for metadata_node in metadata_value_nodes:
+            metadata_values[metadata_node.attrib['name']] = metadata_node.attrib['value']
+        return metadata_values
 
     @staticmethod
     def _spiffworkflow_ready_xpath_for_node(node):

--- a/SpiffWorkflow/spiff/parser/task_spec.py
+++ b/SpiffWorkflow/spiff/parser/task_spec.py
@@ -84,7 +84,7 @@ class SpiffTaskParser(TaskParser):
         metadata_value_nodes = cls._node_children_by_tag_name(node, 'taskMetadataValue')
         metadata_values = {}
         for metadata_node in metadata_value_nodes:
-            metadata_values[metadata_node.attrib['name']] = metadata_node.attrib['value']
+            metadata_values[metadata_node.attrib['name']] = metadata_node.attrib.get('value', None)
         return metadata_values
 
     @staticmethod

--- a/tests/SpiffWorkflow/spiff/HumanTaskMetadataTest.py
+++ b/tests/SpiffWorkflow/spiff/HumanTaskMetadataTest.py
@@ -25,3 +25,7 @@ class HumanTaskMetadataTest(BaseTestCase):
         # Check that the metadata values are correctly parsed
         self.assertEqual(task_metadata_values['dynamic_key'], 'my_var')
         self.assertEqual(task_metadata_values['static_key'], "'static_value'")
+
+        # Check that metadata values without a value attribute are set to None
+        self.assertIsNone(task_metadata_values['key_with_no_value_property_in_xml'],
+                         "Metadata value without value attribute should be None")

--- a/tests/SpiffWorkflow/spiff/HumanTaskMetadataTest.py
+++ b/tests/SpiffWorkflow/spiff/HumanTaskMetadataTest.py
@@ -1,0 +1,27 @@
+from SpiffWorkflow.util.task import TaskState
+from SpiffWorkflow.bpmn.workflow import BpmnWorkflow
+from .BaseTestCase import BaseTestCase
+
+
+class HumanTaskMetadataTest(BaseTestCase):
+
+    def testTaskMetadataValues(self):
+        """Test that taskMetadataValues are parsed as a list of elements, not as XML string"""
+        spec, subprocesses = self.load_workflow_spec('human_task_metadata.bpmn', 'Process_human_task_metadata')
+        workflow = BpmnWorkflow(spec, subprocesses)
+        workflow.do_engine_steps()
+
+        # Get the user task
+        task = workflow.get_next_task(state=TaskState.READY)
+
+        # Check that the task has the taskMetadataValues extension
+        self.assertIn('taskMetadataValues', task.task_spec.extensions)
+
+        # The taskMetadataValues should be a dict, not a string
+        task_metadata_values = task.task_spec.extensions['taskMetadataValues']
+        self.assertIsInstance(task_metadata_values, dict,
+                            "taskMetadataValues should be parsed as a dict, not a string")
+
+        # Check that the metadata values are correctly parsed
+        self.assertEqual(task_metadata_values['dynamic_key'], 'my_var')
+        self.assertEqual(task_metadata_values['static_key'], "'static_value'")

--- a/tests/SpiffWorkflow/spiff/HumanTaskMetadataTest.py
+++ b/tests/SpiffWorkflow/spiff/HumanTaskMetadataTest.py
@@ -4,28 +4,18 @@ from .BaseTestCase import BaseTestCase
 
 
 class HumanTaskMetadataTest(BaseTestCase):
-
     def testTaskMetadataValues(self):
-        """Test that taskMetadataValues are parsed as a list of elements, not as XML string"""
-        spec, subprocesses = self.load_workflow_spec('human_task_metadata.bpmn', 'Process_human_task_metadata')
+        spec, subprocesses = self.load_workflow_spec("human_task_metadata.bpmn", "Process_human_task_metadata")
         workflow = BpmnWorkflow(spec, subprocesses)
         workflow.do_engine_steps()
 
-        # Get the user task
         task = workflow.get_next_task(state=TaskState.READY)
+        self.assertIn("taskMetadataValues", task.task_spec.extensions)
+        task_metadata_values = task.task_spec.extensions["taskMetadataValues"]
+        self.assertIsInstance(task_metadata_values, dict, "taskMetadataValues should be parsed as a dict, not a string")
+        self.assertEqual(task_metadata_values["dynamic_key"], "my_var")
+        self.assertEqual(task_metadata_values["static_key"], "'static_value'")
 
-        # Check that the task has the taskMetadataValues extension
-        self.assertIn('taskMetadataValues', task.task_spec.extensions)
-
-        # The taskMetadataValues should be a dict, not a string
-        task_metadata_values = task.task_spec.extensions['taskMetadataValues']
-        self.assertIsInstance(task_metadata_values, dict,
-                            "taskMetadataValues should be parsed as a dict, not a string")
-
-        # Check that the metadata values are correctly parsed
-        self.assertEqual(task_metadata_values['dynamic_key'], 'my_var')
-        self.assertEqual(task_metadata_values['static_key'], "'static_value'")
-
-        # Check that metadata values without a value attribute are set to None
-        self.assertIsNone(task_metadata_values['key_with_no_value_property_in_xml'],
-                         "Metadata value without value attribute should be None")
+        self.assertIsNone(
+            task_metadata_values["key_with_no_value_property_in_xml"], "Metadata value without value attribute should be None"
+        )

--- a/tests/SpiffWorkflow/spiff/data/human_task_metadata.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/human_task_metadata.bpmn
@@ -20,6 +20,7 @@
         <spiffworkflow:taskMetadataValues>
           <spiffworkflow:taskMetadataValue name="dynamic_key" value="my_var" />
           <spiffworkflow:taskMetadataValue name="static_key" value="'static_value'" />
+          <spiffworkflow:taskMetadataValue name="key_with_no_value_property_in_xml" />
         </spiffworkflow:taskMetadataValues>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0b04rbg</bpmn:incoming>

--- a/tests/SpiffWorkflow/spiff/data/human_task_metadata.bpmn
+++ b/tests/SpiffWorkflow/spiff/data/human_task_metadata.bpmn
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:spiffworkflow="http://spiffworkflow.org/bpmn/schema/1.0/core" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Process_human_task_metadata" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1my9ag5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1my9ag5" sourceRef="StartEvent_1" targetRef="Activity_1qtnye8" />
+    <bpmn:sequenceFlow id="Flow_0b04rbg" sourceRef="Activity_1qtnye8" targetRef="Activity_1gqykqt" />
+    <bpmn:endEvent id="Event_0pchbgr">
+      <bpmn:incoming>Flow_13mlau2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_13mlau2" sourceRef="Activity_1gqykqt" targetRef="Event_0pchbgr" />
+    <bpmn:scriptTask id="Activity_1qtnye8" name="set variables" scriptFormat="python">
+      <bpmn:incoming>Flow_1my9ag5</bpmn:incoming>
+      <bpmn:outgoing>Flow_0b04rbg</bpmn:outgoing>
+      <bpmn:script>my_var = "dynamic_value"</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:userTask id="Activity_1gqykqt" name="User Task with Metadata">
+      <bpmn:extensionElements>
+        <spiffworkflow:taskMetadataValues>
+          <spiffworkflow:taskMetadataValue name="dynamic_key" value="my_var" />
+          <spiffworkflow:taskMetadataValue name="static_key" value="'static_value'" />
+        </spiffworkflow:taskMetadataValues>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0b04rbg</bpmn:incoming>
+      <bpmn:outgoing>Flow_13mlau2</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_human_task_metadata">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pchbgr_di" bpmnElement="Event_0pchbgr">
+        <dc:Bounds x="592" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x1c7bj_di" bpmnElement="Activity_1qtnye8">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0w50892_di" bpmnElement="Activity_1gqykqt">
+        <dc:Bounds x="430" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1my9ag5_di" bpmnElement="Flow_1my9ag5">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b04rbg_di" bpmnElement="Flow_0b04rbg">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="430" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13mlau2_di" bpmnElement="Flow_13mlau2">
+        <di:waypoint x="530" y="177" />
+        <di:waypoint x="592" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
This adds support for task metadata in bpmn extensions. The values are run through the script engine in arena.