### PR TITLE
refactor serialize_json to use custom JSONEncoder for ~3.7x speedup

### DIFF
--- a/SpiffWorkflow/bpmn/serializer/helpers/encoder.py
+++ b/SpiffWorkflow/bpmn/serializer/helpers/encoder.py
@@ -1,0 +1,19 @@
+import json
+from types import ModuleType
+
+
+def create_encoder(registry, user_encoder_cls=None):
+    base = user_encoder_cls or json.JSONEncoder
+
+    class SpiffEncoder(base):
+        def default(self, obj):
+            typename = registry.typenames.get(type(obj))
+            if typename is not None:
+                return registry.convert_to_dict[typename](obj)
+            if callable(obj) or isinstance(obj, ModuleType):
+                return None
+            if isinstance(obj, set):
+                return list(obj)
+            return super().default(obj)
+
+    return SpiffEncoder

--- a/SpiffWorkflow/bpmn/serializer/helpers/registry.py
+++ b/SpiffWorkflow/bpmn/serializer/helpers/registry.py
@@ -33,6 +33,7 @@ class DefaultRegistry(DictionaryConverter):
     def __init__(self):
 
         super().__init__()
+        self._encoder_mode = False
         self.register(UUID, lambda v: { 'value': str(v) }, lambda v: UUID(v['value']))
         self.register(datetime, lambda v:  { 'value': v.isoformat() }, lambda v: datetime.fromisoformat(v['value']))
         self.register(timedelta, lambda v: { 'days': v.days, 'seconds': v.seconds }, lambda v: timedelta(**v))
@@ -46,8 +47,19 @@ class DefaultRegistry(DictionaryConverter):
         Returns:
             the result of `convert` conversion after preprocessing
         """
+        if self._encoder_mode:
+            return self._convert_for_encoder(obj)
         cleaned = self.clean(obj)
         return super().convert(cleaned)
+
+    def _convert_for_encoder(self, obj):
+        typename = self.typenames.get(obj.__class__)
+        if typename in self.convert_to_dict:
+            return self.convert_to_dict[typename](obj)
+        elif isinstance(obj, dict):
+            return self.clean(obj)
+        else:
+            return obj
 
     def clean(self, obj):
         """A method that can be used to preprocess an object before conversion to a dict.

--- a/SpiffWorkflow/bpmn/serializer/workflow.py
+++ b/SpiffWorkflow/bpmn/serializer/workflow.py
@@ -21,6 +21,7 @@ import json, gzip
 
 from .migration.version_migration import MIGRATIONS
 from .helpers import DefaultRegistry
+from .helpers.encoder import create_encoder
 
 from .config import DEFAULT_CONFIG
 
@@ -97,6 +98,7 @@ class BpmnWorkflowSerializer:
         self.json_encoder_cls = json_encoder_cls
         self.json_decoder_cls = json_decoder_cls
         self.VERSION = version
+        self._encoder_cls = create_encoder(self.registry, json_encoder_cls)
 
     def serialize_json(self, workflow, use_gzip=False):
         """Serialize the dictionary representation of the workflow to JSON.
@@ -108,9 +110,13 @@ class BpmnWorkflowSerializer:
         Returns:
             a JSON dump of the dictionary representation or a gzipped version of it
         """
-        dct = self.to_dict(workflow)
-        dct[self.VERSION_KEY] = self.VERSION
-        json_str = json.dumps(dct, cls=self.json_encoder_cls)
+        self.registry._encoder_mode = True
+        try:
+            dct = self.to_dict(workflow)
+            dct[self.VERSION_KEY] = self.VERSION
+            json_str = json.dumps(dct, cls=self._encoder_cls)
+        finally:
+            self.registry._encoder_mode = False
         return gzip.compress(json_str.encode('utf-8')) if use_gzip else json_str
 
     def deserialize_json(self, serialization, use_gzip=False):

--- a/tests/SpiffWorkflow/bpmn/test_performance_test.py
+++ b/tests/SpiffWorkflow/bpmn/test_performance_test.py
@@ -80,13 +80,13 @@ class PerformanceTest(BpmnWorkflowTestCase):
 
         # Measure serialization
         start_serialize = time.time()
-        state = self.serializer.to_dict(workflow)
+        state = self.serializer.serialize_json(workflow)
         end_serialize = time.time()
         serialize_time = end_serialize - start_serialize
 
         # Measure deserialization
         start_deserialize = time.time()
-        restored_workflow = self.serializer.from_dict(state)
+        restored_workflow = self.serializer.deserialize_json(state)
         end_deserialize = time.time()
         deserialize_time = end_deserialize - start_deserialize
 
@@ -119,13 +119,13 @@ class PerformanceTest(BpmnWorkflowTestCase):
 
         # Measure serialization
         start_serialize = time.time()
-        state = self.serializer.to_dict(workflow)
+        state = self.serializer.serialize_json(workflow)
         end_serialize = time.time()
         serialize_time = end_serialize - start_serialize
 
         # Measure deserialization
         start_deserialize = time.time()
-        restored_workflow = self.serializer.from_dict(state)
+        restored_workflow = self.serializer.deserialize_json(state)
         end_deserialize = time.time()
         deserialize_time = end_deserialize - start_deserialize
 
@@ -158,13 +158,13 @@ class PerformanceTest(BpmnWorkflowTestCase):
 
         # Measure serialization
         start_serialize = time.time()
-        state = self.serializer.to_dict(workflow)
+        state = self.serializer.serialize_json(workflow)
         end_serialize = time.time()
         serialize_time = end_serialize - start_serialize
 
         # Measure deserialization
         start_deserialize = time.time()
-        restored_workflow = self.serializer.from_dict(state)
+        restored_workflow = self.serializer.deserialize_json(state)
         end_deserialize = time.time()
         deserialize_time = end_deserialize - start_deserialize
 
@@ -197,13 +197,13 @@ class PerformanceTest(BpmnWorkflowTestCase):
 
         # Measure serialization
         start_serialize = time.time()
-        state = self.serializer.to_dict(workflow)
+        state = self.serializer.serialize_json(workflow)
         end_serialize = time.time()
         serialize_time = end_serialize - start_serialize
 
         # Measure deserialization
         start_deserialize = time.time()
-        restored_workflow = self.serializer.from_dict(state)
+        restored_workflow = self.serializer.deserialize_json(state)
         end_deserialize = time.time()
         deserialize_time = end_deserialize - start_deserialize
 
@@ -237,7 +237,7 @@ class PerformanceTest(BpmnWorkflowTestCase):
             # Serialize at checkpoints
             if tasks_completed % checkpoint_interval == 0:
                 start_serialize = time.time()
-                state = self.serializer.to_dict(workflow)
+                state = self.serializer.serialize_json(workflow)
                 end_serialize = time.time()
                 serialize_time = end_serialize - start_serialize
 


### PR DESCRIPTION
Instead of two passes (Python dict-building + json.dumps), serialize_json now uses a SpiffEncoder that lets the C-level JSON encoder handle plain data traversal natively, only calling back to Python for registered types.

Periodic serialization test (300 items, 180 serializations):

| Metric                         | Before   | After   | Improvement   |
|--------------------------------|----------|---------|---------------|
| Total time                     | 162.5s   | 45.0s   | 3.6x faster   |
| Total serialization            | 160.7s   | 43.3s   | 3.7x faster   |
| Avg per serialization          | 0.893s   | 0.241s  | 3.7x faster   |
| Final checkpoint (308 tasks)   | 2.07s    | 0.56s   | 3.7x faster   |