### PR TITLE
CI job to publish alpha build on merge to main

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -1,0 +1,60 @@
+name: Publish Alpha to PyPI 📦
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-alpha:
+    name: Build and publish alpha release to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Generate alpha version
+      id: version
+      run: |
+        # Extract current version from version.py
+        CURRENT_VERSION=$(grep -oP "__version__ = '\K[0-9.]+(?=')" SpiffWorkflow/version.py)
+
+        # Split version into major.minor.patch
+        MAJOR=$(echo $CURRENT_VERSION | cut -d. -f1)
+        MINOR=$(echo $CURRENT_VERSION | cut -d. -f2)
+        PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
+
+        # Increment patch version
+        NEXT_PATCH=$((PATCH + 1))
+
+        # Get short git SHA
+        GIT_SHA=$(git rev-parse --short HEAD)
+
+        # Generate alpha version: major.minor.(patch+1).alpha+gitsha
+        ALPHA_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}.alpha${GIT_SHA}"
+
+        echo "alpha_version=${ALPHA_VERSION}" >> $GITHUB_OUTPUT
+        echo "Generated alpha version: ${ALPHA_VERSION}"
+
+    - name: Update version.py with alpha version
+      run: |
+        echo "__version__ = '${{ steps.version.outputs.alpha_version }}'" > SpiffWorkflow/version.py
+        cat SpiffWorkflow/version.py
+
+    - name: Install pypa/build
+      run: python -m pip install build --user
+
+    - name: Build a binary wheel and a source tarball
+      run: python -m build --sdist --wheel --outdir dist/
+
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        username: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -34,11 +34,11 @@ jobs:
         # Increment patch version
         NEXT_PATCH=$((PATCH + 1))
 
-        # Get short git SHA
-        GIT_SHA=$(git rev-parse --short HEAD)
+        # Get timestamp for unique alpha version
+        TIMESTAMP=$(date +%s)
 
-        # Generate alpha version: major.minor.(patch+1).alpha+gitsha
-        ALPHA_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}.alpha${GIT_SHA}"
+        # Generate alpha version: major.minor.(patch+1)a<timestamp> (PEP 440 compliant, PyPI compatible)
+        ALPHA_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}a${TIMESTAMP}"
 
         echo "alpha_version=${ALPHA_VERSION}" >> $GITHUB_OUTPUT
         echo "Generated alpha version: ${ALPHA_VERSION}"

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - wf
 
 jobs:
   publish-alpha:

--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - wf
 
 jobs:
   publish-alpha:


### PR DESCRIPTION
Test run succeeded - https://pypi.org/project/SpiffWorkflow/#history

This takes some of the burden off of making an alpha release, which are helpful for testing changes in ed or example, which needs to pull packages from pypi. Each merge gets a pypi version of __version__ with a patch of +1 + a<timestamp>. Just one less thing to do manually.