### PR TITLE
Sanity check pypi push on prs

### DIFF
--- a/.github/workflows/publish-alpha.yml
+++ b/.github/workflows/publish-alpha.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   publish-alpha:
@@ -54,6 +57,7 @@ jobs:
       run: python -m build --sdist --wheel --outdir dist/
 
     - name: Publish distribution 📦 to PyPI
+      if: github.ref == 'refs/heads/main'
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         username: __token__


### PR DESCRIPTION
Previous this only ran after merge, so if there was going to be an issue building the package we didn't see it until after the pr. This runs everything but the actual push to pypi during the pr itself.