### PR TITLE
Add compact BPMN workflow and spec serializers

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,17 +16,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install ruff
-          pip install .
-#      - name: Lint with ruff
-#        run: |
-          # stop the build if there are Python syntax errors or undefined names
-#          ruff --format=github --select=E9,F63,F7,F82 --target-version=py37 .
-          # default set of ruff rules with GitHub Annotations
- #         ruff --format=github --target-version=py37 .
+          uv sync --extra dev
       - name: Run tests
         run: |
-          python -m unittest discover -v -s ./tests/SpiffWorkflow/ -p *Test.py
+          make RUN='uv run' tests
+          make RUN='uv run' tests-compact

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,15 @@ doc:
 tests:
 	$(RUN) python -m unittest discover -vs tests/SpiffWorkflow -p \*Test.py -t .
 
+.PHONY : tests-compact
+tests-compact:
+	SPIFFWORKFLOW_SERIALIZER=compact $(RUN) python -m unittest discover -vs tests/SpiffWorkflow -p \*Test.py -t .
+
+.PHONY : tests-dual
+tests-dual:
+	$(MAKE) tests RUN='$(RUN)'
+	$(MAKE) tests-compact RUN='$(RUN)'
+
 .PHONY : tests-par
 tests-par:
 	@if ! $(RUN) unittest-parallel --help >/dev/null 2>&1; then \

--- a/SpiffWorkflow/bpmn/serializer/__init__.py
+++ b/SpiffWorkflow/bpmn/serializer/__init__.py
@@ -18,5 +18,6 @@
 # 02110-1301  USA
 
 from .workflow import BpmnWorkflowSerializer
+from .compact import CompactBpmnWorkflowSerializer
 from .config import DEFAULT_CONFIG
 from .helpers import DefaultRegistry

--- a/SpiffWorkflow/bpmn/serializer/__init__.py
+++ b/SpiffWorkflow/bpmn/serializer/__init__.py
@@ -19,5 +19,6 @@
 
 from .workflow import BpmnWorkflowSerializer
 from .compact import CompactBpmnWorkflowSerializer
+from .spec import BpmnSpecSerializer
 from .config import DEFAULT_CONFIG
 from .helpers import DefaultRegistry

--- a/SpiffWorkflow/bpmn/serializer/compact.py
+++ b/SpiffWorkflow/bpmn/serializer/compact.py
@@ -1,0 +1,366 @@
+import gzip
+import json
+
+from .workflow import BpmnWorkflowSerializer, VERSION as CANONICAL_VERSION
+
+
+COMPACT_VERSION = "c1"
+
+FORMAT_KEY = "serialization_format"
+FORMAT_VALUE = "compact_bpmn_workflow"
+TYPENAME_TABLE_KEY = "typename_table"
+
+KEY_ALIASES = {
+    "serializer_version": "~v",
+    "serialization_format": "~f",
+    "typename_table": "~tt",
+    "spec": "~s",
+    "subprocess_specs": "~ps",
+    "subprocesses": "~sp",
+    "bpmn_events": "~be",
+    "correlations": "~cr",
+    "completed": "~c",
+    "success": "~su",
+    "last_task": "~lt",
+    "root": "~r",
+    "tasks": "~t",
+    "data": "~d",
+    "typename": "~y",
+    "name": "~n",
+    "description": "~x",
+    "file": "~f1",
+    "task_specs": "~ts",
+    "data_objects": "~do",
+    "correlation_keys": "~ck",
+    "manual": "~m",
+    "lookahead": "~l",
+    "inputs": "~i",
+    "outputs": "~o",
+    "bpmn_id": "~bi",
+    "bpmn_name": "~bn",
+    "lane": "~ln",
+    "documentation": "~doc",
+    "data_input_associations": "~dia",
+    "data_output_associations": "~doa",
+    "io_specification": "~io",
+    "extensions": "~e",
+    "event_definition": "~ed",
+    "cond_task_specs": "~cts",
+    "default_task_spec": "~dt",
+    "task_spec": "~tk",
+    "triggered": "~tr",
+    "internal_data": "~ind",
+    "parent": "~p",
+    "children": "~ch",
+    "last_state_change": "~lc",
+    "delta": "~dl",
+    "updates": "~up",
+    "deletions": "~de",
+    "operation_params": "~op",
+    "split_task": "~st",
+    "threshold": "~th",
+    "cancel": "~ca",
+    "choice": "~ci",
+    "condition": "~co",
+    "script": "~sc",
+    "prescript": "~pre",
+    "postscript": "~post",
+    "cardinality": "~card",
+    "data_input": "~din",
+    "data_output": "~dout",
+    "input_item": "~iin",
+    "output_item": "~iout",
+    "maximum": "~max",
+    "test_before": "~tb",
+    "cancel_activity": "~cact",
+}
+REVERSE_KEY_ALIASES = {value: key for key, value in KEY_ALIASES.items()}
+
+DEFAULT_TASK_DESCRIPTIONS = {
+    "BpmnStartTask": "BPMN Task",
+    "_EndJoin": "BPMN Task",
+    "SimpleBpmnTask": "BPMN Task",
+    "ExclusiveGateway": "Exclusive Gateway",
+    "UserTask": "User Task",
+    "ScriptTask": "Script Task",
+    "EndEvent": "Default End Event",
+    "StartEvent": "Default Start Event",
+    "SubWorkflowTask": "Subprocess",
+    "CallActivity": "Call Activity",
+    "ManualTask": "Manual Task",
+    "StandardLoopTask": "Loop Task",
+    "SequentialMultiInstanceTask": "Sequential MultiInstance",
+    "ParallelMultiInstanceTask": "Parallel MultiInstance",
+    "InclusiveGateway": "Inclusive Gateway",
+    "ParallelGateway": "Parallel Gateway",
+    "ServiceTask": "Service Task",
+    "NoneTask": "Simple Task",
+    "IntermediateThrowEvent": "Intermediate Throw Event",
+    "BoundaryEvent": "Boundary Event",
+}
+
+
+class CompactBpmnWorkflowSerializer:
+    VERSION_KEY = "serializer_version"
+
+    @staticmethod
+    def configure(config=None, registry=None):
+        return BpmnWorkflowSerializer.configure(config=config, registry=registry)
+
+    def __init__(
+        self,
+        registry=None,
+        version=COMPACT_VERSION,
+        canonical_version=CANONICAL_VERSION,
+        json_encoder_cls=None,
+        json_decoder_cls=None,
+    ):
+        self.VERSION = version
+        self.canonical = BpmnWorkflowSerializer(
+            registry=registry,
+            version=canonical_version,
+            json_encoder_cls=json_encoder_cls,
+            json_decoder_cls=json_decoder_cls,
+        )
+        self.registry = self.canonical.registry
+        self.json_encoder_cls = json_encoder_cls
+        self.json_decoder_cls = json_decoder_cls
+        self._typenames = []
+        self._typename_to_index = {}
+
+    def _alias_key(self, key):
+        return KEY_ALIASES.get(key, key)
+
+    def _unalias_key(self, key):
+        return REVERSE_KEY_ALIASES.get(key, key)
+
+    def _intern_typename(self, typename):
+        if typename not in self._typename_to_index:
+            self._typename_to_index[typename] = len(self._typenames)
+            self._typenames.append(typename)
+        return self._typename_to_index[typename]
+
+    def _compact_generic(self, value):
+        if isinstance(value, dict):
+            compact = {}
+            for key, child in value.items():
+                alias = self._alias_key(key)
+                if key == "typename":
+                    compact[alias] = self._intern_typename(child)
+                else:
+                    compact[alias] = self._compact_generic(child)
+            return compact
+        if isinstance(value, list):
+            return [self._compact_generic(item) for item in value]
+        return value
+
+    def _expand_generic(self, value, type_table):
+        if isinstance(value, dict):
+            expanded = {}
+            for key, child in value.items():
+                name = self._unalias_key(key)
+                if name == "typename" and isinstance(child, int):
+                    expanded[name] = type_table[child]
+                else:
+                    expanded[name] = self._expand_generic(child, type_table)
+            return expanded
+        if isinstance(value, list):
+            return [self._expand_generic(item, type_table) for item in value]
+        return value
+
+    def _compact_task_spec(self, task_key, task):
+        compact = {}
+        typename = task["typename"]
+        for key, value in task.items():
+            if key == "name" and value == task_key:
+                continue
+            if key == "description" and DEFAULT_TASK_DESCRIPTIONS.get(typename) == value:
+                continue
+            if key == "manual" and value is False:
+                continue
+            if key == "lookahead" and value == 2:
+                continue
+            if key in {"lane", "documentation", "io_specification", "bpmn_id", "bpmn_name", "prescript", "postscript", "choice"} and value is None:
+                continue
+            if key in {"data_input_associations", "data_output_associations"} and value == []:
+                continue
+            if key == "extensions" and value == {}:
+                continue
+            alias = self._alias_key(key)
+            if key == "typename":
+                compact[alias] = self._intern_typename(value)
+            else:
+                compact[alias] = self._compact_generic(value)
+        return compact
+
+    def _expand_task_spec(self, task_key, task, type_table):
+        expanded = self._expand_generic(task, type_table)
+        typename = expanded["typename"]
+        expanded.setdefault("name", task_key)
+        expanded.setdefault("description", DEFAULT_TASK_DESCRIPTIONS.get(typename))
+        expanded.setdefault("manual", False)
+        expanded.setdefault("lookahead", 2)
+        expanded.setdefault("inputs", [])
+        expanded.setdefault("outputs", [])
+        expanded.setdefault("bpmn_id", None)
+        expanded.setdefault("bpmn_name", None)
+        expanded.setdefault("lane", None)
+        expanded.setdefault("documentation", None)
+        expanded.setdefault("data_input_associations", [])
+        expanded.setdefault("data_output_associations", [])
+        expanded.setdefault("io_specification", None)
+        if "extensions" not in expanded and typename not in {"BpmnStartTask", "_EndJoin", "SimpleBpmnTask"}:
+            expanded["extensions"] = {}
+        return expanded
+
+    def _compact_process_spec(self, spec_key, spec):
+        compact = {}
+        for key, value in spec.items():
+            if key == "name" and spec_key is not None and value == spec_key:
+                continue
+            if key == "description" and value == spec["name"]:
+                continue
+            if key == "task_specs":
+                compact[self._alias_key(key)] = {
+                    task_key: self._compact_task_spec(task_key, task)
+                    for task_key, task in value.items()
+                }
+                continue
+            if key == "io_specification" and value is None:
+                continue
+            if key in {"data_objects", "correlation_keys"} and value == {}:
+                continue
+            alias = self._alias_key(key)
+            if key == "typename":
+                compact[alias] = self._intern_typename(value)
+            else:
+                compact[alias] = self._compact_generic(value)
+        return compact
+
+    def _expand_process_spec(self, spec_key, spec, type_table):
+        expanded = self._expand_generic(spec, type_table)
+        expanded.setdefault("name", spec_key)
+        expanded.setdefault("description", expanded["name"])
+        expanded.setdefault("io_specification", None)
+        expanded.setdefault("data_objects", {})
+        expanded.setdefault("correlation_keys", {})
+        task_specs = expanded.get("task_specs", {})
+        expanded["task_specs"] = {
+            task_key: self._expand_task_spec(task_key, task, type_table)
+            for task_key, task in task_specs.items()
+        }
+        return expanded
+
+    def _compact_runtime_task(self, task):
+        compact = {}
+        for key, value in task.items():
+            if key == "triggered" and value is False:
+                continue
+            if key == "parent" and value is None:
+                continue
+            if key in {"data", "internal_data"} and value == {}:
+                continue
+            if key == "children" and value == []:
+                continue
+            alias = self._alias_key(key)
+            compact[alias] = self._compact_generic(value)
+        return compact
+
+    def _expand_runtime_task(self, task, type_table):
+        expanded = self._expand_generic(task, type_table)
+        expanded.setdefault("parent", None)
+        expanded.setdefault("children", [])
+        expanded.setdefault("triggered", False)
+        expanded.setdefault("internal_data", {})
+        expanded.setdefault("data", {})
+        return expanded
+
+    def canonical_to_compact(self, dct):
+        self._typenames = []
+        self._typename_to_index = {}
+
+        compact = {
+            self._alias_key(FORMAT_KEY): FORMAT_VALUE,
+            self._alias_key(TYPENAME_TABLE_KEY): self._typenames,
+        }
+        for key, value in dct.items():
+            if key == "spec":
+                compact[self._alias_key(key)] = self._compact_process_spec(None, value)
+            elif key == "subprocess_specs":
+                compact[self._alias_key(key)] = {
+                    spec_key: self._compact_process_spec(spec_key, spec)
+                    for spec_key, spec in value.items()
+                }
+            elif key == "tasks":
+                compact[self._alias_key(key)] = {
+                    task_id: self._compact_runtime_task(task)
+                    for task_id, task in value.items()
+                }
+            elif key == "success" and value is False:
+                continue
+            elif key == "completed" and value is False:
+                continue
+            elif key == "last_task" and value is None:
+                continue
+            elif key in {"data", "correlations", "subprocesses", "bpmn_events"} and value in ({}, []):
+                continue
+            else:
+                compact[self._alias_key(key)] = self._compact_generic(value)
+        return compact
+
+    def compact_to_canonical(self, dct):
+        type_table = dct.pop(self._alias_key(TYPENAME_TABLE_KEY), [])
+        dct.pop(self._alias_key(FORMAT_KEY), None)
+        expanded = {}
+        for key, value in dct.items():
+            name = self._unalias_key(key)
+            if name == "spec":
+                expanded[name] = self._expand_process_spec(None, value, type_table)
+            elif name == "subprocess_specs":
+                expanded[name] = {
+                    spec_key: self._expand_process_spec(spec_key, spec, type_table)
+                    for spec_key, spec in self._expand_generic(value, type_table).items()
+                }
+            elif name == "tasks":
+                expanded[name] = {
+                    task_id: self._expand_runtime_task(task, type_table)
+                    for task_id, task in self._expand_generic(value, type_table).items()
+                }
+            else:
+                expanded[name] = self._expand_generic(value, type_table)
+
+        expanded.setdefault("data", {})
+        expanded.setdefault("correlations", {})
+        expanded.setdefault("last_task", None)
+        expanded.setdefault("success", False)
+        expanded.setdefault("completed", False)
+        expanded.setdefault("subprocesses", {})
+        expanded.setdefault("bpmn_events", [])
+        return expanded
+
+    def to_dict(self, workflow):
+        canonical = self.canonical.to_dict(workflow)
+        return self.canonical_to_compact(canonical)
+
+    def from_dict(self, dct):
+        canonical = self.compact_to_canonical(dict(dct))
+        return self.canonical.from_dict(canonical)
+
+    def serialize_json(self, workflow, use_gzip=False):
+        dct = self.to_dict(workflow)
+        dct[self._alias_key(self.VERSION_KEY)] = self.VERSION
+        json_str = json.dumps(dct, separators=(",", ":"), cls=self.canonical._encoder_cls)
+        return gzip.compress(json_str.encode("utf-8")) if use_gzip else json_str
+
+    def deserialize_json(self, serialization, use_gzip=False):
+        json_str = gzip.decompress(serialization) if use_gzip else serialization
+        dct = json.loads(json_str, cls=self.json_decoder_cls)
+        dct.pop(self._alias_key(self.VERSION_KEY), None)
+        return self.from_dict(dct)
+
+    def get_version(self, serialization):
+        if isinstance(serialization, dict):
+            return serialization.get(self._alias_key(self.VERSION_KEY))
+        if isinstance(serialization, str):
+            dct = json.loads(serialization, cls=self.json_decoder_cls)
+            return dct.get(self._alias_key(self.VERSION_KEY))

--- a/SpiffWorkflow/bpmn/serializer/compact.py
+++ b/SpiffWorkflow/bpmn/serializer/compact.py
@@ -4,16 +4,18 @@ import json
 from .workflow import BpmnWorkflowSerializer, VERSION as CANONICAL_VERSION
 
 
-COMPACT_VERSION = "c1"
+COMPACT_VERSION = "c2"
 
 FORMAT_KEY = "serialization_format"
 FORMAT_VALUE = "compact_bpmn_workflow"
 TYPENAME_TABLE_KEY = "typename_table"
+STRING_TABLE_KEY = "string_table"
 
 KEY_ALIASES = {
     "serializer_version": "~v",
     "serialization_format": "~f",
     "typename_table": "~tt",
+    "string_table": "~st",
     "spec": "~s",
     "subprocess_specs": "~ps",
     "subprocesses": "~sp",
@@ -99,6 +101,27 @@ DEFAULT_TASK_DESCRIPTIONS = {
     "BoundaryEvent": "Boundary Event",
 }
 
+STRING_REF_FIELDS = {
+    "name",
+    "file",
+    "task_spec",
+    "bpmn_id",
+    "bpmn_name",
+    "spec",
+    "default_task_spec",
+    "split_task",
+    "parent",
+    "id",
+    "root",
+    "last_task",
+}
+
+STRING_LIST_FIELDS = {
+    "inputs",
+    "outputs",
+    "children",
+}
+
 
 class CompactBpmnWorkflowSerializer:
     VERSION_KEY = "serializer_version"
@@ -127,6 +150,8 @@ class CompactBpmnWorkflowSerializer:
         self.json_decoder_cls = json_decoder_cls
         self._typenames = []
         self._typename_to_index = {}
+        self._strings = []
+        self._string_to_index = {}
 
     def _alias_key(self, key):
         return KEY_ALIASES.get(key, key)
@@ -139,6 +164,12 @@ class CompactBpmnWorkflowSerializer:
             self._typename_to_index[typename] = len(self._typenames)
             self._typenames.append(typename)
         return self._typename_to_index[typename]
+
+    def _intern_string(self, value):
+        if value not in self._string_to_index:
+            self._string_to_index[value] = len(self._strings)
+            self._strings.append(value)
+        return self._string_to_index[value]
 
     def _compact_generic(self, value):
         if isinstance(value, dict):
@@ -154,6 +185,17 @@ class CompactBpmnWorkflowSerializer:
             return [self._compact_generic(item) for item in value]
         return value
 
+    def _compact_schema_value(self, key, value):
+        if isinstance(value, str) and key in STRING_REF_FIELDS:
+            return self._intern_string(value)
+        if (
+            isinstance(value, list)
+            and key in STRING_LIST_FIELDS
+            and all(isinstance(item, str) for item in value)
+        ):
+            return [self._intern_string(item) for item in value]
+        return self._compact_generic(value)
+
     def _expand_generic(self, value, type_table):
         if isinstance(value, dict):
             expanded = {}
@@ -167,6 +209,17 @@ class CompactBpmnWorkflowSerializer:
         if isinstance(value, list):
             return [self._expand_generic(item, type_table) for item in value]
         return value
+
+    def _expand_schema_value(self, key, value, type_table, string_table):
+        if isinstance(value, int) and key in STRING_REF_FIELDS:
+            return string_table[value]
+        if (
+            isinstance(value, list)
+            and key in STRING_LIST_FIELDS
+            and all(isinstance(item, int) for item in value)
+        ):
+            return [string_table[item] for item in value]
+        return self._expand_generic(value, type_table)
 
     def _compact_task_spec(self, task_key, task):
         compact = {}
@@ -190,11 +243,17 @@ class CompactBpmnWorkflowSerializer:
             if key == "typename":
                 compact[alias] = self._intern_typename(value)
             else:
-                compact[alias] = self._compact_generic(value)
+                compact[alias] = self._compact_schema_value(key, value)
         return compact
 
-    def _expand_task_spec(self, task_key, task, type_table):
-        expanded = self._expand_generic(task, type_table)
+    def _expand_task_spec(self, task_key, task, type_table, string_table):
+        expanded = {}
+        for key, value in task.items():
+            logical_key = self._unalias_key(key)
+            if logical_key == "typename" and isinstance(value, int):
+                expanded[logical_key] = type_table[value]
+            else:
+                expanded[logical_key] = self._expand_schema_value(logical_key, value, type_table, string_table)
         typename = expanded["typename"]
         expanded.setdefault("name", task_key)
         expanded.setdefault("description", DEFAULT_TASK_DESCRIPTIONS.get(typename))
@@ -222,7 +281,7 @@ class CompactBpmnWorkflowSerializer:
                 continue
             if key == "task_specs":
                 compact[self._alias_key(key)] = {
-                    task_key: self._compact_task_spec(task_key, task)
+                    str(self._intern_string(task_key)): self._compact_task_spec(task_key, task)
                     for task_key, task in value.items()
                 }
                 continue
@@ -234,21 +293,27 @@ class CompactBpmnWorkflowSerializer:
             if key == "typename":
                 compact[alias] = self._intern_typename(value)
             else:
-                compact[alias] = self._compact_generic(value)
+                compact[alias] = self._compact_schema_value(key, value)
         return compact
 
-    def _expand_process_spec(self, spec_key, spec, type_table):
-        expanded = self._expand_generic(spec, type_table)
+    def _expand_process_spec(self, spec_key, spec, type_table, string_table):
+        expanded = {}
+        for key, value in spec.items():
+            logical_key = self._unalias_key(key)
+            if logical_key == "typename" and isinstance(value, int):
+                expanded[logical_key] = type_table[value]
+            elif logical_key == "task_specs":
+                expanded[logical_key] = {
+                    string_table[int(task_key)]: self._expand_task_spec(string_table[int(task_key)], task, type_table, string_table)
+                    for task_key, task in value.items()
+                }
+            else:
+                expanded[logical_key] = self._expand_schema_value(logical_key, value, type_table, string_table)
         expanded.setdefault("name", spec_key)
         expanded.setdefault("description", expanded["name"])
         expanded.setdefault("io_specification", None)
         expanded.setdefault("data_objects", {})
         expanded.setdefault("correlation_keys", {})
-        task_specs = expanded.get("task_specs", {})
-        expanded["task_specs"] = {
-            task_key: self._expand_task_spec(task_key, task, type_table)
-            for task_key, task in task_specs.items()
-        }
         return expanded
 
     def _compact_runtime_task(self, task):
@@ -263,11 +328,14 @@ class CompactBpmnWorkflowSerializer:
             if key == "children" and value == []:
                 continue
             alias = self._alias_key(key)
-            compact[alias] = self._compact_generic(value)
+            compact[alias] = self._compact_schema_value(key, value)
         return compact
 
-    def _expand_runtime_task(self, task, type_table):
-        expanded = self._expand_generic(task, type_table)
+    def _expand_runtime_task(self, task, type_table, string_table):
+        expanded = {}
+        for key, value in task.items():
+            logical_key = self._unalias_key(key)
+            expanded[logical_key] = self._expand_schema_value(logical_key, value, type_table, string_table)
         expanded.setdefault("parent", None)
         expanded.setdefault("children", [])
         expanded.setdefault("triggered", False)
@@ -278,22 +346,25 @@ class CompactBpmnWorkflowSerializer:
     def canonical_to_compact(self, dct):
         self._typenames = []
         self._typename_to_index = {}
+        self._strings = []
+        self._string_to_index = {}
 
         compact = {
             self._alias_key(FORMAT_KEY): FORMAT_VALUE,
             self._alias_key(TYPENAME_TABLE_KEY): self._typenames,
+            self._alias_key(STRING_TABLE_KEY): self._strings,
         }
         for key, value in dct.items():
             if key == "spec":
                 compact[self._alias_key(key)] = self._compact_process_spec(None, value)
             elif key == "subprocess_specs":
                 compact[self._alias_key(key)] = {
-                    spec_key: self._compact_process_spec(spec_key, spec)
+                    str(self._intern_string(spec_key)): self._compact_process_spec(spec_key, spec)
                     for spec_key, spec in value.items()
                 }
             elif key == "tasks":
                 compact[self._alias_key(key)] = {
-                    task_id: self._compact_runtime_task(task)
+                    str(self._intern_string(task_id)): self._compact_runtime_task(task)
                     for task_id, task in value.items()
                 }
             elif key == "success" and value is False:
@@ -305,29 +376,30 @@ class CompactBpmnWorkflowSerializer:
             elif key in {"data", "correlations", "subprocesses", "bpmn_events"} and value in ({}, []):
                 continue
             else:
-                compact[self._alias_key(key)] = self._compact_generic(value)
+                compact[self._alias_key(key)] = self._compact_schema_value(key, value)
         return compact
 
     def compact_to_canonical(self, dct):
         type_table = dct.pop(self._alias_key(TYPENAME_TABLE_KEY), [])
+        string_table = dct.pop(self._alias_key(STRING_TABLE_KEY), [])
         dct.pop(self._alias_key(FORMAT_KEY), None)
         expanded = {}
         for key, value in dct.items():
             name = self._unalias_key(key)
             if name == "spec":
-                expanded[name] = self._expand_process_spec(None, value, type_table)
+                expanded[name] = self._expand_process_spec(None, value, type_table, string_table)
             elif name == "subprocess_specs":
                 expanded[name] = {
-                    spec_key: self._expand_process_spec(spec_key, spec, type_table)
-                    for spec_key, spec in self._expand_generic(value, type_table).items()
+                    string_table[int(spec_key)]: self._expand_process_spec(string_table[int(spec_key)], spec, type_table, string_table)
+                    for spec_key, spec in value.items()
                 }
             elif name == "tasks":
                 expanded[name] = {
-                    task_id: self._expand_runtime_task(task, type_table)
-                    for task_id, task in self._expand_generic(value, type_table).items()
+                    string_table[int(task_id)]: self._expand_runtime_task(task, type_table, string_table)
+                    for task_id, task in value.items()
                 }
             else:
-                expanded[name] = self._expand_generic(value, type_table)
+                expanded[name] = self._expand_schema_value(name, value, type_table, string_table)
 
         expanded.setdefault("data", {})
         expanded.setdefault("correlations", {})

--- a/SpiffWorkflow/bpmn/serializer/compact.py
+++ b/SpiffWorkflow/bpmn/serializer/compact.py
@@ -16,6 +16,8 @@ KEY_ALIASES = {
     "serialization_format": "~f",
     "typename_table": "~tt",
     "string_table": "~st",
+    "process_table": "~pt",
+    "root_process": "~rt",
     "spec": "~s",
     "subprocess_specs": "~ps",
     "subprocesses": "~sp",

--- a/SpiffWorkflow/bpmn/serializer/spec.py
+++ b/SpiffWorkflow/bpmn/serializer/spec.py
@@ -250,6 +250,7 @@ class BpmnSpecSerializer:
                 expanded[logical_key] = self._expand_schema_value(logical_key, value, type_table, string_table)
         expanded.setdefault("name", spec_key)
         expanded.setdefault("description", expanded["name"])
+        expanded.setdefault("file", None)
         expanded.setdefault("io_specification", None)
         expanded.setdefault("data_objects", {})
         expanded.setdefault("correlation_keys", {})

--- a/SpiffWorkflow/bpmn/serializer/spec.py
+++ b/SpiffWorkflow/bpmn/serializer/spec.py
@@ -17,6 +17,8 @@ from .compact import (
 
 
 FORMAT_VALUE = "compact_bpmn_spec"
+PROCESS_TABLE_KEY = "process_table"
+ROOT_PROCESS_KEY = "root_process"
 
 
 class BpmnSpecSerializer:
@@ -118,10 +120,16 @@ class BpmnSpecSerializer:
         return self._expand_generic(value, type_table)
 
     def _compact_task_spec(self, task_key, task):
-        compact = {}
         typename = task["typename"]
+        extras = {}
         for key, value in task.items():
             if key == "name" and value == task_key:
+                continue
+            if key == "typename":
+                continue
+            if key == "inputs":
+                continue
+            if key == "outputs":
                 continue
             if key == "description" and DEFAULT_TASK_DESCRIPTIONS.get(typename) == value:
                 continue
@@ -145,22 +153,37 @@ class BpmnSpecSerializer:
             if key == "extensions" and value == {}:
                 continue
             alias = self._alias_key(key)
-            if key == "typename":
-                compact[alias] = self._intern_typename(value)
-            else:
-                compact[alias] = self._compact_schema_value(key, value)
-        return compact
+            extras[alias] = self._compact_schema_value(key, value)
 
-    def _expand_task_spec(self, task_key, task, type_table, string_table):
-        expanded = {}
-        for key, value in task.items():
-            logical_key = self._unalias_key(key)
-            if logical_key == "typename" and isinstance(value, int):
-                expanded[logical_key] = type_table[value]
-            else:
+        row = [
+            self._intern_string(task_key),
+            self._intern_typename(typename),
+        ]
+        inputs = [self._intern_string(item) for item in task.get("inputs", [])]
+        outputs = [self._intern_string(item) for item in task.get("outputs", [])]
+        if inputs or outputs or extras:
+            row.append(inputs)
+        if outputs or extras:
+            row.append(outputs)
+        if extras:
+            row.append(extras)
+        return row
+
+    def _expand_task_spec(self, row, type_table, string_table):
+        task_key = string_table[row[0]]
+        expanded = {
+            "name": task_key,
+            "typename": type_table[row[1]],
+        }
+        if len(row) > 2:
+            expanded["inputs"] = [string_table[item] for item in row[2]]
+        if len(row) > 3:
+            expanded["outputs"] = [string_table[item] for item in row[3]]
+        if len(row) > 4:
+            for key, value in row[4].items():
+                logical_key = self._unalias_key(key)
                 expanded[logical_key] = self._expand_schema_value(logical_key, value, type_table, string_table)
         typename = expanded["typename"]
-        expanded.setdefault("name", task_key)
         expanded.setdefault("description", DEFAULT_TASK_DESCRIPTIONS.get(typename))
         expanded.setdefault("manual", False)
         expanded.setdefault("lookahead", 2)
@@ -178,43 +201,52 @@ class BpmnSpecSerializer:
         return expanded
 
     def _compact_process_spec(self, spec_key, spec):
-        compact = {}
+        tasks = []
+        extras = {}
         for key, value in spec.items():
-            if key == "name" and spec_key is not None and value == spec_key:
+            if key == "name":
                 continue
             if key == "description" and value == spec["name"]:
                 continue
+            if key == "file":
+                continue
             if key == "task_specs":
-                compact[self._alias_key(key)] = {
-                    str(self._intern_string(task_key)): self._compact_task_spec(task_key, task)
+                tasks = [
+                    self._compact_task_spec(task_key, task)
                     for task_key, task in value.items()
-                }
+                ]
                 continue
             if key == "io_specification" and value is None:
                 continue
             if key in {"data_objects", "correlation_keys"} and value == {}:
                 continue
-            alias = self._alias_key(key)
-            if key == "typename":
-                compact[alias] = self._intern_typename(value)
-            else:
-                compact[alias] = self._compact_schema_value(key, value)
-        return compact
+            if key == "typename" and value == "BpmnProcessSpec":
+                continue
+            extras[self._alias_key(key)] = self._compact_schema_value(key, value)
 
-    def _expand_process_spec(self, spec_key, spec, type_table, string_table):
-        expanded = {}
-        for key, value in spec.items():
-            logical_key = self._unalias_key(key)
-            if logical_key == "typename" and isinstance(value, int):
-                expanded[logical_key] = type_table[value]
-            elif logical_key == "task_specs":
-                expanded[logical_key] = {
-                    string_table[int(task_key)]: self._expand_task_spec(
-                        string_table[int(task_key)], task, type_table, string_table
-                    )
-                    for task_key, task in value.items()
-                }
-            else:
+        file_ref = self._intern_string(spec["file"]) if spec.get("file") is not None else None
+        row = [file_ref, tasks]
+        if extras:
+            row.append(extras)
+        return row
+
+    def _expand_process_spec(self, spec_key, row, type_table, string_table):
+        expanded = {
+            "name": spec_key,
+            "typename": "BpmnProcessSpec",
+        }
+        if row[0] is not None:
+            expanded["file"] = string_table[row[0]]
+        expanded["task_specs"] = {
+            task["name"]: task
+            for task in (
+                self._expand_task_spec(task_row, type_table, string_table)
+                for task_row in row[1]
+            )
+        }
+        if len(row) > 2:
+            for key, value in row[2].items():
+                logical_key = self._unalias_key(key)
                 expanded[logical_key] = self._expand_schema_value(logical_key, value, type_table, string_table)
         expanded.setdefault("name", spec_key)
         expanded.setdefault("description", expanded["name"])
@@ -240,25 +272,28 @@ class BpmnSpecSerializer:
             self._alias_key(FORMAT_KEY): FORMAT_VALUE,
             self._alias_key(TYPENAME_TABLE_KEY): self._typenames,
             self._alias_key(STRING_TABLE_KEY): self._strings,
-            self._alias_key("spec"): self._compact_process_spec(None, dct["spec"]),
-            self._alias_key("subprocess_specs"): {
-                str(self._intern_string(spec_key)): self._compact_process_spec(spec_key, spec)
-                for spec_key, spec in dct["subprocess_specs"].items()
-            },
+            self._alias_key(ROOT_PROCESS_KEY): self._intern_string(dct["spec"]["name"]),
+            self._alias_key(PROCESS_TABLE_KEY): {},
         }
+        process_table = compact[self._alias_key(PROCESS_TABLE_KEY)]
+        process_table[str(self._intern_string(dct["spec"]["name"]))] = self._compact_process_spec(None, dct["spec"])
+        for spec_key, spec in dct["subprocess_specs"].items():
+            process_table[str(self._intern_string(spec_key))] = self._compact_process_spec(spec_key, spec)
         return compact
 
     def compact_to_canonical(self, dct):
         type_table = dct.pop(self._alias_key(TYPENAME_TABLE_KEY), [])
         string_table = dct.pop(self._alias_key(STRING_TABLE_KEY), [])
         dct.pop(self._alias_key(FORMAT_KEY), None)
+        root_process_ref = dct.pop(self._alias_key(ROOT_PROCESS_KEY))
+        root_process_key = string_table[root_process_ref]
+        process_table = dct.pop(self._alias_key(PROCESS_TABLE_KEY), {})
         return {
-            "spec": self._expand_process_spec(None, dct[self._alias_key("spec")], type_table, string_table),
+            "spec": self._expand_process_spec(root_process_key, process_table[str(root_process_ref)], type_table, string_table),
             "subprocess_specs": {
-                string_table[int(spec_key)]: self._expand_process_spec(
-                    string_table[int(spec_key)], spec, type_table, string_table
-                )
-                for spec_key, spec in dct.get(self._alias_key("subprocess_specs"), {}).items()
+                string_table[int(spec_key)]: self._expand_process_spec(string_table[int(spec_key)], spec, type_table, string_table)
+                for spec_key, spec in process_table.items()
+                if string_table[int(spec_key)] != root_process_key
             },
         }
 

--- a/SpiffWorkflow/bpmn/serializer/spec.py
+++ b/SpiffWorkflow/bpmn/serializer/spec.py
@@ -1,0 +1,288 @@
+import gzip
+import json
+
+from .workflow import BpmnWorkflowSerializer
+from .compact import (
+    CANONICAL_VERSION,
+    COMPACT_VERSION,
+    DEFAULT_TASK_DESCRIPTIONS,
+    FORMAT_KEY,
+    KEY_ALIASES,
+    REVERSE_KEY_ALIASES,
+    STRING_LIST_FIELDS,
+    STRING_REF_FIELDS,
+    STRING_TABLE_KEY,
+    TYPENAME_TABLE_KEY,
+)
+
+
+FORMAT_VALUE = "compact_bpmn_spec"
+
+
+class BpmnSpecSerializer:
+    VERSION_KEY = "serializer_version"
+
+    @staticmethod
+    def configure(config=None, registry=None):
+        return BpmnWorkflowSerializer.configure(config=config, registry=registry)
+
+    def __init__(
+        self,
+        registry=None,
+        version=COMPACT_VERSION,
+        canonical_version=CANONICAL_VERSION,
+        json_encoder_cls=None,
+        json_decoder_cls=None,
+    ):
+        self.VERSION = version
+        self.canonical = BpmnWorkflowSerializer(
+            registry=registry,
+            version=canonical_version,
+            json_encoder_cls=json_encoder_cls,
+            json_decoder_cls=json_decoder_cls,
+        )
+        self.registry = self.canonical.registry
+        self.json_encoder_cls = json_encoder_cls
+        self.json_decoder_cls = json_decoder_cls
+        self._typenames = []
+        self._typename_to_index = {}
+        self._strings = []
+        self._string_to_index = {}
+
+    def _alias_key(self, key):
+        return KEY_ALIASES.get(key, key)
+
+    def _unalias_key(self, key):
+        return REVERSE_KEY_ALIASES.get(key, key)
+
+    def _intern_typename(self, typename):
+        if typename not in self._typename_to_index:
+            self._typename_to_index[typename] = len(self._typenames)
+            self._typenames.append(typename)
+        return self._typename_to_index[typename]
+
+    def _intern_string(self, value):
+        if value not in self._string_to_index:
+            self._string_to_index[value] = len(self._strings)
+            self._strings.append(value)
+        return self._string_to_index[value]
+
+    def _compact_generic(self, value):
+        if isinstance(value, dict):
+            compact = {}
+            for key, child in value.items():
+                alias = self._alias_key(key)
+                if key == "typename":
+                    compact[alias] = self._intern_typename(child)
+                else:
+                    compact[alias] = self._compact_generic(child)
+            return compact
+        if isinstance(value, list):
+            return [self._compact_generic(item) for item in value]
+        return value
+
+    def _compact_schema_value(self, key, value):
+        if isinstance(value, str) and key in STRING_REF_FIELDS:
+            return self._intern_string(value)
+        if (
+            isinstance(value, list)
+            and key in STRING_LIST_FIELDS
+            and all(isinstance(item, str) for item in value)
+        ):
+            return [self._intern_string(item) for item in value]
+        return self._compact_generic(value)
+
+    def _expand_generic(self, value, type_table):
+        if isinstance(value, dict):
+            expanded = {}
+            for key, child in value.items():
+                name = self._unalias_key(key)
+                if name == "typename" and isinstance(child, int):
+                    expanded[name] = type_table[child]
+                else:
+                    expanded[name] = self._expand_generic(child, type_table)
+            return expanded
+        if isinstance(value, list):
+            return [self._expand_generic(item, type_table) for item in value]
+        return value
+
+    def _expand_schema_value(self, key, value, type_table, string_table):
+        if isinstance(value, int) and key in STRING_REF_FIELDS:
+            return string_table[value]
+        if (
+            isinstance(value, list)
+            and key in STRING_LIST_FIELDS
+            and all(isinstance(item, int) for item in value)
+        ):
+            return [string_table[item] for item in value]
+        return self._expand_generic(value, type_table)
+
+    def _compact_task_spec(self, task_key, task):
+        compact = {}
+        typename = task["typename"]
+        for key, value in task.items():
+            if key == "name" and value == task_key:
+                continue
+            if key == "description" and DEFAULT_TASK_DESCRIPTIONS.get(typename) == value:
+                continue
+            if key == "manual" and value is False:
+                continue
+            if key == "lookahead" and value == 2:
+                continue
+            if key in {
+                "lane",
+                "documentation",
+                "io_specification",
+                "bpmn_id",
+                "bpmn_name",
+                "prescript",
+                "postscript",
+                "choice",
+            } and value is None:
+                continue
+            if key in {"data_input_associations", "data_output_associations"} and value == []:
+                continue
+            if key == "extensions" and value == {}:
+                continue
+            alias = self._alias_key(key)
+            if key == "typename":
+                compact[alias] = self._intern_typename(value)
+            else:
+                compact[alias] = self._compact_schema_value(key, value)
+        return compact
+
+    def _expand_task_spec(self, task_key, task, type_table, string_table):
+        expanded = {}
+        for key, value in task.items():
+            logical_key = self._unalias_key(key)
+            if logical_key == "typename" and isinstance(value, int):
+                expanded[logical_key] = type_table[value]
+            else:
+                expanded[logical_key] = self._expand_schema_value(logical_key, value, type_table, string_table)
+        typename = expanded["typename"]
+        expanded.setdefault("name", task_key)
+        expanded.setdefault("description", DEFAULT_TASK_DESCRIPTIONS.get(typename))
+        expanded.setdefault("manual", False)
+        expanded.setdefault("lookahead", 2)
+        expanded.setdefault("inputs", [])
+        expanded.setdefault("outputs", [])
+        expanded.setdefault("bpmn_id", None)
+        expanded.setdefault("bpmn_name", None)
+        expanded.setdefault("lane", None)
+        expanded.setdefault("documentation", None)
+        expanded.setdefault("data_input_associations", [])
+        expanded.setdefault("data_output_associations", [])
+        expanded.setdefault("io_specification", None)
+        if "extensions" not in expanded and typename not in {"BpmnStartTask", "_EndJoin", "SimpleBpmnTask"}:
+            expanded["extensions"] = {}
+        return expanded
+
+    def _compact_process_spec(self, spec_key, spec):
+        compact = {}
+        for key, value in spec.items():
+            if key == "name" and spec_key is not None and value == spec_key:
+                continue
+            if key == "description" and value == spec["name"]:
+                continue
+            if key == "task_specs":
+                compact[self._alias_key(key)] = {
+                    str(self._intern_string(task_key)): self._compact_task_spec(task_key, task)
+                    for task_key, task in value.items()
+                }
+                continue
+            if key == "io_specification" and value is None:
+                continue
+            if key in {"data_objects", "correlation_keys"} and value == {}:
+                continue
+            alias = self._alias_key(key)
+            if key == "typename":
+                compact[alias] = self._intern_typename(value)
+            else:
+                compact[alias] = self._compact_schema_value(key, value)
+        return compact
+
+    def _expand_process_spec(self, spec_key, spec, type_table, string_table):
+        expanded = {}
+        for key, value in spec.items():
+            logical_key = self._unalias_key(key)
+            if logical_key == "typename" and isinstance(value, int):
+                expanded[logical_key] = type_table[value]
+            elif logical_key == "task_specs":
+                expanded[logical_key] = {
+                    string_table[int(task_key)]: self._expand_task_spec(
+                        string_table[int(task_key)], task, type_table, string_table
+                    )
+                    for task_key, task in value.items()
+                }
+            else:
+                expanded[logical_key] = self._expand_schema_value(logical_key, value, type_table, string_table)
+        expanded.setdefault("name", spec_key)
+        expanded.setdefault("description", expanded["name"])
+        expanded.setdefault("io_specification", None)
+        expanded.setdefault("data_objects", {})
+        expanded.setdefault("correlation_keys", {})
+        return expanded
+
+    def extract_canonical_specs(self, workflow):
+        canonical = self.canonical.to_dict(workflow)
+        return {
+            "spec": canonical["spec"],
+            "subprocess_specs": canonical["subprocess_specs"],
+        }
+
+    def canonical_to_compact(self, dct):
+        self._typenames = []
+        self._typename_to_index = {}
+        self._strings = []
+        self._string_to_index = {}
+
+        compact = {
+            self._alias_key(FORMAT_KEY): FORMAT_VALUE,
+            self._alias_key(TYPENAME_TABLE_KEY): self._typenames,
+            self._alias_key(STRING_TABLE_KEY): self._strings,
+            self._alias_key("spec"): self._compact_process_spec(None, dct["spec"]),
+            self._alias_key("subprocess_specs"): {
+                str(self._intern_string(spec_key)): self._compact_process_spec(spec_key, spec)
+                for spec_key, spec in dct["subprocess_specs"].items()
+            },
+        }
+        return compact
+
+    def compact_to_canonical(self, dct):
+        type_table = dct.pop(self._alias_key(TYPENAME_TABLE_KEY), [])
+        string_table = dct.pop(self._alias_key(STRING_TABLE_KEY), [])
+        dct.pop(self._alias_key(FORMAT_KEY), None)
+        return {
+            "spec": self._expand_process_spec(None, dct[self._alias_key("spec")], type_table, string_table),
+            "subprocess_specs": {
+                string_table[int(spec_key)]: self._expand_process_spec(
+                    string_table[int(spec_key)], spec, type_table, string_table
+                )
+                for spec_key, spec in dct.get(self._alias_key("subprocess_specs"), {}).items()
+            },
+        }
+
+    def to_dict(self, workflow):
+        return self.canonical_to_compact(self.extract_canonical_specs(workflow))
+
+    def from_dict(self, dct):
+        return self.compact_to_canonical(dict(dct))
+
+    def serialize_json(self, workflow, use_gzip=False):
+        dct = self.to_dict(workflow)
+        dct[self._alias_key(self.VERSION_KEY)] = self.VERSION
+        json_str = json.dumps(dct, separators=(",", ":"), cls=self.canonical._encoder_cls)
+        return gzip.compress(json_str.encode("utf-8")) if use_gzip else json_str
+
+    def deserialize_json(self, serialization, use_gzip=False):
+        json_str = gzip.decompress(serialization) if use_gzip else serialization
+        dct = json.loads(json_str, cls=self.json_decoder_cls)
+        dct.pop(self._alias_key(self.VERSION_KEY), None)
+        return self.from_dict(dct)
+
+    def get_version(self, serialization):
+        if isinstance(serialization, dict):
+            return serialization.get(self._alias_key(self.VERSION_KEY))
+        if isinstance(serialization, str):
+            dct = json.loads(serialization, cls=self.json_decoder_cls)
+            return dct.get(self._alias_key(self.VERSION_KEY))

--- a/scripts/explore_bpmn_serialization.py
+++ b/scripts/explore_bpmn_serialization.py
@@ -10,6 +10,7 @@ import argparse
 from collections import defaultdict
 import json
 import sys
+import time
 from pathlib import Path
 
 
@@ -19,7 +20,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from SpiffWorkflow.bpmn import BpmnWorkflow
 from SpiffWorkflow.bpmn.specs.mixins.subworkflow_task import SubWorkflowTask as SubWorkflowTaskMixin
-from SpiffWorkflow.bpmn.serializer import BpmnWorkflowSerializer, CompactBpmnWorkflowSerializer
+from SpiffWorkflow.bpmn.serializer import BpmnWorkflowSerializer, CompactBpmnWorkflowSerializer, BpmnSpecSerializer
 from SpiffWorkflow.spiff.parser import SpiffBpmnParser, VALIDATOR
 from SpiffWorkflow.spiff.serializer import DEFAULT_CONFIG
 
@@ -57,10 +58,20 @@ def parse_args():
         help="Optional path to write the compact serialized JSON.",
     )
     parser.add_argument(
+        "--spec-output",
+        type=Path,
+        help="Optional path to write the editor-spec serialized JSON.",
+    )
+    parser.add_argument(
         "--serializer",
         choices=["canonical", "compact", "both"],
         default="both",
         help="Which serializer(s) to run. Default: both",
+    )
+    parser.add_argument(
+        "--spec-serializer",
+        action="store_true",
+        help="Also run the editor-spec serializer.",
     )
     parser.add_argument(
         "--no-fallback",
@@ -183,6 +194,38 @@ def inspect_compact_serialization(workflow):
     return serializer, as_dict, as_json, parsed_json, restored
 
 
+def inspect_spec_serialization(workflow):
+    serializer = BpmnSpecSerializer(BpmnSpecSerializer.configure(DEFAULT_CONFIG))
+    canonical_specs = serializer.extract_canonical_specs(workflow)
+    canonical_spec_json = json.dumps(
+        {
+            "spec": canonical_specs["spec"],
+            "subprocess_specs": canonical_specs["subprocess_specs"],
+            "serializer_version": serializer.VERSION,
+        },
+        cls=serializer.canonical._encoder_cls,
+    )
+
+    serialize_start = time.perf_counter()
+    as_json = serializer.serialize_json(workflow)
+    serialize_elapsed = time.perf_counter() - serialize_start
+
+    parsed_json = json.loads(as_json)
+    deserialize_start = time.perf_counter()
+    restored = serializer.deserialize_json(as_json)
+    deserialize_elapsed = time.perf_counter() - deserialize_start
+    return (
+        serializer,
+        canonical_specs,
+        canonical_spec_json,
+        as_json,
+        parsed_json,
+        restored,
+        serialize_elapsed,
+        deserialize_elapsed,
+    )
+
+
 def json_size(value):
     return len(json.dumps(value, sort_keys=True).encode("utf-8"))
 
@@ -197,11 +240,24 @@ def main():
     )
     serializer = as_dict = as_json = parsed_json = None
     compact_serializer = compact_dict = compact_json = compact_parsed_json = compact_restored = None
+    spec_serializer = canonical_specs = canonical_spec_json = spec_json = spec_parsed_json = spec_restored = None
+    spec_serialize_elapsed = spec_deserialize_elapsed = None
 
     if args.serializer in {"canonical", "both"}:
         serializer, as_dict, as_json, parsed_json = inspect_serialization(workflow)
     if args.serializer in {"compact", "both"}:
         compact_serializer, compact_dict, compact_json, compact_parsed_json, compact_restored = inspect_compact_serialization(workflow)
+    if args.spec_serializer:
+        (
+            spec_serializer,
+            canonical_specs,
+            canonical_spec_json,
+            spec_json,
+            spec_parsed_json,
+            spec_restored,
+            spec_serialize_elapsed,
+            spec_deserialize_elapsed,
+        ) = inspect_spec_serialization(workflow)
 
     if args.output is not None and as_json is not None:
         output_path = args.output.resolve()
@@ -215,6 +271,12 @@ def main():
         compact_output_path.write_text(compact_json)
     else:
         compact_output_path = None
+    if args.spec_output is not None and spec_json is not None:
+        spec_output_path = args.spec_output.resolve()
+        spec_output_path.parent.mkdir(parents=True, exist_ok=True)
+        spec_output_path.write_text(spec_json)
+    else:
+        spec_output_path = None
 
     print(f"Root BPMN: {args.bpmn_file.resolve()}")
     print(f"Directory: {args.bpmn_file.resolve().parent}")
@@ -264,10 +326,28 @@ def main():
         print(f"Compact round-trip task count: {len(compact_restored.tasks)}")
         print(f"Compact round-trip subprocess specs: {len(compact_restored.subprocess_specs)}")
 
+    if spec_json is not None:
+        print(f"Canonical spec-only JSON bytes: {len(canonical_spec_json.encode('utf-8'))}")
+        print(f"Editor-spec JSON bytes: {len(spec_json.encode('utf-8'))}")
+        print(f"Editor-spec gzip bytes: {len(spec_serializer.serialize_json(workflow, use_gzip=True))}")
+        print(f"Editor-spec serializer version: {spec_serializer.get_version(spec_json)}")
+        print(f"Editor-spec top-level keys: {sorted(spec_parsed_json.keys())}")
+        print(f"Editor-spec round-trip subprocess specs: {len(spec_restored['subprocess_specs'])}")
+        print(f"Editor-spec serialize seconds: {spec_serialize_elapsed:.6f}")
+        print(f"Editor-spec deserialize seconds: {spec_deserialize_elapsed:.6f}")
+
     if as_json is not None and compact_json is not None:
         savings = len(as_json.encode("utf-8")) - len(compact_json.encode("utf-8"))
         percent = (savings / len(as_json.encode("utf-8")) * 100) if as_json else 0
         print(f"Compact savings vs canonical: {savings} bytes ({percent:.1f}%)")
+    if spec_json is not None:
+        spec_savings = len(canonical_spec_json.encode("utf-8")) - len(spec_json.encode("utf-8"))
+        spec_percent = (spec_savings / len(canonical_spec_json.encode("utf-8")) * 100) if canonical_spec_json else 0
+        print(f"Editor-spec savings vs canonical spec-only: {spec_savings} bytes ({spec_percent:.1f}%)")
+        if as_json is not None:
+            workflow_savings = len(as_json.encode("utf-8")) - len(spec_json.encode("utf-8"))
+            workflow_percent = (workflow_savings / len(as_json.encode("utf-8")) * 100) if as_json else 0
+            print(f"Editor-spec savings vs canonical workflow: {workflow_savings} bytes ({workflow_percent:.1f}%)")
 
     subprocess_names = sorted(subprocesses.keys())
     if subprocess_names:
@@ -291,6 +371,8 @@ def main():
         print(f"Serialization written to: {output_path}")
     if compact_output_path is not None:
         print(f"Compact serialization written to: {compact_output_path}")
+    if spec_output_path is not None:
+        print(f"Editor-spec serialization written to: {spec_output_path}")
 
 
 if __name__ == "__main__":

--- a/scripts/explore_bpmn_serialization.py
+++ b/scripts/explore_bpmn_serialization.py
@@ -57,6 +57,12 @@ def parse_args():
         help="Optional path to write the compact serialized JSON.",
     )
     parser.add_argument(
+        "--serializer",
+        choices=["canonical", "compact", "both"],
+        default="both",
+        help="Which serializer(s) to run. Default: both",
+    )
+    parser.add_argument(
         "--no-fallback",
         action="store_true",
         help="Disable temporary process-reference fallback resolution.",
@@ -189,16 +195,21 @@ def main():
         validate=args.validate,
         allow_fallback=not args.no_fallback,
     )
-    serializer, as_dict, as_json, parsed_json = inspect_serialization(workflow)
-    compact_serializer, compact_dict, compact_json, compact_parsed_json, compact_restored = inspect_compact_serialization(workflow)
+    serializer = as_dict = as_json = parsed_json = None
+    compact_serializer = compact_dict = compact_json = compact_parsed_json = compact_restored = None
 
-    if args.output is not None:
+    if args.serializer in {"canonical", "both"}:
+        serializer, as_dict, as_json, parsed_json = inspect_serialization(workflow)
+    if args.serializer in {"compact", "both"}:
+        compact_serializer, compact_dict, compact_json, compact_parsed_json, compact_restored = inspect_compact_serialization(workflow)
+
+    if args.output is not None and as_json is not None:
         output_path = args.output.resolve()
         output_path.parent.mkdir(parents=True, exist_ok=True)
         output_path.write_text(as_json)
     else:
         output_path = None
-    if args.compact_output is not None:
+    if args.compact_output is not None and compact_json is not None:
         compact_output_path = args.compact_output.resolve()
         compact_output_path.parent.mkdir(parents=True, exist_ok=True)
         compact_output_path.write_text(compact_json)
@@ -219,41 +230,50 @@ def main():
     print(f"Executable process IDs discovered: {len(parser.get_process_ids())}")
     print(f"Subprocess specs: {len(subprocesses)}")
     print(f"Fallback enabled: {not args.no_fallback}")
+    print(f"Serializer mode: {args.serializer}")
     print(f"Workflow tasks: {len(workflow.tasks)}")
-    print(f"Top-level serialization keys: {sorted(as_dict.keys())}")
-    print(f"JSON keys: {sorted(parsed_json.keys())}")
-    print(f"Serialized JSON bytes: {len(as_json.encode('utf-8'))}")
-    print(f"Canonical gzip bytes: {len(serializer.serialize_json(workflow, use_gzip=True))}")
-    print(f"Serializer version: {serializer.get_version(as_json)}")
-    size_breakdown = sorted(
-        ((key, json_size(value)) for key, value in parsed_json.items() if key != "serializer_version"),
-        key=lambda item: item[1],
-        reverse=True,
-    )
-    print("Top-level section sizes:")
-    for key, size in size_breakdown:
-        print(f"  - {key}: {size} bytes")
-    print(f"Compact JSON bytes: {len(compact_json.encode('utf-8'))}")
-    print(f"Compact gzip bytes: {len(compact_serializer.serialize_json(workflow, use_gzip=True))}")
-    print(f"Compact serializer version: {compact_serializer.get_version(compact_json)}")
-    savings = len(as_json.encode("utf-8")) - len(compact_json.encode("utf-8"))
-    percent = (savings / len(as_json.encode("utf-8")) * 100) if as_json else 0
-    print(f"Compact savings vs canonical: {savings} bytes ({percent:.1f}%)")
-    print(f"Compact top-level keys: {sorted(compact_parsed_json.keys())}")
-
-    tasks = parsed_json.get("tasks", {})
-    print(f"Serialized task entries: {len(tasks)}")
-    if tasks:
-        sample_names = sorted(
-            task.get("task_spec", "<unknown>")
-            for task in list(tasks.values())[:10]
+    if as_json is not None:
+        print(f"Top-level serialization keys: {sorted(as_dict.keys())}")
+        print(f"JSON keys: {sorted(parsed_json.keys())}")
+        print(f"Serialized JSON bytes: {len(as_json.encode('utf-8'))}")
+        print(f"Canonical gzip bytes: {len(serializer.serialize_json(workflow, use_gzip=True))}")
+        print(f"Serializer version: {serializer.get_version(as_json)}")
+        size_breakdown = sorted(
+            ((key, json_size(value)) for key, value in parsed_json.items() if key != "serializer_version"),
+            key=lambda item: item[1],
+            reverse=True,
         )
-        print(f"Sample serialized task specs: {sample_names}")
+        print("Top-level section sizes:")
+        for key, size in size_breakdown:
+            print(f"  - {key}: {size} bytes")
+
+        tasks = parsed_json.get("tasks", {})
+        print(f"Serialized task entries: {len(tasks)}")
+        if tasks:
+            sample_names = sorted(
+                task.get("task_spec", "<unknown>")
+                for task in list(tasks.values())[:10]
+            )
+            print(f"Sample serialized task specs: {sample_names}")
+
+    if compact_json is not None:
+        print(f"Compact JSON bytes: {len(compact_json.encode('utf-8'))}")
+        print(f"Compact gzip bytes: {len(compact_serializer.serialize_json(workflow, use_gzip=True))}")
+        print(f"Compact serializer version: {compact_serializer.get_version(compact_json)}")
+        print(f"Compact top-level keys: {sorted(compact_parsed_json.keys())}")
+        print(f"Compact round-trip task count: {len(compact_restored.tasks)}")
+        print(f"Compact round-trip subprocess specs: {len(compact_restored.subprocess_specs)}")
+
+    if as_json is not None and compact_json is not None:
+        savings = len(as_json.encode("utf-8")) - len(compact_json.encode("utf-8"))
+        percent = (savings / len(as_json.encode("utf-8")) * 100) if as_json else 0
+        print(f"Compact savings vs canonical: {savings} bytes ({percent:.1f}%)")
 
     subprocess_names = sorted(subprocesses.keys())
     if subprocess_names:
         print(f"Sample subprocess spec names: {subprocess_names[:10]}")
-        print(f"Serialized subprocess spec entries: {len(parsed_json.get('subprocess_specs', {}))}")
+        if parsed_json is not None:
+            print(f"Serialized subprocess spec entries: {len(parsed_json.get('subprocess_specs', {}))}")
     if resolutions:
         print("Fallback resolutions:")
         for source_name, resolved_name, resolution_kind, location in resolutions:
@@ -266,8 +286,6 @@ def main():
     process_ids = sorted(parser.get_process_ids())
     if process_ids:
         print(f"Sample executable process IDs: {process_ids[:10]}")
-    print(f"Compact round-trip task count: {len(compact_restored.tasks)}")
-    print(f"Compact round-trip subprocess specs: {len(compact_restored.subprocess_specs)}")
 
     if output_path is not None:
         print(f"Serialization written to: {output_path}")

--- a/scripts/explore_bpmn_serialization.py
+++ b/scripts/explore_bpmn_serialization.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#   "lxml",
+# ]
+# ///
+
+import argparse
+from collections import defaultdict
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from SpiffWorkflow.bpmn import BpmnWorkflow
+from SpiffWorkflow.bpmn.specs.mixins.subworkflow_task import SubWorkflowTask as SubWorkflowTaskMixin
+from SpiffWorkflow.bpmn.serializer import BpmnWorkflowSerializer, CompactBpmnWorkflowSerializer
+from SpiffWorkflow.spiff.parser import SpiffBpmnParser, VALIDATOR
+from SpiffWorkflow.spiff.serializer import DEFAULT_CONFIG
+
+
+DEFAULT_PROCESS_ID = "FoI_Collection"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Load sibling BPMN files for a root BPMN and inspect workflow serialization."
+    )
+    parser.add_argument(
+        "bpmn_file",
+        type=Path,
+        help="Root BPMN file.",
+    )
+    parser.add_argument(
+        "--process-id",
+        default=DEFAULT_PROCESS_ID,
+        help=f"Top-level process ID to instantiate. Default: {DEFAULT_PROCESS_ID}",
+    )
+    parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Enable BPMN validation while parsing.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the canonical serialized JSON.",
+    )
+    parser.add_argument(
+        "--compact-output",
+        type=Path,
+        help="Optional path to write the compact serialized JSON.",
+    )
+    parser.add_argument(
+        "--no-fallback",
+        action="store_true",
+        help="Disable temporary process-reference fallback resolution.",
+    )
+    return parser.parse_args()
+
+
+def get_bpmn_files(root_bpmn: Path):
+    directory = root_bpmn.resolve().parent
+    files = sorted(
+        path for path in directory.glob("*.bpmn")
+        if not path.name.endswith("_test.bpmn")
+    )
+    return directory, files
+
+
+def index_processes(parser):
+    by_id = {}
+    by_name = defaultdict(list)
+    by_id_lower = defaultdict(list)
+    by_name_lower = defaultdict(list)
+    for process_id, process_parser in parser.process_parsers.items():
+        if not process_parser.process_executable:
+            continue
+        by_id[process_id] = process_parser
+        by_name[process_parser.get_name()].append(process_parser)
+        by_id_lower[process_id.lower()].append(process_parser)
+        by_name_lower[process_parser.get_name().lower()].append(process_parser)
+    return by_id, by_name, by_id_lower, by_name_lower
+
+
+def resolve_process_reference(parser, called_element, allow_fallback):
+    by_id, by_name, by_id_lower, by_name_lower = index_processes(parser)
+
+    if called_element in by_id:
+        return called_element, "exact_id"
+    if len(by_name[called_element]) == 1:
+        return by_name[called_element][0].bpmn_id, "exact_name"
+    if not allow_fallback:
+        return None, "unresolved"
+    if len(by_id_lower[called_element.lower()]) == 1:
+        return by_id_lower[called_element.lower()][0].bpmn_id, "casefold_id"
+    if len(by_name_lower[called_element.lower()]) == 1:
+        return by_name_lower[called_element.lower()][0].bpmn_id, "casefold_name"
+    return None, "unresolved"
+
+
+def collect_recursive_subprocess_specs(parser, root_spec, allow_fallback):
+    subprocesses = {}
+    missing = defaultdict(list)
+    resolutions = []
+    expanded = set()
+    queue = [root_spec]
+
+    while queue:
+        spec = queue.pop(0)
+        if spec.name in expanded:
+            continue
+        expanded.add(spec.name)
+
+        for task_spec in spec.task_specs.values():
+            if not isinstance(task_spec, SubWorkflowTaskMixin):
+                continue
+
+            called_element = task_spec.spec
+            if called_element in subprocesses:
+                continue
+
+            resolved_id, resolution_kind = resolve_process_reference(parser, called_element, allow_fallback)
+            if resolved_id is None:
+                missing[called_element].append(f"{spec.name}:{task_spec.name}")
+                continue
+
+            resolved_spec = parser.get_spec(resolved_id, required=False)
+            subprocesses[called_element] = resolved_spec
+            if resolution_kind != "exact_id":
+                resolutions.append((called_element, resolved_id, resolution_kind, f"{spec.name}:{task_spec.name}"))
+            if resolved_spec is not None:
+                queue.append(resolved_spec)
+
+    return subprocesses, missing, resolutions
+
+
+def build_workflow(root_bpmn: Path, process_id: str, validate: bool, allow_fallback: bool):
+    directory, bpmn_files = get_bpmn_files(root_bpmn)
+    parser = SpiffBpmnParser(validator=None if not validate else VALIDATOR)
+    loaded_files = []
+    skipped_files = []
+    for path in bpmn_files:
+        try:
+            parser.add_bpmn_file(str(path))
+            loaded_files.append(path)
+        except Exception as exc:
+            skipped_files.append((path, f"{type(exc).__name__}: {exc}"))
+
+    spec = parser.get_spec(process_id)
+    subprocesses, missing_subprocess_specs, resolutions = collect_recursive_subprocess_specs(
+        parser, spec, allow_fallback=allow_fallback
+    )
+    workflow = BpmnWorkflow(spec, subprocesses)
+    return workflow, parser, loaded_files, skipped_files, subprocesses, missing_subprocess_specs, resolutions
+
+
+def inspect_serialization(workflow):
+    serializer = BpmnWorkflowSerializer(BpmnWorkflowSerializer.configure(DEFAULT_CONFIG))
+    as_dict = serializer.to_dict(workflow)
+    as_json = serializer.serialize_json(workflow)
+    parsed_json = json.loads(as_json)
+    return serializer, as_dict, as_json, parsed_json
+
+
+def inspect_compact_serialization(workflow):
+    serializer = CompactBpmnWorkflowSerializer(CompactBpmnWorkflowSerializer.configure(DEFAULT_CONFIG))
+    as_dict = serializer.to_dict(workflow)
+    as_json = serializer.serialize_json(workflow)
+    parsed_json = json.loads(as_json)
+    restored = serializer.deserialize_json(as_json)
+    return serializer, as_dict, as_json, parsed_json, restored
+
+
+def json_size(value):
+    return len(json.dumps(value, sort_keys=True).encode("utf-8"))
+
+
+def main():
+    args = parse_args()
+    workflow, parser, loaded_files, skipped_files, subprocesses, missing_subprocess_specs, resolutions = build_workflow(
+        args.bpmn_file,
+        args.process_id,
+        validate=args.validate,
+        allow_fallback=not args.no_fallback,
+    )
+    serializer, as_dict, as_json, parsed_json = inspect_serialization(workflow)
+    compact_serializer, compact_dict, compact_json, compact_parsed_json, compact_restored = inspect_compact_serialization(workflow)
+
+    if args.output is not None:
+        output_path = args.output.resolve()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(as_json)
+    else:
+        output_path = None
+    if args.compact_output is not None:
+        compact_output_path = args.compact_output.resolve()
+        compact_output_path.parent.mkdir(parents=True, exist_ok=True)
+        compact_output_path.write_text(compact_json)
+    else:
+        compact_output_path = None
+
+    print(f"Root BPMN: {args.bpmn_file.resolve()}")
+    print(f"Directory: {args.bpmn_file.resolve().parent}")
+    print(f"Loaded BPMN files: {len(loaded_files)}")
+    print("Files:")
+    for path in loaded_files:
+        print(f"  - {path.name}")
+    if skipped_files:
+        print(f"Skipped BPMN files: {len(skipped_files)}")
+        for path, reason in skipped_files:
+            print(f"  - {path.name}: {reason}")
+    print(f"Process ID: {args.process_id}")
+    print(f"Executable process IDs discovered: {len(parser.get_process_ids())}")
+    print(f"Subprocess specs: {len(subprocesses)}")
+    print(f"Fallback enabled: {not args.no_fallback}")
+    print(f"Workflow tasks: {len(workflow.tasks)}")
+    print(f"Top-level serialization keys: {sorted(as_dict.keys())}")
+    print(f"JSON keys: {sorted(parsed_json.keys())}")
+    print(f"Serialized JSON bytes: {len(as_json.encode('utf-8'))}")
+    print(f"Canonical gzip bytes: {len(serializer.serialize_json(workflow, use_gzip=True))}")
+    print(f"Serializer version: {serializer.get_version(as_json)}")
+    size_breakdown = sorted(
+        ((key, json_size(value)) for key, value in parsed_json.items() if key != "serializer_version"),
+        key=lambda item: item[1],
+        reverse=True,
+    )
+    print("Top-level section sizes:")
+    for key, size in size_breakdown:
+        print(f"  - {key}: {size} bytes")
+    print(f"Compact JSON bytes: {len(compact_json.encode('utf-8'))}")
+    print(f"Compact gzip bytes: {len(compact_serializer.serialize_json(workflow, use_gzip=True))}")
+    print(f"Compact serializer version: {compact_serializer.get_version(compact_json)}")
+    savings = len(as_json.encode("utf-8")) - len(compact_json.encode("utf-8"))
+    percent = (savings / len(as_json.encode("utf-8")) * 100) if as_json else 0
+    print(f"Compact savings vs canonical: {savings} bytes ({percent:.1f}%)")
+    print(f"Compact top-level keys: {sorted(compact_parsed_json.keys())}")
+
+    tasks = parsed_json.get("tasks", {})
+    print(f"Serialized task entries: {len(tasks)}")
+    if tasks:
+        sample_names = sorted(
+            task.get("task_spec", "<unknown>")
+            for task in list(tasks.values())[:10]
+        )
+        print(f"Sample serialized task specs: {sample_names}")
+
+    subprocess_names = sorted(subprocesses.keys())
+    if subprocess_names:
+        print(f"Sample subprocess spec names: {subprocess_names[:10]}")
+        print(f"Serialized subprocess spec entries: {len(parsed_json.get('subprocess_specs', {}))}")
+    if resolutions:
+        print("Fallback resolutions:")
+        for source_name, resolved_name, resolution_kind, location in resolutions:
+            print(f"  - {source_name} -> {resolved_name} ({resolution_kind}) at {location}")
+    missing_subprocesses = sorted(missing_subprocess_specs.keys())
+    if missing_subprocesses:
+        print("Missing subprocess specs:")
+        for name in missing_subprocesses:
+            print(f"  - {name}: {missing_subprocess_specs[name]}")
+    process_ids = sorted(parser.get_process_ids())
+    if process_ids:
+        print(f"Sample executable process IDs: {process_ids[:10]}")
+    print(f"Compact round-trip task count: {len(compact_restored.tasks)}")
+    print(f"Compact round-trip subprocess specs: {len(compact_restored.subprocess_specs)}")
+
+    if output_path is not None:
+        print(f"Serialization written to: {output_path}")
+    if compact_output_path is not None:
+        print(f"Compact serialization written to: {compact_output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/explore_bpmn_serialization.py
+++ b/scripts/explore_bpmn_serialization.py
@@ -9,6 +9,7 @@
 import argparse
 from collections import defaultdict
 import json
+import statistics
 import sys
 import time
 from pathlib import Path
@@ -72,6 +73,12 @@ def parse_args():
         "--spec-serializer",
         action="store_true",
         help="Also run the editor-spec serializer.",
+    )
+    parser.add_argument(
+        "--benchmark-iterations",
+        type=int,
+        default=0,
+        help="Optionally benchmark raw serialize/deserialize times over N iterations.",
     )
     parser.add_argument(
         "--no-fallback",
@@ -230,6 +237,37 @@ def json_size(value):
     return len(json.dumps(value, sort_keys=True).encode("utf-8"))
 
 
+def percentile_ms(samples, percentile):
+    if not samples:
+        return 0.0
+    if len(samples) == 1:
+        return samples[0] * 1000
+    index = max(0, min(len(samples) - 1, round((len(samples) - 1) * percentile)))
+    return sorted(samples)[index] * 1000
+
+
+def benchmark_serializer(serializer, workflow, iterations):
+    serialize_times = []
+    deserialize_times = []
+    payload = serializer.serialize_json(workflow)
+    for _ in range(iterations):
+        start = time.perf_counter()
+        payload = serializer.serialize_json(workflow)
+        serialize_times.append(time.perf_counter() - start)
+        start = time.perf_counter()
+        serializer.deserialize_json(payload)
+        deserialize_times.append(time.perf_counter() - start)
+
+    payload_bytes = len(payload) if isinstance(payload, bytes) else len(payload.encode("utf-8"))
+    return {
+        "bytes": payload_bytes,
+        "serialize_avg_ms": statistics.mean(serialize_times) * 1000,
+        "serialize_p95_ms": percentile_ms(serialize_times, 0.95),
+        "deserialize_avg_ms": statistics.mean(deserialize_times) * 1000,
+        "deserialize_p95_ms": percentile_ms(deserialize_times, 0.95),
+    }
+
+
 def main():
     args = parse_args()
     workflow, parser, loaded_files, skipped_files, subprocesses, missing_subprocess_specs, resolutions = build_workflow(
@@ -242,6 +280,7 @@ def main():
     compact_serializer = compact_dict = compact_json = compact_parsed_json = compact_restored = None
     spec_serializer = canonical_specs = canonical_spec_json = spec_json = spec_parsed_json = spec_restored = None
     spec_serialize_elapsed = spec_deserialize_elapsed = None
+    benchmark_results = {}
 
     if args.serializer in {"canonical", "both"}:
         serializer, as_dict, as_json, parsed_json = inspect_serialization(workflow)
@@ -258,6 +297,13 @@ def main():
             spec_serialize_elapsed,
             spec_deserialize_elapsed,
         ) = inspect_spec_serialization(workflow)
+    if args.benchmark_iterations > 0:
+        if serializer is not None:
+            benchmark_results["canonical"] = benchmark_serializer(serializer, workflow, args.benchmark_iterations)
+        if compact_serializer is not None:
+            benchmark_results["compact"] = benchmark_serializer(compact_serializer, workflow, args.benchmark_iterations)
+        if spec_serializer is not None:
+            benchmark_results["editor_spec"] = benchmark_serializer(spec_serializer, workflow, args.benchmark_iterations)
 
     if args.output is not None and as_json is not None:
         output_path = args.output.resolve()
@@ -373,6 +419,15 @@ def main():
         print(f"Compact serialization written to: {compact_output_path}")
     if spec_output_path is not None:
         print(f"Editor-spec serialization written to: {spec_output_path}")
+    if benchmark_results:
+        print(f"Benchmark iterations: {args.benchmark_iterations}")
+        for name, stats in benchmark_results.items():
+            print(f"{name} benchmark:")
+            print(f"  - bytes: {stats['bytes']}")
+            print(f"  - serialize avg: {stats['serialize_avg_ms']:.3f} ms")
+            print(f"  - serialize p95: {stats['serialize_p95_ms']:.3f} ms")
+            print(f"  - deserialize avg: {stats['deserialize_avg_ms']:.3f} ms")
+            print(f"  - deserialize p95: {stats['deserialize_p95_ms']:.3f} ms")
 
 
 if __name__ == "__main__":

--- a/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
+++ b/tests/SpiffWorkflow/bpmn/BpmnWorkflowTestCase.py
@@ -4,18 +4,16 @@ import unittest
 
 from SpiffWorkflow import TaskState
 from SpiffWorkflow.bpmn.parser import BpmnValidator
-from SpiffWorkflow.bpmn.serializer import BpmnWorkflowSerializer
 
 from .BpmnLoaderForTests import TestBpmnParser, SERIALIZER_CONFIG
+from .serializer_support import build_serializer
 
 
 __author__ = 'matth'
 
-registry = BpmnWorkflowSerializer.configure(SERIALIZER_CONFIG)
-
 class BpmnWorkflowTestCase(unittest.TestCase):
 
-    serializer = BpmnWorkflowSerializer(registry)
+    serializer = build_serializer(SERIALIZER_CONFIG)
 
     def get_parser(self, filename, validate=True):
         f = os.path.join(os.path.dirname(__file__), 'data', filename)

--- a/tests/SpiffWorkflow/bpmn/serializer/BaseTestCase.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/BaseTestCase.py
@@ -5,6 +5,7 @@ from SpiffWorkflow import TaskState
 from SpiffWorkflow.bpmn import BpmnWorkflow
 from SpiffWorkflow.bpmn.parser import BpmnParser
 from SpiffWorkflow.bpmn.serializer import BpmnWorkflowSerializer
+from tests.SpiffWorkflow.bpmn.serializer_support import build_serializer
 
 
 class BaseTestCase(unittest.TestCase):
@@ -29,7 +30,6 @@ class BaseTestCase(unittest.TestCase):
 
     def setUp(self):
         super(BaseTestCase, self).setUp()
-        wf_spec_converter = BpmnWorkflowSerializer.configure()
-        self.serializer = BpmnWorkflowSerializer(wf_spec_converter, version=self.SERIALIZER_VERSION)
+        self.serializer = build_serializer(None, version=self.SERIALIZER_VERSION)
         spec, subprocesses = self.load_workflow_spec('random_fact.bpmn', 'random_fact')
         self.workflow = BpmnWorkflow(spec, subprocesses)

--- a/tests/SpiffWorkflow/bpmn/serializer/BpmnSpecSerializerTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/BpmnSpecSerializerTest.py
@@ -33,3 +33,17 @@ class BpmnSpecSerializerTest(BaseTestCase):
         )
         compact_spec_json = self.spec_serializer.serialize_json(self.workflow)
         self.assertLess(len(compact_spec_json), len(canonical_spec_json))
+
+    def test_spec_uses_process_table_and_row_encoded_tasks(self):
+        payload = json.loads(self.spec_serializer.serialize_json(self.workflow))
+
+        self.assertIn("~pt", payload)
+        self.assertIn("~rt", payload)
+        self.assertNotIn("~s", payload)
+        self.assertNotIn("~ps", payload)
+
+        root_process = payload["~pt"][str(payload["~rt"])]
+        self.assertIsInstance(root_process, list)
+        self.assertIsInstance(root_process[1], list)
+        self.assertTrue(root_process[1])
+        self.assertIsInstance(root_process[1][0], list)

--- a/tests/SpiffWorkflow/bpmn/serializer/BpmnSpecSerializerTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/BpmnSpecSerializerTest.py
@@ -1,0 +1,35 @@
+import json
+
+from SpiffWorkflow.bpmn.serializer import BpmnWorkflowSerializer, BpmnSpecSerializer
+
+from .BaseTestCase import BaseTestCase
+
+
+class BpmnSpecSerializerTest(BaseTestCase):
+
+    def setUp(self):
+        super().setUp()
+        registry = BpmnSpecSerializer.configure()
+        self.spec_serializer = BpmnSpecSerializer(registry=registry, version=self.SERIALIZER_VERSION)
+        canonical_registry = BpmnWorkflowSerializer.configure()
+        self.canonical_serializer = BpmnWorkflowSerializer(registry=canonical_registry, version=self.SERIALIZER_VERSION)
+
+    def test_spec_round_trips_to_canonical_dicts(self):
+        serialized = self.spec_serializer.serialize_json(self.workflow)
+        restored = self.spec_serializer.deserialize_json(serialized)
+        canonical = self.canonical_serializer.to_dict(self.workflow)
+
+        self.assertEqual(canonical["spec"], restored["spec"])
+        self.assertEqual(canonical["subprocess_specs"], restored["subprocess_specs"])
+
+    def test_spec_json_is_smaller_than_canonical_spec_json(self):
+        canonical = self.canonical_serializer.to_dict(self.workflow)
+        canonical_spec_json = json.dumps(
+            {
+                "spec": canonical["spec"],
+                "subprocess_specs": canonical["subprocess_specs"],
+                "serializer_version": self.SERIALIZER_VERSION,
+            }
+        )
+        compact_spec_json = self.spec_serializer.serialize_json(self.workflow)
+        self.assertLess(len(compact_spec_json), len(canonical_spec_json))

--- a/tests/SpiffWorkflow/bpmn/serializer/BpmnWorkflowSerializerTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/BpmnWorkflowSerializerTest.py
@@ -3,10 +3,10 @@ import os
 import json
 
 from SpiffWorkflow.bpmn import BpmnWorkflow
-from SpiffWorkflow.bpmn.serializer import BpmnWorkflowSerializer
 from SpiffWorkflow.bpmn.script_engine import PythonScriptEngine
 
 from .BaseTestCase import BaseTestCase
+from tests.SpiffWorkflow.bpmn.serializer_support import get_serializer_class, is_compact_serializer_enabled
 
 class BpmnWorkflowSerializerTest(BaseTestCase):
 
@@ -70,17 +70,21 @@ class BpmnWorkflowSerializerTest(BaseTestCase):
 
         try:
             self.assertRaises(TypeError, self.serializer.serialize_json, self.workflow)
-            wf_spec_converter = BpmnWorkflowSerializer.configure()
-            custom_serializer = BpmnWorkflowSerializer(wf_spec_converter,
-                                                       version=self.SERIALIZER_VERSION,
-                                                       json_encoder_cls=MyJsonEncoder,
-                                                       json_decoder_cls=MyJsonDecoder)
+            serializer_class = get_serializer_class()
+            wf_spec_converter = serializer_class.configure()
+            custom_serializer = serializer_class(
+                wf_spec_converter,
+                version=self.SERIALIZER_VERSION,
+                json_encoder_cls=MyJsonEncoder,
+                json_decoder_cls=MyJsonDecoder,
+            )
             serialized_workflow = custom_serializer.serialize_json(self.workflow)
         finally:
             a_task.data.pop('jsonTest',None)
 
-        serialized_task = [x for x in json.loads(serialized_workflow)['tasks'].values() if x['task_spec'] == a_task_spec.name][0]
-        self.assertEqual(serialized_task['data']['jsonTest'], {'a': 1, 'my_type': 'mycls'})
+        if not is_compact_serializer_enabled():
+            serialized_task = [x for x in json.loads(serialized_workflow)['tasks'].values() if x['task_spec'] == a_task_spec.name][0]
+            self.assertEqual(serialized_task['data']['jsonTest'], {'a': 1, 'my_type': 'mycls'})
 
         deserialized_workflow = custom_serializer.deserialize_json(serialized_workflow)
         deserialized_task = deserialized_workflow.get_tasks(spec_name=a_task_spec.name)[0]
@@ -131,7 +135,7 @@ class BpmnWorkflowSerializerTest(BaseTestCase):
             return n + 1
         user_task.data = { 'f': f }
         task_id = str(user_task.id)
-        dct = self.serializer.to_dict(self.workflow)
+        dct = self.serializer.canonical.to_dict(self.workflow) if is_compact_serializer_enabled() else self.serializer.to_dict(self.workflow)
         self.assertNotIn('f', dct['tasks'][task_id]['data'])
 
     def testLastTaskIsSetAndWorksThroughRestore(self):

--- a/tests/SpiffWorkflow/bpmn/serializer/VersionMigrationTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/VersionMigrationTest.py
@@ -1,5 +1,6 @@
 import os
 import time
+import unittest
 from uuid import UUID
 
 from SpiffWorkflow import TaskState
@@ -7,8 +8,9 @@ from SpiffWorkflow.bpmn.script_engine import PythonScriptEngine, TaskDataEnviron
 from SpiffWorkflow.bpmn.serializer.exceptions import VersionMigrationError
 
 from .BaseTestCase import BaseTestCase
+from tests.SpiffWorkflow.bpmn.serializer_support import is_compact_serializer_enabled
 
-
+@unittest.skipIf(is_compact_serializer_enabled(), "Version migration fixtures are canonical-serializer only")
 class Version_1_0_Test(BaseTestCase):
 
     def test_convert_subprocess(self):
@@ -26,6 +28,7 @@ class Version_1_0_Test(BaseTestCase):
         self.assertEqual(True, wf.completed)
 
 
+@unittest.skipIf(is_compact_serializer_enabled(), "Version migration fixtures are canonical-serializer only")
 class Version_1_1_Test(BaseTestCase):
 
     def test_timers(self):
@@ -84,6 +87,7 @@ class Version_1_1_Test(BaseTestCase):
         self.assertTrue(wf.completed)
 
 
+@unittest.skipIf(is_compact_serializer_enabled(), "Version migration fixtures are canonical-serializer only")
 class Version_1_2_Test(BaseTestCase):
 
     def test_remove_boundary_events(self):
@@ -173,6 +177,7 @@ class Version_1_2_Test(BaseTestCase):
         self.assertIn('sub_level_data_object_three', call_sub.data_objects)
         self.assertNotIn('sub_level_data_object_three', process_sub.data_objects)
 
+@unittest.skipIf(is_compact_serializer_enabled(), "Version migration fixtures are canonical-serializer only")
 class Version_1_3_Test(BaseTestCase):
 
     def test_update_mi_states(self):

--- a/tests/SpiffWorkflow/bpmn/serializer_support.py
+++ b/tests/SpiffWorkflow/bpmn/serializer_support.py
@@ -1,0 +1,35 @@
+import os
+
+from SpiffWorkflow.bpmn.serializer import BpmnWorkflowSerializer, CompactBpmnWorkflowSerializer
+
+
+SERIALIZER_ENV_VAR = "SPIFFWORKFLOW_SERIALIZER"
+CANONICAL_SERIALIZER = "canonical"
+COMPACT_SERIALIZER = "compact"
+
+
+def get_serializer_mode():
+    return os.environ.get(SERIALIZER_ENV_VAR, CANONICAL_SERIALIZER).strip().lower()
+
+
+def is_compact_serializer_enabled():
+    return get_serializer_mode() == COMPACT_SERIALIZER
+
+
+def get_serializer_class():
+    if is_compact_serializer_enabled():
+        return CompactBpmnWorkflowSerializer
+    return BpmnWorkflowSerializer
+
+
+def build_serializer(config, version=None, json_encoder_cls=None, json_decoder_cls=None):
+    serializer_class = get_serializer_class()
+    registry = serializer_class.configure(config)
+    kwargs = {
+        "registry": registry,
+        "json_encoder_cls": json_encoder_cls,
+        "json_decoder_cls": json_decoder_cls,
+    }
+    if version is not None:
+        kwargs["version"] = version
+    return serializer_class(**kwargs)

--- a/tests/SpiffWorkflow/camunda/BaseTestCase.py
+++ b/tests/SpiffWorkflow/camunda/BaseTestCase.py
@@ -1,19 +1,17 @@
 import os
 
-from SpiffWorkflow.bpmn.serializer import BpmnWorkflowSerializer
 from SpiffWorkflow.camunda.serializer import DEFAULT_CONFIG
 from SpiffWorkflow.camunda.parser.CamundaParser import CamundaParser
 
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
-
-registry = BpmnWorkflowSerializer.configure(DEFAULT_CONFIG)
+from tests.SpiffWorkflow.bpmn.serializer_support import build_serializer
 
 __author__ = 'danfunk'
 
 class BaseTestCase(BpmnWorkflowTestCase):
     """ Provides some basic tools for loading up and parsing camunda BPMN files """
 
-    serializer = BpmnWorkflowSerializer(registry)
+    serializer = build_serializer(DEFAULT_CONFIG)
 
     def get_parser(self, filename, dmn_filename=None):
         f = os.path.join(os.path.dirname(__file__), 'data', filename)

--- a/tests/SpiffWorkflow/spiff/BaseTestCase.py
+++ b/tests/SpiffWorkflow/spiff/BaseTestCase.py
@@ -1,17 +1,15 @@
 import os
 
-from SpiffWorkflow.bpmn.serializer import BpmnWorkflowSerializer
 from SpiffWorkflow.spiff.serializer import DEFAULT_CONFIG
 from SpiffWorkflow.spiff.parser import SpiffBpmnParser, VALIDATOR
 
 from tests.SpiffWorkflow.bpmn.BpmnWorkflowTestCase import BpmnWorkflowTestCase
-
-registry = BpmnWorkflowSerializer.configure(DEFAULT_CONFIG)
+from tests.SpiffWorkflow.bpmn.serializer_support import build_serializer
 
 class BaseTestCase(BpmnWorkflowTestCase):
     """ Provides some basic tools for loading up and parsing Spiff extensions"""
 
-    serializer = BpmnWorkflowSerializer(registry)
+    serializer = build_serializer(DEFAULT_CONFIG)
 
     def load_workflow_spec(self, filename, process_name, dmn_filename=None, validate=True):
         bpmn = os.path.join(os.path.dirname(__file__), 'data', filename)


### PR DESCRIPTION
_It is worth noting that the primary use case for this is within ed, where the specs are saved in local storage, so as these production workflows get large the ~43% savings helps a lot._

  Introduce a compact BPMN workflow serializer that reduces persisted payload size by aliasing keys and interning repeated strings/type names, and add a spec-only serializer that row-encodes process/task specs for smaller editor-facing payloads.

  Update the serializer test harness so the suite can run against canonical or compact serializers via SPIFFWORKFLOW_SERIALIZER, add a Make target for the compact run, and keep canonical migration fixtures limited to canonical mode.

  Also add an exploration script for inspecting serializer output.

  Update GitHub Actions to use uv and run both serializer modes in CI across the existing Python version matrix.

  Verification:
  - make RUN='uv run' tests: 677 tests in 16.528s (skipped=1)
  - make RUN='uv run' tests-compact: 677 tests in 15.374s (skipped=13)
  - Large production workflow payload comparison:
    canonical workflow JSON: 1,105,334 bytes
    compact workflow JSON: 647,419 bytes (-41.4%)
    spec-only JSON: 625,368 bytes (-43.4% vs canonical workflow)

