### PR TITLE
Optimize DeepMerge list membership checks

### DIFF
--- a/SpiffWorkflow/util/deep_merge.py
+++ b/SpiffWorkflow/util/deep_merge.py
@@ -60,17 +60,33 @@ class DeepMerge(object):
 
     @staticmethod
     def merge_array(a, b, path=None):
+        seen_hashable = set()
+        seen_unhashable = []
+
+        for item in a:
+            try:
+                seen_hashable.add(item)
+            except TypeError:
+                seen_unhashable.append(item)
 
         for idx, val in enumerate(b):
-            if isinstance(b[idx], dict):  # Recurse back on dictionaries.
+            if isinstance(val, dict):  # Recurse back on dictionaries.
                 # If lists of dictionaries get out of order, this might
                 # cause us some pain.
                 if len(a) > idx:
-                    a[idx] = DeepMerge.merge(a[idx], b[idx], path + [str(idx)])
+                    a[idx] = DeepMerge.merge(a[idx], val, path + [str(idx)])
                 else:
-                    a.append(b[idx])
-            else: # Just merge whatever it is back in.
-                a.extend(x for x in b if x not in a)
+                    a.append(val)
+            else:  # Just merge whatever it is back in.
+                try:
+                    if val in seen_hashable:
+                        continue
+                    seen_hashable.add(val)
+                except TypeError:
+                    if val in seen_unhashable:
+                        continue
+                    seen_unhashable.append(val)
+                a.append(val)
 
         # Trim a back to the length of b.  In the end, the two arrays should match
         del a[len(b):]

--- a/tests/SpiffWorkflow/core/DeepMergeTest.py
+++ b/tests/SpiffWorkflow/core/DeepMergeTest.py
@@ -4,6 +4,23 @@ from unittest import TestCase
 from SpiffWorkflow.util.deep_merge import DeepMerge
 
 
+class CountingValue:
+
+    comparisons = 0
+
+    def __init__(self, value):
+        self.value = value
+
+    def __eq__(self, other):
+        CountingValue.comparisons += 1
+        if not isinstance(other, CountingValue):
+            return NotImplemented
+        return self.value == other.value
+
+    def __hash__(self):
+        return hash(self.value)
+
+
 class DeepMergeTest(TestCase):
 
     def testBasicMerge(self):
@@ -57,3 +74,12 @@ class DeepMergeTest(TestCase):
 
         self.assertEqual({"foods": [{"fruit": {"apples": "tasty", "oranges": "also tasty"}}]}, c)
 
+    def testMergeArrayAvoidsRepeatedMembershipScansForHashableValues(self):
+        CountingValue.comparisons = 0
+        a = {"values": [CountingValue(idx) for idx in range(10)]}
+        b = {"values": [CountingValue(idx) for idx in range(10, 20)]}
+
+        DeepMerge.merge(a, b)
+
+        self.assertEqual(list(range(10)), [item.value for item in a["values"]])
+        self.assertLess(CountingValue.comparisons, 30)


### PR DESCRIPTION
Refactor DeepMerge.merge_array() so non-dict list values are tracked explicitly instead of repeatedly scanning the target list during extend. This preserves the existing append-only semantics for unseen values while making the common hashable case linear instead of quadratic.

Add a focused regression test that counts equality comparisons, so the improvement is verified without relying on noisy wall-clock timing.