### PR TITLE
Optimize BPMN start message lookups

### DIFF
--- a/SpiffWorkflow/bpmn/parser/ProcessParser.py
+++ b/SpiffWorkflow/bpmn/parser/ProcessParser.py
@@ -67,7 +67,10 @@ class ProcessParser(NodeParser):
         """ This returns a list of message names that would cause this
             process to start. """
         message_names = []
-        messages = self.xpath("//bpmn:message")
+        messages_by_id = {
+            message.attrib.get('id'): message
+            for message in self.xpath("//bpmn:message")
+        }
         message_event_definitions = self.xpath(
             "//bpmn:startEvent/bpmn:messageEventDefinition")
         for message_event_definition in message_event_definitions:
@@ -80,7 +83,7 @@ class ProcessParser(NodeParser):
                     f"Could not find messageRef from message event definition: {med_id}"
                 )
             # Convert the id into a Message Name
-            message_name = next((m for m in messages if m.attrib.get('id') == message_model_identifier), None)
+            message_name = messages_by_id.get(message_model_identifier)
             message_names.append(message_name.attrib.get('name'))
 
         return message_names

--- a/tests/SpiffWorkflow/bpmn/ProcessParserTest.py
+++ b/tests/SpiffWorkflow/bpmn/ProcessParserTest.py
@@ -4,6 +4,7 @@ import unittest
 
 from SpiffWorkflow.dmn.parser.BpmnDmnParser import BpmnDmnParser
 from SpiffWorkflow.bpmn.parser.BpmnParser import BpmnParser
+from SpiffWorkflow.bpmn.parser.ProcessParser import ProcessParser
 
 def _process_parser(bpmn_filename, process_id):
     parser = BpmnParser()
@@ -12,6 +13,39 @@ def _process_parser(bpmn_filename, process_id):
     return parser.get_process_parser(process_id)
 
 class ProcessParserTest(unittest.TestCase):
+    def testStartMessagesAvoidsRepeatedMessageIdScans(self):
+        class CountingAttrib(dict):
+            id_gets = 0
+
+            def get(self, key, default=None):
+                if key == 'id':
+                    CountingAttrib.id_gets += 1
+                return super().get(key, default)
+
+        class FakeNode:
+            def __init__(self, attrib):
+                self.attrib = attrib
+
+        messages = [
+            FakeNode(CountingAttrib(id=f'message_{idx}', name=f'Message {idx}'))
+            for idx in range(10)
+        ]
+        message_event_definitions = [
+            FakeNode({'messageRef': f'message_{idx}'})
+            for idx in range(10)
+        ]
+        parser = ProcessParser.__new__(ProcessParser)
+        parser.xpath = lambda expr: (
+            message_event_definitions
+            if expr == "//bpmn:startEvent/bpmn:messageEventDefinition"
+            else messages
+        )
+
+        message_names = parser.start_messages()
+
+        self.assertEqual([f'Message {idx}' for idx in range(10)], message_names)
+        self.assertLessEqual(CountingAttrib.id_gets, 10)
+
     def testReturnsEmptyListIfNoCallActivities(self):
         parser = _process_parser("no-tasks.bpmn", "no_tasks")
         assert parser.called_element_ids() == []


### PR DESCRIPTION
Refactor ProcessParser.start_messages() to build a message-id lookup table once instead of rescanning all BPMN message nodes for each message start event.

This preserves the existing behavior while reducing the lookup path from O(m*n) to O(m+n), where m is the number of messages and n is the number of message start events. Add a focused regression test that counts id lookups so the improvement is verified without relying on noisy timing assertions.