### PR TITLE
Avoid mutating typed dictionaries during restore

### DIFF
--- a/SpiffWorkflow/bpmn/serializer/helpers/dictionary.py
+++ b/SpiffWorkflow/bpmn/serializer/helpers/dictionary.py
@@ -19,6 +19,9 @@
 
 from functools import partial
 
+_JSON_PRIMITIVE_TYPES = {str, int, float, bool, type(None)}
+
+
 class DictionaryConverter:
     """
     This is a base class used to convert BPMN specs, workflows, tasks, and (optonally)
@@ -123,12 +126,24 @@ class DictionaryConverter:
         Returns:
             dict: the restored object for registered objects or the original for unregistered values
         """
-        if isinstance(val, dict) and 'typename' in val:
-            from_dict = self.convert_from_dict.get(val.pop('typename'))
-            return from_dict(val, **kwargs)
-        elif isinstance(val, dict):
-            return dict((k, self.restore(v, **kwargs)) for k, v in val.items())
-        if isinstance(val, (list, tuple, set)):
-            return val.__class__([ self.restore(item, **kwargs) for item in val ])
-        else:
+        val_type = type(val)
+        if val_type in _JSON_PRIMITIVE_TYPES:
             return val
+
+        if isinstance(val, dict):
+            if 'typename' in val:
+                from_dict = self.convert_from_dict.get(val['typename'])
+                dct = dict(val)
+                del dct['typename']
+                return from_dict(dct, **kwargs)
+            return dict((k, self.restore(v, **kwargs)) for k, v in val.items())
+
+        if val_type is list:
+            return [self.restore(item, **kwargs) for item in val]
+        if val_type is tuple:
+            return tuple(self.restore(item, **kwargs) for item in val)
+        if val_type is set:
+            return {self.restore(item, **kwargs) for item in val}
+        if isinstance(val, (list, tuple, set)):
+            return val.__class__([self.restore(item, **kwargs) for item in val])
+        return val

--- a/tests/SpiffWorkflow/bpmn/serializer/DictionaryConverterTest.py
+++ b/tests/SpiffWorkflow/bpmn/serializer/DictionaryConverterTest.py
@@ -1,0 +1,30 @@
+import unittest
+
+from SpiffWorkflow.bpmn.serializer.helpers.dictionary import DictionaryConverter
+
+
+class DictionaryConverterTest(unittest.TestCase):
+
+    def test_restore_typed_dict_does_not_mutate_input(self):
+        class Thing:
+
+            def __init__(self, value):
+                self.value = value
+
+        converter = DictionaryConverter()
+        converter.register(
+            Thing,
+            lambda thing: {'value': thing.value},
+            lambda dct: Thing(dct['value']),
+            typename='Thing',
+        )
+        data = {
+            'typename': 'Thing',
+            'value': 42,
+        }
+
+        restored = converter.restore(data)
+
+        self.assertIsInstance(restored, Thing)
+        self.assertEqual(42, restored.value)
+        self.assertEqual({'typename': 'Thing', 'value': 42}, data)


### PR DESCRIPTION
 ## Summary

  This change fixes a side effect in `DictionaryConverter.restore()` when restoring typed dictionaries.

  Previously, if the input dict contained a `typename`, `restore()` removed that key from the original input via
  `pop()`. That meant callers could get their source data mutated during deserialization.

  This update changes `restore()` to:
  - read `typename` without mutating the original input
  - restore from a shallow copy of the typed dictionary
  - keep the existing recursive restore behavior for nested values
  - add a regression test covering the non-mutation behavior

  It also includes a small cleanup in `restore()` for JSON primitive values and common container types.

  ## Why

  Deserializer helpers should not mutate caller-owned input data. That behavior is surprising, can make debugging
  harder, and can break reuse of the same serialized structure across multiple restore calls or assertions.

  ## Test Plan

  - Ran:
    - `uv run python -m unittest -v tests.SpiffWorkflow.bpmn.serializer.DictionaryConverterTest`

