### PR TITLE
Don't KeyError for missing called element

### DIFF
--- a/SpiffWorkflow/bpmn/specs/mixins/subworkflow_task.py
+++ b/SpiffWorkflow/bpmn/specs/mixins/subworkflow_task.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 
 from SpiffWorkflow.util.task import TaskState
 from SpiffWorkflow.specs.base import TaskSpec
-from SpiffWorkflow.bpmn.exceptions import WorkflowDataException
+from SpiffWorkflow.bpmn.exceptions import WorkflowDataException, WorkflowTaskException
 
 
 class SubWorkflowTask(TaskSpec):
@@ -70,7 +70,13 @@ class SubWorkflowTask(TaskSpec):
     def update_data(self, my_task, subworkflow):
         my_task.data = deepcopy(subworkflow.last_task.data)
 
+    def get_missing_subworkflow_error(self, my_task):
+        return f"The subprocess '{self.spec}' was not found."
+
     def start_workflow(self, my_task):
+        if self.spec not in my_task.workflow.top_workflow.subprocess_specs:
+            my_task.error()
+            raise WorkflowTaskException(self.get_missing_subworkflow_error(my_task), task=my_task)
         subworkflow = my_task.workflow.top_workflow.create_subprocess(my_task, self.spec)
         subworkflow.completed_event.connect(self._on_subworkflow_completed, my_task)
         self.copy_data(my_task, subworkflow)
@@ -82,6 +88,9 @@ class CallActivity(SubWorkflowTask):
 
     def __init__(self, wf_spec, bpmn_id, subworkflow_spec, **kwargs):
         super(CallActivity, self).__init__(wf_spec, bpmn_id, subworkflow_spec, False, **kwargs)
+
+    def get_missing_subworkflow_error(self, my_task):
+        return f"The called process '{self.spec}' was not found."
 
     def copy_data(self, my_task, subworkflow):
 

--- a/tests/SpiffWorkflow/bpmn/CallActivityTest.py
+++ b/tests/SpiffWorkflow/bpmn/CallActivityTest.py
@@ -55,6 +55,19 @@ class CallActivityTest(BpmnWorkflowTestCase):
         task = self.workflow.get_next_task(spec_name='Sub_Bpmn_Task')
         self.assertEqual(task.state, TaskState.ERROR)
 
+    def test_call_activity_missing_subprocess_sets_task_error_state(self):
+        error_spec, subprocesses = self.load_workflow_spec('call_activity_*.bpmn', 'ErroringBPMN')
+        subprocesses = dict(subprocesses)
+        subprocesses.pop('Call_Activity_Get_Data')
+
+        with self.assertRaises(WorkflowTaskException) as context:
+            self.workflow = BpmnWorkflow(error_spec, subprocesses)
+            self.workflow.do_engine_steps()
+
+        self.assertIn("The called process 'Call_Activity_Get_Data' was not found.", str(context.exception))
+        task = [task for task in self.workflow.get_tasks() if task.task_spec.name == 'Activity_12zat0d'][0]
+        self.assertEqual(task.state, TaskState.ERROR)
+
     def test_order_of_tasks_in_get_task_is_call_acitivty_task_first_then_sub_tasks(self):
         self.workflow = BpmnWorkflow(self.spec, self.subprocesses)
         self.workflow.do_engine_steps()


### PR DESCRIPTION
This changes CallActivity error handling when the referenced calledElement is missing at runtime.

  Previously, that case could escape as a raw KeyError during subprocess creation, which meant the call activity
  itself did not reliably enter ERROR state. In downstream consumers like ed, that made the failure much harder to
  locate because there was no task-level error to report against the BPMN element.

  The fix keeps existing parser-time validation unchanged, but hardens the runtime path in
  SubWorkflowTask.start_workflow(). If the subprocess spec is missing when the call activity starts, SpiffWorkflow
  now marks the task as ERROR and raises a WorkflowTaskException with a task-aware message instead of allowing the
  dictionary lookup to fail.

  A regression test was added to cover the runtime case by removing the subprocess from an otherwise valid loaded
  workflow and asserting that:

  - a WorkflowTaskException is raised
  - the message identifies the missing called process
  - the call activity task ends in TaskState.ERROR

  This preserves current validation behavior while making runtime failures behave like other task execution errors,
  which gives callers a concrete task location to surface in the UI.
