### PR TITLE
Remove redundant tests

### DIFF
--- a/tests/SpiffWorkflow/core/specs/TaskSpecTest.py
+++ b/tests/SpiffWorkflow/core/specs/TaskSpecTest.py
@@ -35,9 +35,6 @@ class TaskSpecTest(unittest.TestCase):
         self.assertEqual(self.spec.get_data('foo'), 'foobar')
         self.assertEqual(self.spec.get_data('foo', 'bar'), 'foobar')
 
-    def testGetData(self):
-        return self.testSetData()
-
     def testConnect(self):
         self.assertEqual(self.spec._outputs, [])
         self.assertEqual(self.spec._inputs, [])

--- a/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
+++ b/tests/SpiffWorkflow/spiff/PrescriptPostscriptTest.py
@@ -20,12 +20,12 @@ class PrescriptPostsciptTest(BaseTestCase):
         self.call_activity_test(True)
 
     def testDataObject(self):
-        self.test_data_object()
+        self.data_object_test()
 
     def testDataObjectSaveRestore(self):
-        self.test_data_object(True)
+        self.data_object_test(True)
 
-    def test_data_object(self, save_restore=False):
+    def data_object_test(self, save_restore=False):
 
         spec, subprocesses = self.load_workflow_spec('prescript_postscript_data_object.bpmn', 'Process_1')
         self.workflow = BpmnWorkflow(spec, subprocesses)


### PR DESCRIPTION
Remove a TaskSpec test that only re-ran the set-data coverage, and rename the prescript/postscript data-object helper so unittest does not discover it as a duplicate test case.