### PR TITLE
Inline trivial helpers

### DIFF
--- a/SpiffWorkflow/bpmn/parser/BpmnParser.py
+++ b/SpiffWorkflow/bpmn/parser/BpmnParser.py
@@ -253,12 +253,9 @@ class BpmnParser:
             self._find_dependencies(process)
             self.create_parser(process, filename)
 
-    def _document_key(self, bpmn):
-        root = bpmn.getroot() if hasattr(bpmn, 'getroot') else bpmn
-        return id(root)
-
     def _add_diagram_indexes(self, bpmn):
-        document_key = self._document_key(bpmn)
+        root = bpmn.getroot() if hasattr(bpmn, 'getroot') else bpmn
+        document_key = id(root)
         if document_key in self.document_lanes:
             return
 

--- a/SpiffWorkflow/bpmn/parser/ValidationException.py
+++ b/SpiffWorkflow/bpmn/parser/ValidationException.py
@@ -31,7 +31,8 @@ class ValidationException(SpiffWorkflowException):
 
     def __init__(self, msg, node=None, file_name=None, *args, **kwargs):
         if node is not None:
-            self.tag = self._shorten_tag(node.tag)
+            prefix = '{%s}' % BPMN_MODEL_NS
+            self.tag = 'bpmn:' + node.tag[len(prefix):] if node.tag.startswith(prefix) else node.tag
             self.id = node.get('id', '')
             self.name = node.get('name', '')
             self.line_number = getattr(node, 'line_number', '')
@@ -43,10 +44,3 @@ class ValidationException(SpiffWorkflowException):
         self.file_name = file_name or ''
 
         super().__init__(msg, *args)
-
-    @classmethod
-    def _shorten_tag(cls, tag):
-        prefix = '{%s}' % BPMN_MODEL_NS
-        if tag.startswith(prefix):
-            return 'bpmn:' + tag[len(prefix):]
-        return tag

--- a/SpiffWorkflow/bpmn/util/task.py
+++ b/SpiffWorkflow/bpmn/util/task.py
@@ -29,13 +29,13 @@ class BpmnTaskFilter(TaskFilter):
 
     def matches(self, task):
 
-        def _catches_event(task):
-            return isinstance(task.task_spec, CatchingEvent) and task.task_spec.catches(task, self.catches_event)
-
         if not super().matches(task):
             return False
 
-        if not (self.catches_event is None or _catches_event(task)):
+        if not (
+            self.catches_event is None
+            or isinstance(task.task_spec, CatchingEvent) and task.task_spec.catches(task, self.catches_event)
+        ):
             return False
 
         if not (self.lane is None or task.task_spec.lane == self.lane):

--- a/SpiffWorkflow/bpmn/workflow.py
+++ b/SpiffWorkflow/bpmn/workflow.py
@@ -81,7 +81,7 @@ class _WaitingTaskIndex:
 
     def _add(self, task):
         self.waiting_tasks[task.id] = task
-        if self._is_timer_task(task):
+        if isinstance(task.task_spec, CatchingEvent) and self._has_timer_definition(task.task_spec.event_definition):
             self.timer_tasks[task.id] = task
             self._schedule_timer(task)
 
@@ -105,9 +105,6 @@ class _WaitingTaskIndex:
         self.timer_due_at[task.id] = due_at
         self._sequence += 1
         heapq.heappush(self.timer_heap, (due_at, self._sequence, task.id))
-
-    def _is_timer_task(self, task):
-        return isinstance(task.task_spec, CatchingEvent) and self._has_timer_definition(task.task_spec.event_definition)
 
     def _has_timer_definition(self, event_definition):
         if isinstance(event_definition, TimerEventDefinition):

--- a/SpiffWorkflow/spiff/parser/task_spec.py
+++ b/SpiffWorkflow/spiff/parser/task_spec.py
@@ -68,7 +68,7 @@ class SpiffTaskParser(TaskParser):
 
     @classmethod
     def _node_children_by_tag_name(cls, node, tag_name):
-        xpath = cls._spiffworkflow_ready_xpath_for_node(node)
+        xpath = xpath_eval(node, SPIFFWORKFLOW_NSMAP)
         return xpath(f'.//spiffworkflow:{tag_name}')
 
     @classmethod
@@ -86,10 +86,6 @@ class SpiffTaskParser(TaskParser):
         for metadata_node in metadata_value_nodes:
             metadata_values[metadata_node.attrib['name']] = metadata_node.attrib.get('value', None)
         return metadata_values
-
-    @staticmethod
-    def _spiffworkflow_ready_xpath_for_node(node):
-        return xpath_eval(node, SPIFFWORKFLOW_NSMAP)
 
     @classmethod
     def _parse_script_unit_tests(cls, node):


### PR DESCRIPTION
Remove small one-use helper functions in BPMN filtering, parser tag handling, diagram indexing, timer task detection, and Spiff extension parsing.